### PR TITLE
Add more details for the HA OCF resource creation

### DIFF
--- a/site/pacemaker.xml
+++ b/site/pacemaker.xml
@@ -555,30 +555,71 @@ ha-node-3:~#
         <p>
           To start using this OCF agent, first create a
           <a href="http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-multistate.html">multi-state resource</a>
-          in your running Pacemaker cluster of 3 or more nodes. With the <code>pcs</code> tool,
-          the command syntax should look like:
+          in your running Pacemaker cluster of 3 or more nodes. With either the <code>pcs</code>
+          or <code>crm</code> tools, the example commands may look like:
         </p>
         <pre class="sourcecode">
-$ <i>pcs resource create resource_id standard:provider:type|type [resource options] \
---master [meta master_options]</i>
+$ <i>pcs resource create --force --master p_rabbitmq-server ocf:rabbitmq:rabbitmq-server-ha \
+  erlang_cookie=DPMDALGUKEOMPTHWPYKC node_port=5672 \
+  op monitor interval=30 timeout=60 \
+  op monitor interval=27 role=Master timeout=60 \
+  op monitor interval=103 role=Slave timeout=60 OCF_CHECK_LEVEL=30 \
+  op start interval=0 timeout=360 \
+  op stop interval=0 timeout=120 \
+  op promote interval=0 timeout=120 \
+  op demote interval=0 timeout=120 \
+  op notify interval=0 timeout=180 \
+  meta notify=true ordered=false interleave=true master-max=1 master-node-max=1
+</i>
+$ <i>crm configure primitive p_rabbitmq-server ocf:rabbitmq:rabbitmq-server-ha \
+        params erlang_cookie=DPMDALGUKEOMPTHWPYKC node_port=5672 \
+        op monitor interval=30 timeout=60 \
+        op monitor interval=27 role=Master timeout=60 \
+        op monitor interval=103 role=Slave timeout=60 OCF_CHECK_LEVEL=30 \
+        op start interval=0 timeout=360 \
+        op stop interval=0 timeout=120 \
+        op promote interval=0 timeout=120 \
+        op demote interval=0 timeout=120 \
+        op notify interval=0 timeout=180 \
+        meta migration-threshold=10 failure-timeout=30s resource-stickiness=100
+</i>
+$ <i>crm configure ms p_rabbitmq-server-master p_rabbitmq-server \
+        meta notify=true ordered=false interleave=true master-max=1 master-node-max=1</i>
         </pre>
         <p>
-          But this is out of the scope of this document. The resulting resource may look like:
+          Note, that for a symmetric Pacemaker cluster, the resource should be started
+          immediately after it has been created. And the resulting resource may look like:
         </p>
         <pre class="sourcecode">
- Master: master_p_rabbitmq-server
+$ <i>pcs resource show p_rabbitmq-server-master</i>
+ Master: p_rabbitmq-server-master
   Meta Attrs: notify=true ordered=false interleave=true master-max=1 master-node-max=1
   Resource: p_rabbitmq-server (class=ocf provider=rabbitmq type=rabbitmq-server-ha)
-   Attributes: node_port=5672 debug=false command_timeout=--signal=KILL erlang_cookie=EOKOWXQREETZSHFNTPEY admin_user=rabbitmq
-   Meta Attrs: migration-threshold=INFINITY failure-timeout=360s
-   Operations: monitor interval=30 timeout=180 (p_rabbitmq-server-monitor-30)
-               monitor interval=27 role=Master timeout=180 (p_rabbitmq-server-monitor-27)
-               monitor interval=103 role=Slave timeout=180 OCF_CHECK_LEVEL=30 (p_rabbitmq-server-monitor-103)
-               start interval=0 timeout=360 (p_rabbitmq-server-start-0)
-               stop interval=0 timeout=120 (p_rabbitmq-server-stop-0)
-               promote interval=0 timeout=120 (p_rabbitmq-server-promote-0)
-               demote interval=0 timeout=120 (p_rabbitmq-server-demote-0)
-               notify interval=0 timeout=180 (p_rabbitmq-server-notify-0)
+   Attributes: erlang_cookie=DPMDALGUKEOMPTHWPYKC node_port=5672
+   Meta Attrs: migration-threshold=10 failure-timeout=30s resource-stickiness=100
+   Operations: monitor interval=30 timeout=60 (p_rabbitmq-server-monitor-interval-30)
+               monitor interval=27 role=Master timeout=60 (p_rabbitmq-server-monitor-interval-27)
+               monitor interval=103 role=Slave timeout=60 OCF_CHECK_LEVEL=30 (p_rabbitmq-server-monitor-interval-103)
+               start interval=0 timeout=360 (p_rabbitmq-server-start-interval-0)
+               stop interval=0 timeout=120 (p_rabbitmq-server-stop-interval-0)
+               promote interval=0 timeout=120 (p_rabbitmq-server-promote-interval-0)
+               demote interval=0 timeout=120 (p_rabbitmq-server-demote-interval-0)
+               notify interval=0 timeout=180 (p_rabbitmq-server-notify-interval-0)
+$ <i>crm configure show p_rabbitmq-server</i>
+primitive p_rabbitmq-server ocf:rabbitmq:rabbitmq-server-ha \
+        params erlang_cookie=DPMDALGUKEOMPTHWPYKC node_port=5672 \
+        op monitor interval=30 timeout=60 \
+        op monitor interval=27 role=Master timeout=60 \
+        op monitor interval=103 role=Slave timeout=60 OCF_CHECK_LEVEL=30 \
+        op start interval=0 timeout=360 \
+        op stop interval=0 timeout=120 \
+        op promote interval=0 timeout=120 \
+        op demote interval=0 timeout=120 \
+        op notify interval=0 timeout=180 \
+        meta migration-threshold=10 failure-timeout=30s resource-stickiness=100
+$ <i>crm configure show p_rabbitmq-server-master</i>
+ms p_rabbitmq-server-master p_rabbitmq-server \
+        meta notify=true ordered=false interleave=true master-max=1 master-node-max=1
         </pre>
         <p>
           After that, your cluster has to be assembled by the OCF agent and ready for operations.
@@ -592,11 +633,13 @@ $ <i>pcs resource create resource_id standard:provider:type|type [resource optio
       <doc:section name="params">
 	<doc:heading>Configuration Parameters</doc:heading>
 
-        <p>The configuration parameters that can be provided in
-        Pacemaker to the <code>ocf:rabbitmq:rabbitmq-server</code>
-        script are all logical translations of the
-        <code>RABBITMQ_*</code> environment variables that can be used
-        to configure Rabbit. They are:</p>
+        <p>
+          The configuration parameters that can be provided in
+          Pacemaker to the <code>ocf:rabbitmq:rabbitmq-server</code>
+          script are all logical translations of the
+          <code>RABBITMQ_*</code> environment variables that can be used
+          to configure Rabbit. They are:
+        </p>
         <dl>
           <dt>server</dt>
           <dd>The path to the rabbitmq-server script</dd>
@@ -625,6 +668,20 @@ $ <i>pcs resource create resource_id standard:provider:type|type [resource optio
           <dt>server_start_args</dt>
           <dd>Additional arguments provided to the server on startup</dd>
         </dl>
+        <p>
+          And there are even more configuration parameters for the
+          <code>ocf:rabbitmq:rabbitmq-server-ha</code> script. Note, that the parameters
+          can be as well listed with either the <code>pcs</code> tool:
+        </p>
+        <pre class="sourcecode">
+$ <i>pcs resource describe ocf:rabbitmq:rabbitmq-server-ha</i>
+        </pre>
+        <p>
+          or by the direct execution of the resource agent:
+        </p>
+        <pre class="sourcecode">
+$i <i>OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/rabbitmq/rabbitmq-server-ha meta-data</i> 
+        </pre>
       </doc:section>
   </body>
 </html>


### PR DESCRIPTION
* Provide precise example commands to create multi-state resource
for the RabbitMQ HA resource agent in Pacemaker.
* Provide the example commands in both pcs and crm tools notations.
* Describe the way to get meta-data parameters of the
OCF scripts via the command line (just to not duplicate
maintaning them in the guide and the script ot once)

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>