### PR TITLE
Add comma to TCP buffer size block

### DIFF
--- a/site/networking.xml
+++ b/site/networking.xml
@@ -221,7 +221,7 @@ is equivalent to
   {rabbit, [
   {tcp_listen_options, [
                         {backlog,   128},
-                        {nodelay,   true}  
+                        {nodelay,   true},
                         {sndbuf,    196608},
                         {recbuf,    196608}
                        ]}
@@ -363,7 +363,7 @@ RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+A 128"
   {rabbit, [
     {tcp_listen_options, [
                           {backlog,   4096},
-                          {nodelay,   true}  
+                          {nodelay,   true}
                          ]}
   ]}
 ].
@@ -396,7 +396,7 @@ RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+A 128"
   {rabbit, [
     {tcp_listen_options, [
                           {backlog,   4096},
-                          {nodelay,   true}  
+                          {nodelay,   true}
                          ]}
   ]}
 ].


### PR DESCRIPTION
Addresses [Issue #173](https://github.com/rabbitmq/rabbitmq-website/issues/173), and cleans up some stray whitespace.