### PR TITLE
Fix error returned by second channel.open

### DIFF
--- a/site/resources/specs/amqp0-9-1.extended.xml
+++ b/site/resources/specs/amqp0-9-1.extended.xml
@@ -943,7 +943,7 @@
       <doc>
         This method opens a channel to the server.
       </doc>
-      <rule name = "state" on-failure = "channel-error">
+      <rule name = "state" on-failure = "command-invalid">
         <doc>
           The client MUST NOT use this method on an already-opened channel.
         </doc>


### PR DESCRIPTION
It is actually `command-invalid` https://github.com/rabbitmq/rabbitmq-common/blob/master/src/rabbit_channel.erl#L858
XML from amqp.org also states `channel-error`, so I'm not sure whether this intended and documentation should be fixed (and probably noted [here](https://github.com/rabbitmq/rabbitmq-website/blob/master/site/specification.xml)) or this is actually implementation bug and fix should be made in https://github.com/rabbitmq/rabbitmq-common