### PR TITLE
Added more 'Related Links' for Erlang client

### DIFF
--- a/site/pages.xml.dat
+++ b/site/pages.xml.dat
@@ -135,7 +135,10 @@ limitations under the License.
        </x:page>
        <x:page url="/dotnet-api-guide.html" text=".NET Client Guide"/>
        <x:page url="/heartbeats.html" text="Heartbeats"/>
-       <x:page url="/erlang-client-user-guide.html" text="Erlang Client Guide"/>
+       <x:page url="/erlang-client-user-guide.html" text="Erlang Client Guide">
+         <x:related url="/amqp-0-9-1-reference.html" text="AMQP Reference"/>
+         <x:related url="&dir-current-edoc;" text="Erlang edoc"/>
+       </x:page>
        <x:page url="/uri-spec.html" text="AMQP URI Spec">
          <x:page url="/uri-query-parameters.html" text="AMQP URI Params"/>
        </x:page>


### PR DESCRIPTION
Sometime it's not easy (for me) to find a link to the right
Erlang client documentation. I'd add more links to the website
so that I don't search so long next time.