### PR TITLE
fix Java sample - access to properties

### DIFF
--- a/site/api-guide.xml
+++ b/site/api-guide.xml
@@ -312,7 +312,7 @@ channel.basicConsume(queueName, autoAck, "myConsumerTag",
              <b>throws</b> IOException
          {
              String routingKey = envelope.getRoutingKey();
-             String contentType = properties.contentType;
+             String contentType = properties.getContentType();
              <b>long</b> deliveryTag = envelope.getDeliveryTag();
              <i>// (process the message components here ...)</i>
              channel.basicAck(deliveryTag, <b>false</b>);


### PR DESCRIPTION
Use properties.getContentType() instead of properties.contentType

https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/AMQP.BasicProperties.html#getContentType%28%29

properties.contentType is private field and is not accessible this
way in Java.

Note:
I did not submit Contributor Agreement but I assume that this change is trivial so Contributor Agreement is not required.
