### PR TITLE
Inconsistency between website documentation and tutorials

### DIFF
--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -86,7 +86,7 @@ program will schedule tasks to our work queue, so let's name it
                          routingKey: "task_queue",
                          basicProperties: properties,
                          body: body);
-    
+
 
 Some help to get the message from the command line argument:
 
@@ -213,9 +213,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned on by default. In previous
 examples we explicitly turned them off by setting the `noAck` ("no manual acks")
@@ -296,7 +296,7 @@ a queue with different name, for example `task_queue`:
                          exclusive: false,
                          autoDelete: false,
                          arguments: null);
-    
+
 
 This `queueDeclare` change needs to be applied to both the producer
 and consumer code.
@@ -348,7 +348,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];
@@ -384,7 +384,7 @@ Final code of our `NewTask.cs` class:
     using System;
     using RabbitMQ.Client;
     using System.Text;
-    
+
     class NewTask
     {
         public static void Main(string[] args)
@@ -398,24 +398,24 @@ Final code of our `NewTask.cs` class:
                                      exclusive: false,
                                      autoDelete: false,
                                      arguments: null);
-    
+
                 var message = GetMessage(args);
                 var body = Encoding.UTF8.GetBytes(message);
-    
+
                 var properties = channel.CreateBasicProperties();
                 properties.SetPersistent(true);
-    
+
                 channel.BasicPublish(exchange: "",
                                      routingKey: "task_queue",
                                      basicProperties: properties,
                                      body: body);
                 Console.WriteLine(" [x] Sent {0}", message);
             }
-    
+
             Console.WriteLine(" Press [enter] to exit.");
             Console.ReadLine();
         }
-    
+
         private static string GetMessage(string[] args)
         {
             return ((args.Length > 0) ? string.Join(" ", args) : "Hello World!");
@@ -433,7 +433,7 @@ And our `Worker.cs`:
     using RabbitMQ.Client.Events;
     using System.Text;
     using System.Threading;
-    
+
     class Worker
     {
         public static void Main()
@@ -447,29 +447,29 @@ And our `Worker.cs`:
                                      exclusive: false,
                                      autoDelete: false,
                                      arguments: null);
-    
+
                 channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
-    
+
                 Console.WriteLine(" [*] Waiting for messages.");
-    
+
                 var consumer = new EventingBasicConsumer(channel);
                 consumer.Received += (model, ea) =>
                 {
                     var body = ea.Body;
                     var message = Encoding.UTF8.GetString(body);
                     Console.WriteLine(" [x] Received {0}", message);
-    
+
                     int dots = message.Split('.').Length - 1;
                     Thread.Sleep(dots * 1000);
-    
+
                     Console.WriteLine(" [x] Done");
-    
+
                     channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
                 };
                 channel.BasicConsume(queue: "task_queue",
                                      noAck: false,
                                      consumer: consumer);
-    
+
                 Console.WriteLine(" Press [enter] to exit.");
                 Console.ReadLine();
             }

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -1,9 +1,9 @@
 <!--
-Copyright (C) 2007-2015 Pivotal Software, Inc. 
+Copyright (C) 2007-2015 Pivotal Software, Inc.
 
 All rights reserved. This program and the accompanying materials
-are made available under the terms of the under the Apache License, 
-Version 2.0 (the "License”); you may not use this file except in compliance 
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
@@ -210,9 +210,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned off by default.
 It's time to turn them on using the `false,  // auto-ack` option and send a proper acknowledgment
@@ -370,7 +370,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];
@@ -415,26 +415,26 @@ Final code of our `new_task.go` class:
             "log"
             "os"
             "strings"
-    
+
             "github.com/streadway/amqp"
     )
-    
+
     func failOnError(err error, msg string) {
             if err != nil {
                     log.Fatalf("%s: %s", msg, err)
                     panic(fmt.Sprintf("%s: %s", msg, err))
             }
     }
-    
+
     func main() {
             conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
             failOnError(err, "Failed to connect to RabbitMQ")
             defer conn.Close()
-    
+
             ch, err := conn.Channel()
             failOnError(err, "Failed to open a channel")
             defer ch.Close()
-    
+
             q, err := ch.QueueDeclare(
                     "task_queue", // name
                     true,         // durable
@@ -444,7 +444,7 @@ Final code of our `new_task.go` class:
                     nil,          // arguments
             )
             failOnError(err, "Failed to declare a queue")
-    
+
             body := bodyFrom(os.Args)
             err = ch.Publish(
                     "",           // exchange
@@ -459,7 +459,7 @@ Final code of our `new_task.go` class:
             failOnError(err, "Failed to publish a message")
             log.Printf(" [x] Sent %s", body)
     }
-    
+
     func bodyFrom(args []string) string {
             var s string
             if (len(args) < 2) || os.Args[1] == "" {
@@ -485,23 +485,23 @@ And our `worker.go`:
             "log"
             "time"
     )
-    
+
     func failOnError(err error, msg string) {
             if err != nil {
                     log.Fatalf("%s: %s", msg, err)
                     panic(fmt.Sprintf("%s: %s", msg, err))
             }
     }
-    
+
     func main() {
             conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
             failOnError(err, "Failed to connect to RabbitMQ")
             defer conn.Close()
-    
+
             ch, err := conn.Channel()
             failOnError(err, "Failed to open a channel")
             defer ch.Close()
-    
+
             q, err := ch.QueueDeclare(
                     "task_queue", // name
                     true,         // durable
@@ -511,14 +511,14 @@ And our `worker.go`:
                     nil,          // arguments
             )
             failOnError(err, "Failed to declare a queue")
-    
+
             err = ch.Qos(
                     1,     // prefetch count
                     0,     // prefetch size
                     false, // global
             )
             failOnError(err, "Failed to set QoS")
-    
+
             msgs, err := ch.Consume(
                     q.Name, // queue
                     "",     // consumer
@@ -529,9 +529,9 @@ And our `worker.go`:
                     nil,    // args
             )
             failOnError(err, "Failed to register a consumer")
-    
+
             forever := make(chan bool)
-    
+
             go func() {
                     for d := range msgs {
                             log.Printf("Received a message: %s", d.Body)
@@ -542,7 +542,7 @@ And our `worker.go`:
                             log.Printf("Done")
                     }
             }()
-    
+
             log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
             <-forever
     }

--- a/site/tutorials/tutorial-two-java.md
+++ b/site/tutorials/tutorial-two-java.md
@@ -1,9 +1,9 @@
 <!--
-Copyright (C) 2007-2015 Pivotal Software, Inc. 
+Copyright (C) 2007-2015 Pivotal Software, Inc.
 
 All rights reserved. This program and the accompanying materials
-are made available under the terms of the under the Apache License, 
-Version 2.0 (the "License”); you may not use this file except in compliance 
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 # RabbitMQ tutorial - Work Queues SUPPRESS-RHS
 
-## Work Queues 
+## Work Queues
 ### (using the Java Client)
 
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
@@ -90,7 +90,7 @@ Some help to get the message from the command line argument:
             return "Hello World!";
         return joinStrings(strings, " ");
     }  
-  
+
     private static String joinStrings(String[] strings, String delimiter) {
         int length = strings.length;
         if (length == 0) return "";
@@ -224,9 +224,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned on by default. In previous
 examples we explicitly turned them off via the `autoAck=true`
@@ -285,7 +285,7 @@ unless you tell it not to. Two things are required to make sure that
 messages aren't lost: we need to mark both the queue and messages as
 durable.
 
-First, we need to make sure that RabbitMQ will never lose our 
+First, we need to make sure that RabbitMQ will never lose our
 queue. In order to do so, we need to declare it as _durable_:
 
     :::java
@@ -308,13 +308,13 @@ and consumer code.
 
 At this point we're sure that the `task_queue` queue won't be lost
 even if RabbitMQ restarts. Now we need to mark our messages as persistent
-- by setting `MessageProperties` (which implements `BasicProperties`) 
+- by setting `MessageProperties` (which implements `BasicProperties`)
 to the value `PERSISTENT_TEXT_PLAIN`.
 
     :::java
     import com.rabbitmq.client.MessageProperties;
-        
-    channel.basicPublish("", "task_queue", 
+
+    channel.basicPublish("", "task_queue",
                 MessageProperties.PERSISTENT_TEXT_PLAIN,
                 message.getBytes());
 
@@ -357,7 +357,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];
@@ -396,28 +396,28 @@ Final code of our `NewTask.java` class:
     import com.rabbitmq.client.Connection;
     import com.rabbitmq.client.Channel;
     import com.rabbitmq.client.MessageProperties;
-    
+
     public class NewTask {
-    
+
       private static final String TASK_QUEUE_NAME = "task_queue";
-    
-      public static void main(String[] argv) 
+
+      public static void main(String[] argv)
                           throws java.io.IOException {
-    
+
         ConnectionFactory factory = new ConnectionFactory();
         factory.setHost("localhost");
         Connection connection = factory.newConnection();
         Channel channel = connection.createChannel();
-        
+
         channel.queueDeclare(TASK_QUEUE_NAME, true, false, false, null);
-        
+
         String message = getMessage(argv);
-    
-        channel.basicPublish( "", TASK_QUEUE_NAME, 
+
+        channel.basicPublish( "", TASK_QUEUE_NAME,
                 MessageProperties.PERSISTENT_TEXT_PLAIN,
                 message.getBytes());
         System.out.println(" [x] Sent '" + message + "'");
-        
+
         channel.close();
         connection.close();
       }      
@@ -430,28 +430,28 @@ And our `Worker.java`:
 
     :::java
     import com.rabbitmq.client.*;
-    
+
     import java.io.IOException;
-    
+
     public class Worker {
       private static final String TASK_QUEUE_NAME = "task_queue";
-    
+
       public static void main(String[] argv) throws Exception {
         ConnectionFactory factory = new ConnectionFactory();
         factory.setHost("localhost");
         final Connection connection = factory.newConnection();
         final Channel channel = connection.createChannel();
-    
+
         channel.queueDeclare(TASK_QUEUE_NAME, true, false, false, null);
         System.out.println(" [*] Waiting for messages. To exit press CTRL+C");
-    
+
         channel.basicQos(1);
-    
+
         final Consumer consumer = new DefaultConsumer(channel) {
           @Override
           public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
             String message = new String(body, "UTF-8");
-    
+
             System.out.println(" [x] Received '" + message + "'");
             try {
               doWork(message);
@@ -463,7 +463,7 @@ And our `Worker.java`:
         };
         channel.basicConsume(TASK_QUEUE_NAME, false, consumer);
       }
-    
+
       private static void doWork(String task) {
         for (char ch : task.toCharArray()) {
           if (ch == '.') {

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -1,9 +1,9 @@
 <!--
-Copyright (C) 2007-2015 Pivotal Software, Inc. 
+Copyright (C) 2007-2015 Pivotal Software, Inc.
 
 All rights reserved. This program and the accompanying materials
-are made available under the terms of the under the Apache License, 
-Version 2.0 (the "License”); you may not use this file except in compliance 
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
@@ -89,7 +89,7 @@ messages from the queue and perform the task, so let's call it `worker.js`:
     :::javascript
     ch.consume(q, function(msg) {
       var secs = msg.content.toString().split('.').length - 1;
-      
+
       console.log(" [x] Received %s", msg.content.toString());
       setTimeout(function() {
         console.log(" [x] Done");
@@ -185,9 +185,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned off by default.
 It's time to turn them on using the `{noAck: false}` option and send a proper acknowledgment
@@ -302,7 +302,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -189,9 +189,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned off by default.
 It's time to turn them on by setting the fourth parameter to `basic_consume` to `false`
@@ -310,7 +310,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];

--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -1,9 +1,9 @@
 <!--
-Copyright (C) 2007-2015 Pivotal Software, Inc. 
+Copyright (C) 2007-2015 Pivotal Software, Inc.
 
 All rights reserved. This program and the accompanying materials
-are made available under the terms of the under the Apache License, 
-Version 2.0 (the "License”); you may not use this file except in compliance 
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
@@ -77,7 +77,7 @@ program will schedule tasks to our work queue, so let's name it
 
     :::python
     import sys
-    
+
     message = ' '.join(sys.argv[1:]) or "Hello World!"
     channel.basic_publish(exchange='',
                           routing_key='hello',
@@ -178,9 +178,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned on by default. In previous
 examples we explicitly turned them off via the `no_ack=True`
@@ -301,7 +301,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];

--- a/site/tutorials/tutorial-two-ruby.md
+++ b/site/tutorials/tutorial-two-ruby.md
@@ -1,9 +1,9 @@
 <!--
-Copyright (C) 2007-2015 Pivotal Software, Inc. 
+Copyright (C) 2007-2015 Pivotal Software, Inc.
 
 All rights reserved. This program and the accompanying materials
-are made available under the terms of the under the Apache License, 
-Version 2.0 (the "License”); you may not use this file except in compliance 
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
@@ -183,9 +183,9 @@ message wasn't processed fully and will redeliver it to another
 consumer. That way you can be sure that no message is lost, even if
 the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message
-only when the worker connection dies. It's fine even if processing a
-message takes a very, very long time.
+There aren't any message timeouts; RabbitMQ will redeliver the message when
+the consumer dies. It's fine even if processing a message takes a very, very
+long time.
 
 Message acknowledgments are turned off by default.
 It's time to turn them on using the `:manual_ack` option and send a proper acknowledgment
@@ -299,7 +299,7 @@ to the n-th consumer.
       P1 [label="P", fillcolor="#00ffff"];
       subgraph cluster_Q1 {
         label="queue_name=hello";
-	color=transparent;
+    color=transparent;
         Q1 [label="{||||}", fillcolor="red", shape="record"];
       };
       C1 [label=&lt;C&lt;font point-size="7"&gt;1&lt;/font&gt;&gt;, fillcolor="#33ccff"];


### PR DESCRIPTION
Made the wording between the documentation (in semantics.xml) and tutorials regarding redelivering of messages consistent. Fixes #88.