### PR TITLE
Replaced broken link to Java example with working one.

### DIFF
--- a/site/confirms.xml
+++ b/site/confirms.xml
@@ -60,7 +60,7 @@ limitations under the License.
       An example in Java that publishes a large number of
       messages to a channel in confirm mode and waits for the
       acknowledgements can be found <a
-        href="https://raw.githubusercontent.com/rabbitmq/rabbitmq-java-client/master/test/src/com/rabbitmq/examples/ConfirmDontLoseMessages.java">here</a>.
+        href="https://raw.githubusercontent.com/rabbitmq/rabbitmq-java-client/master/src/test/java/com/rabbitmq/examples/ConfirmDontLoseMessages.java">here</a>.
     </p>
 
     <h3>Negative Acknowledgment</h3>


### PR DESCRIPTION
Accessing 
https://raw.githubusercontent.com/rabbitmq/rabbitmq-java-client/master/test/src/com/rabbitmq/examples/ConfirmDontLoseMessages.java 
returned a 404 Not Found. 

Replaced it with 
https://raw.githubusercontent.com/rabbitmq/rabbitmq-java-client/master/src/test/java/com/rabbitmq/examples/ConfirmDontLoseMessages.java
to make it work again.