### PR TITLE
Fixed error in examples: unexpected semicolon or newline

### DIFF
--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -198,8 +198,7 @@ to the queue:
       amqp.Publishing {
         ContentType: "text/plain",
         Body:        []byte(body),
-      }
-    )
+      })
     failOnError(err, "Failed to publish a message")
 
 Declaring a queue is idempotent - it will only be created if it doesn't

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -86,8 +86,7 @@ program will schedule tasks to our work queue, so let's name it
         DeliveryMode: amqp.Persistent,
         ContentType:  "text/plain",
         Body:         []byte(body),
-      }
-    )
+      })
     failOnError(err, "Failed to publish a message")
     log.Printf(" [x] Sent %s", body)
 
@@ -330,8 +329,7 @@ even if RabbitMQ restarts. Now we need to mark our messages as persistent
         DeliveryMode: amqp.Persistent,
         ContentType:  "text/plain",
         Body:         []byte(body),
-      }
-    )
+      })
 
 > #### Note on message persistence
 >


### PR DESCRIPTION
Sorry, it's PR was wrong: https://github.com/rabbitmq/rabbitmq-tutorials/pull/72
This code run normally:
```Go
err = ch.Publish(
    "logs", // exchange
    "",     // routing key
    false,  // mandatory
    false,  // immediate
    amqp.Publishing{
            ContentType: "text/plain",
            Body:        []byte(body),
    })
```

Error appears:
```Go
err = ch.Publish(
  "",     // exchange
  q.Name, // routing key
  false,  // mandatory
  false,  // immediate
  amqp.Publishing {
    ContentType: "text/plain",
    Body:        []byte(body),
  }
)
```
*syntax error: unexpected semicolon or newline, expecting )*