### PR TITLE
Update java client build instructions

### DIFF
--- a/site/build-java-client.xml
+++ b/site/build-java-client.xml
@@ -37,7 +37,7 @@ limitations under the License.
 	  </li>
 
 	  <li>Check the code out directly from <a href="github.html">our GitHub repositories</a>:
-	    <pre class="sourcecode">$ git clone https://github.com/rabbitmq/rabbitmq-codegen.git
+	    <pre class="sourcecode">$ git clone https://github.com/rabbitmq/rabbitmq-codegen.git rabbitmq_codegen
 $ git clone https://github.com/rabbitmq/rabbitmq-java-client.git
 $ cd rabbitmq-java-client
 $ ant dist</pre>


### PR DESCRIPTION
They've become invalid after 0d1b2bd0e84b8f77b2f62d4ee90983458baef02d to
rabbitmq-java-client, which mentions that erlang.mk-layout is now used
by default.

Fixes #102 