### PR TITLE
Auto-configuration of a cluster with a Pacemaker

### DIFF
--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -526,6 +526,54 @@ Cluster status of node rabbit@rabbit3 ...
           cluster.  Only then, can it be reset safely.
         </p>
         </doc:subsection>
+        <doc:subsection name="auto-pacemaker">
+          <doc:heading>Auto-configuration of a cluster with a Pacemaker</doc:heading>
+          <p>
+            Another option to configure clusters "on the fly" is
+            <a href="http://www.linux-ha.org/wiki/Resource_agents">Pacemaker resource agents</a>.
+            The OCF scripts for the cluster resource agents are located at
+            <code>/usr/lib/ocf/resource.d/rabbitmq/</code>. The first one
+            <code>/usr/lib/ocf/resource.d/rabbitmq/rabbitmq-server</code>
+            is a generic init-like script and provides no clustering.
+            The second one <code>/usr/lib/ocf/resource.d/rabbitmq/rabbitmq-server-ha</code>
+            provides an active-active cluster configuration with a dynamic membership of nodes.
+            Note that only disc nodes are currently supported by the OCF agent.
+          </p>
+          <p>
+            To start using this OCF agent, first create a
+            <a href="http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-multistate.html">multi-state resource</a>
+            in your running Pacemaker cluster of 3 or more nodes. With the <code>pcs</code> tool,
+            the command syntax should look like:
+          </p>
+          <pre class="sourcecode">
+$ <i>pcs resource create resource_id standard:provider:type|type [resource options] \
+--master [meta master_options]</i>
+          </pre>
+          <p>
+            But this is out of the scope of this document. The resulting resource may look like:
+          </p>
+          <pre class="sourcecode">
+ Master: master_p_rabbitmq-server
+  Meta Attrs: notify=true ordered=false interleave=true master-max=1 master-node-max=1
+  Resource: p_rabbitmq-server (class=ocf provider=rabbitmq type=rabbitmq-server-ha)
+   Attributes: node_port=5672 debug=false command_timeout=--signal=KILL erlang_cookie=EOKOWXQREETZSHFNTPEY admin_user=rabbitmq
+   Meta Attrs: migration-threshold=INFINITY failure-timeout=360s
+   Operations: monitor interval=30 timeout=180 (p_rabbitmq-server-monitor-30)
+               monitor interval=27 role=Master timeout=180 (p_rabbitmq-server-monitor-27)
+               monitor interval=103 role=Slave timeout=180 OCF_CHECK_LEVEL=30 (p_rabbitmq-server-monitor-103)
+               start interval=0 timeout=360 (p_rabbitmq-server-start-0)
+               stop interval=0 timeout=120 (p_rabbitmq-server-stop-0)
+               promote interval=0 timeout=120 (p_rabbitmq-server-promote-0)
+               demote interval=0 timeout=120 (p_rabbitmq-server-demote-0)
+               notify interval=0 timeout=180 (p_rabbitmq-server-notify-0)
+          </pre>
+          <p>
+            After that, your cluster has to be assembled by the OCF agent and ready for operations.
+            When assembled, one and only resource instance must run as a resource master, and others as a slaves.
+            Note that these are the multi-state resource's Master/Slave and has nothing to the RabbitMQ cluster,
+            which is active-active.
+          </p>
+        </doc:subsection>
       </doc:section>
       <doc:section name="upgrading">
           <doc:heading>Upgrading clusters</doc:heading>


### PR DESCRIPTION
Describe how to use the shipped OCF script for a
Pacemaker resource agent to configure an A/A cluster
with dynamic nodes' membership.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>