### PR TITLE
Fix README suffix.

### DIFF
--- a/site/plugins.xml
+++ b/site/plugins.xml
@@ -83,7 +83,7 @@ limitations under the License.
             Authentication mechanism plugin using SASL EXTERNAL to authenticate
             using SSL client certificates.
             <ul>
-              <li><r:readme-link repo="rabbitmq-auth-mechanism-ssl"/></li>
+              <li><r:readme-link repo="rabbitmq-auth-mechanism-ssl" extension=".md"/></li>
             </ul>
           </r:plugin>
 


### PR DESCRIPTION
The filename suffix has been changed, but the change was not
reflected here.