### PR TITLE
Tutorial 2 corrections

### DIFF
--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -113,10 +113,8 @@ handle messages delivered by RabbitMQ and perform the task, so let's call it `Wo
         Thread.Sleep(dots * 1000);
 
         Console.WriteLine(" [x] Done");
-
-        channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
     };
-    channel.BasicConsume(queue: "task_queue", noAck: false, consumer: consumer);
+    channel.BasicConsume(queue: "task_queue", noAck: true, consumer: consumer);
 
 
 Our fake task to simulate execution time:

--- a/site/tutorials/tutorial-two-elixir.md
+++ b/site/tutorials/tutorial-two-elixir.md
@@ -103,7 +103,6 @@ messages from the queue and perform the task, so let's call it `worker.exs`:
             |> Kernel.*(1000)
             |> :timer.sleep
             IO.puts " [x] Done."
-            AMQP.Basic.ack(channel, meta.delivery_tag)
 
             wait_for_messages(channel)
         end

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -98,7 +98,7 @@ messages from the queue and perform the task, so let's call it `worker.go`:
     msgs, err := ch.Consume(
       q.Name, // queue
       "",     // consumer
-      false,  // auto-ack
+      true,   // auto-ack
       false,  // exclusive
       false,  // no-local
       false,  // no-wait
@@ -111,7 +111,6 @@ messages from the queue and perform the task, so let's call it `worker.go`:
     go func() {
       for d := range msgs {
         log.Printf("Received a message: %s", d.Body)
-        d.Ack(false)
         dot_count := bytes.Count(d.Body, []byte("."))
         t := time.Duration(dot_count)
         time.Sleep(t * time.Second)
@@ -237,11 +236,11 @@ from the worker `d.Ack(false)`, once we're done with a task.
     go func() {
       for d := range msgs {
         log.Printf("Received a message: %s", d.Body)
-        d.Ack(false)
         dot_count := bytes.Count(d.Body, []byte("."))
         t := time.Duration(dot_count)
         time.Sleep(t * time.Second)
         log.Printf("Done")
+        d.Ack(false)
       }
     }()
 

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -93,9 +93,8 @@ messages from the queue and perform the task, so let's call it `worker.js`:
       console.log(" [x] Received %s", msg.content.toString());
       setTimeout(function() {
         console.log(" [x] Done");
-        ch.ack(msg);
       }, secs * 1000);
-    }, {noAck: false});
+    }, {noAck: true});
 
 Note that our fake task simulates execution time.
 
@@ -191,9 +190,10 @@ There aren't any message timeouts; RabbitMQ will redeliver the message when
 the consumer dies. It's fine even if processing a message takes a very, very
 long time.
 
-Message acknowledgments are turned off by default.
-It's time to turn them on using the `{noAck: false}` option and send a proper acknowledgment
-from the worker, once we're done with a task.
+Message acknowledgments have been turned off in previous examples.
+It's time to turn them on using the `{noAck: false}` (you may also remove the
+options altogether) option and send a proper acknowledgment from the worker,
+once we're done with a task.
 
     :::javascript
     ch.consume(q, function(msg) {

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -95,11 +95,10 @@ messages from the queue and perform the task, so let's call it `worker.php`:
       echo " [x] Received ", $msg->body, "\n";
       sleep(substr_count($msg->body, '.'));
       echo " [x] Done", "\n";
-      $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
     };
 
     $channel->basic_qos(null, 1, null);
-    $channel->basic_consume('task_queue', '', false, false, false, false, $callback);
+    $channel->basic_consume('task_queue', '', false, true, false, false, $callback);
 
 Note that our fake task simulates execution time.
 

--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -98,7 +98,6 @@ messages from the queue and perform the task, so let's call it `worker.py`:
         print(" [x] Received %r" % body)
         time.sleep(body.count(b'.'))
         print(" [x] Done")
-        ch.basic_ack(delivery_tag = method.delivery_tag)
 
 
 Round-robin dispatching

--- a/site/tutorials/tutorial-two-ruby.md
+++ b/site/tutorials/tutorial-two-ruby.md
@@ -86,13 +86,11 @@ fake a second of work for every dot in the message body. It will pop
 messages from the queue and perform the task, so let's call it `worker.rb`:
 
     :::ruby
-    q.subscribe(:manual_ack => true, :block => true) do |delivery_info, properties, body|
+    q.subscribe(:block => true) do |delivery_info, properties, body|
       puts " [x] Received #{body}"
       # imitate some work
       sleep body.count(".").to_i
       puts " [x] Done"
-
-      ch.ack(delivery_info.delivery_tag)
     end
 
 Note that our fake task simulates execution time.


### PR DESCRIPTION
Issue #180

Also, move ack below work in Go tutorial 2 - Issue #181

Correct prose used with node client, as this client defaults to noAck:
false (requiring manual acknowledgment).

See http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume

[#117326341]
[#117326391]