### PR TITLE
Add missing comma

### DIFF
--- a/site/networking.xml
+++ b/site/networking.xml
@@ -377,7 +377,7 @@ In the <a href="/configure.html#erlang-term-config-file">classic config format</
   {rabbit, [
     {tcp_listen_options, [
                           {backlog,   128},
-                          {nodelay,   true}
+                          {nodelay,   true},
                           {sndbuf,    32768},
                           {recbuf,    32768}
                          ]}


### PR DESCRIPTION
There is a syntax error in networking.html page (missing comma after {nodelay, true}):

```
[
  {rabbit, [
  {tcp_listen_options, [
                        {backlog,   128},
                        {nodelay,   true}  
                        {sndbuf,    196608},
                        {recbuf,    196608}
                       ]}
  ]}
].
```