### PR TITLE
Replace `:ack => true` with `:manual_ack => true` in Ruby tutorial

### DIFF
--- a/site/tutorials/tutorial-two-ruby.md
+++ b/site/tutorials/tutorial-two-ruby.md
@@ -86,7 +86,7 @@ fake a second of work for every dot in the message body. It will pop
 messages from the queue and perform the task, so let's call it `worker.rb`:
 
     :::ruby
-    q.subscribe(:ack => true, :block => true) do |delivery_info, properties, body|
+    q.subscribe(:manual_ack => true, :block => true) do |delivery_info, properties, body|
       puts " [x] Received #{body}"
       # imitate some work
       sleep body.count(".").to_i
@@ -375,7 +375,7 @@ And our `worker.rb`:
     puts " [*] Waiting for messages. To exit press CTRL+C"
 
     begin
-      q.subscribe(:ack => true, :block => true) do |delivery_info, properties, body|
+      q.subscribe(:manual_ack => true, :block => true) do |delivery_info, properties, body|
         puts " [x] Received '#{body}'"
         # imitate some work
         sleep 1.0


### PR DESCRIPTION
Bunny has deprecated `:ack` in favor of `:manual_ack` (https://github.com/ruby-amqp/bunny/commit/9bfd6fc33bf150cc74423e13628576cb2e102317). More importantly, we don't want the tutorial to suggest that there are different semantics for the two, so we should use one consistently.

Found this a tad confusing myself; hopefully this spares someone else the same. Cheers!