### PR TITLE
AMQPStreamConnection class is deprecated.

### DIFF
--- a/site/tutorials/tutorial-five-php.md
+++ b/site/tutorials/tutorial-five-php.md
@@ -159,10 +159,10 @@ The code for `emit_log_topic.php`:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
 
@@ -190,9 +190,9 @@ The code for `receive_logs_topic.php`:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->exchange_declare('topic_logs', 'topic', false, false, false);

--- a/site/tutorials/tutorial-four-php.md
+++ b/site/tutorials/tutorial-four-php.md
@@ -256,10 +256,10 @@ The code for `emit_log_direct.php` class:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->exchange_declare('direct_logs', 'direct', false, false, false);
@@ -287,9 +287,9 @@ The code for `receive_logs_direct.php`:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->exchange_declare('direct_logs', 'direct', false, false, false);

--- a/site/tutorials/tutorial-one-php.md
+++ b/site/tutorials/tutorial-one-php.md
@@ -147,13 +147,13 @@ we need to include the library and `use` the necessary classes:
 
     :::php
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
 then we can create a connection to the server:
 
     :::php
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
 The connection abstracts the socket connection, and takes care of
@@ -216,14 +216,14 @@ The code (in [`receive.php`](https://github.com/rabbitmq/rabbitmq-tutorials/blob
 
     :::php
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
 
 Setting up is the same as the sender; we open a connection and a
 channel, and declare the queue from which we're going to consume.
 Note this matches up with the queue that `send` publishes to.
 
     :::php
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->queue_declare('hello', false, false, false, false);

--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -224,10 +224,10 @@ The code for our RPC server [rpc_server.php](https://github.com/rabbitmq/rabbitm
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->queue_declare('rpc_queue', false, false, false, false);
@@ -285,7 +285,7 @@ The code for our RPC client [rpc_client.php](https://github.com/rabbitmq/rabbitm
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
     class FibonacciRpcClient {
@@ -296,7 +296,7 @@ The code for our RPC client [rpc_client.php](https://github.com/rabbitmq/rabbitm
     	private $corr_id;
 
     	public function __construct() {
-    		$this->connection = new AMQPStreamConnection(
+    		$this->connection = new AMQPConnection(
     			'localhost', 5672, 'guest', 'guest');
     		$this->channel = $this->connection->channel();
     		list($this->callback_queue, ,) = $this->channel->queue_declare(

--- a/site/tutorials/tutorial-three-php.md
+++ b/site/tutorials/tutorial-three-php.md
@@ -260,10 +260,10 @@ value is ignored for `fanout` exchanges. Here goes the code for
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->exchange_declare('logs', 'fanout', false, false, false);
@@ -297,9 +297,9 @@ The code for `receive_logs.php`:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
 

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -346,10 +346,10 @@ Final code of our `new_task.php` file:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
     use PhpAmqpLib\Message\AMQPMessage;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
 
@@ -380,9 +380,9 @@ And our `worker.php`:
     <?php
 
     require_once __DIR__ . '/vendor/autoload.php';
-    use PhpAmqpLib\Connection\AMQPStreamConnection;
+    use PhpAmqpLib\Connection\AMQPConnection;
 
-    $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+    $connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
     $channel = $connection->channel();
 
     $channel->queue_declare('task_queue', false, true, false, false);


### PR DESCRIPTION
Updated php tutorials to use AMQPConnection class instead of the deprecated AMQPStreamConnection class. It has been officially deprecated since Nov. 2014, see: https://github.com/videlalvaro/php-amqplib/commit/64eb289c9f5721daa2bd3ad0f333c5b738580843#diff-d22541aa1646efa4a61d570b8a0a0ff0