### PR TITLE
Use one-liners for quick copy/paste and less traces

### DIFF
--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -104,8 +104,10 @@ limitations under the License.
         <h3>Using rabbitmq.com APT Repository</h3>
 	<ol>
 	  <li>
-	    Add the following line to your <code>/etc/apt/sources.list</code>:
-	    <pre class="sourcecode">deb http://www.rabbitmq.com/debian/ testing main</pre>
+	    Execute the following command to add the APT repository to your <code>/etc/apt/sources.list.d</code>:
+	    <pre class="sourcecode">
+            echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+	    </pre>
 	    (Please note that the word <code>testing</code> in this
 	    line refers to the state of our release of RabbitMQ, not
 	    any particular Debian distribution. You can use it with

--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -125,7 +125,7 @@ limitations under the License.
 	  </li>
 	  <li>
 	    Run the following command to update the package list:
-	    <pre class="sourcecode">sudo apt-get update</pre>.
+	    <pre class="sourcecode">sudo apt-get update</pre>
 	  </li>
 	  <li>
 	    Install <code>rabbitmq-server</code> package:

--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -118,11 +118,10 @@ limitations under the License.
 	    our <a href="rabbitmq-signing-key-public.asc">public
 	      key</a> to your trusted key list using
 	    <code>apt-key(8)</code>:
-
-	    <pre class="sourcecode">wget https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
-sudo apt-key add rabbitmq-signing-key-public.asc</pre>
-
-            <p>Our public signing key is also <a href="https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq">available from Bintray</a>.</p>
+	    <pre class="sourcecode">
+            wget -O- https://www.rabbitmq.com/rabbitmq-signing-key-public.asc | sudo apt-key add -
+	    </pre>
+	    <p>Our public signing key is also <a href="https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq">available from Bintray</a>.</p>
 	  </li>
 	  <li>
 	    Run <code>apt-get update</code>.

--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -126,11 +126,11 @@ limitations under the License.
 	    <p>Our public signing key is also <a href="https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq">available from Bintray</a>.</p>
 	  </li>
 	  <li>
-	    Run <code>apt-get update</code>.
+	    Run the following command to update the package list:
+	    <pre class="sourcecode">sudo apt-get update</pre>.
 	  </li>
 	  <li>
-	    Install packages as usual; for instance,
-
+	    Install <code>rabbitmq-server</code> package:
 	    <pre class="sourcecode">sudo apt-get install rabbitmq-server</pre>
 	  </li>
 	</ol>

--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -105,9 +105,8 @@ limitations under the License.
 	<ol>
 	  <li>
 	    Execute the following command to add the APT repository to your <code>/etc/apt/sources.list.d</code>:
-	    <pre class="sourcecode">
-            echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list
-	    </pre>
+	    <pre class="sourcecode">echo 'deb http://www.rabbitmq.com/debian/ testing main' |
+                sudo tee /etc/apt/sources.list.d/rabbitmq.list</pre>
 	    (Please note that the word <code>testing</code> in this
 	    line refers to the state of our release of RabbitMQ, not
 	    any particular Debian distribution. You can use it with
@@ -120,9 +119,8 @@ limitations under the License.
 	    our <a href="rabbitmq-signing-key-public.asc">public
 	      key</a> to your trusted key list using
 	    <code>apt-key(8)</code>:
-	    <pre class="sourcecode">
-            wget -O- https://www.rabbitmq.com/rabbitmq-signing-key-public.asc | sudo apt-key add -
-	    </pre>
+	    <pre class="sourcecode">wget -O- https://www.rabbitmq.com/rabbitmq-signing-key-public.asc |
+                sudo apt-key add -</pre>
 	    <p>Our public signing key is also <a href="https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq">available from Bintray</a>.</p>
 	  </li>
 	  <li>

--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -106,7 +106,7 @@ limitations under the License.
 	  <li>
 	    Execute the following command to add the APT repository to your <code>/etc/apt/sources.list.d</code>:
 	    <pre class="sourcecode">echo 'deb http://www.rabbitmq.com/debian/ testing main' |
-                sudo tee /etc/apt/sources.list.d/rabbitmq.list</pre>
+        sudo tee /etc/apt/sources.list.d/rabbitmq.list</pre>
 	    (Please note that the word <code>testing</code> in this
 	    line refers to the state of our release of RabbitMQ, not
 	    any particular Debian distribution. You can use it with
@@ -120,7 +120,7 @@ limitations under the License.
 	      key</a> to your trusted key list using
 	    <code>apt-key(8)</code>:
 	    <pre class="sourcecode">wget -O- https://www.rabbitmq.com/rabbitmq-signing-key-public.asc |
-                sudo apt-key add -</pre>
+        sudo apt-key add -</pre>
 	    <p>Our public signing key is also <a href="https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq">available from Bintray</a>.</p>
 	  </li>
 	  <li>


### PR DESCRIPTION
### Changelog
* Moved `rabbitmq` APT repository to separate sources list
* Changed some installation commands into one-liners to decrease the number of required steps
* Minor instruction enhancements