### PR TITLE
sha1 is deprecated: Use sha256 in the example OpenSSL config

### DIFF
--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -102,7 +102,7 @@ serial = $dir/serial
 
 default_crl_days = 7
 default_days = 365
-default_md = sha1
+default_md = sha256
 
 policy = testca_policy
 x509_extensions = certificate_extensions
@@ -121,7 +121,7 @@ basicConstraints = CA:false
 [ req ]
 default_bits = 2048
 default_keyfile = ./private/cakey.pem
-default_md = sha1
+default_md = sha256
 prompt = yes
 distinguished_name = root_ca_distinguished_name
 x509_extensions = root_ca_extensions


### PR DESCRIPTION
This PR updates the SSL guide to use sha265 in the example openSSL config instead of sha1 as sha1 is deprecated.  As users with a weak SSL background may copy the example for production without realizing a weak cipher is in place I believe a strong cipher should be used in the example.

Using sha1 can also be a pain point if the cert is used to sign the management interface, as is the [default in the public RabbitMQ container](https://github.com/docker-library/rabbitmq/blob/d9c4635649edacf6728bd2a28aedc97c77ac47f9/docker-entrypoint.sh#L102-L112) as browsers are now rejecting SHA1 certs.