### PR TITLE
Update ObjC tutorials for v0.7

### DIFF
--- a/site/tutorials/tutorial-five-objectivec.md
+++ b/site/tutorials/tutorial-five-objectivec.md
@@ -169,8 +169,8 @@ The code for `receiveLogsTopic`:
 
         NSLog(@"Waiting for logs.");
 
-        [q subscribe:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
-            NSLog(@"%@:%@", deliveryInfo.routingKey, message.content);
+        [q subscribe:^(RMQMessage * _Nonnull message) {
+            NSLog(@"%@:%@", message.routingKey, message.content);
         }];
     }
 

--- a/site/tutorials/tutorial-four-objectivec.md
+++ b/site/tutorials/tutorial-four-objectivec.md
@@ -266,8 +266,8 @@ The code for `receiveLogsDirect`:
 
         NSLog(@"Waiting for logs.");
 
-        [q subscribe:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
-            NSLog(@"%@:%@", deliveryInfo.routingKey, message.content);
+        [q subscribe:^(RMQMessage * _Nonnull message) {
+            NSLog(@"%@:%@", message.routingKey, message.content);
         }];
     }
 

--- a/site/tutorials/tutorial-one-objectivec.md
+++ b/site/tutorials/tutorial-one-objectivec.md
@@ -144,7 +144,7 @@ Note this matches up with the queue that `send` publishes to.
         RMQConnection *conn = [[RMQConnection alloc] initWithDelegate:[RMQConnectionDelegateLogger new]];
         [conn start];
 
-        id<RMQChannel> ch = [conn createChannelWithError:&error];
+        id<RMQChannel> ch = [conn createChannel];
 
         RMQQueue *q = [ch queue:@"hello"];
 
@@ -158,7 +158,7 @@ callback that will be executed when RabbitMQ pushes messages to
 our consumer. This is what `RMQQueue subscribe:` does.
 
     NSLog(@"Waiting for messages.");
-    [q subscribe:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
+    [q subscribe:^(RMQMessage * _Nonnull message) {
         NSLog(@"Received %@", message.content);
     }];
 

--- a/site/tutorials/tutorial-three-objectivec.md
+++ b/site/tutorials/tutorial-three-objectivec.md
@@ -111,7 +111,7 @@ queues it knows. And that's exactly what we need for our logger.
 >
 > Recall how we published a message before:
 >
->     [ch.default_exchange publish:@"hello" routingKey:@"hello"];
+>     [ch.defaultExchange publish:@"hello" routingKey:@"hello" persistent:YES];
 >
 > Here we use the default or _nameless_ exchange: messages are
 > routed to the queue with the name specified by `routingKey`, if it exists.
@@ -273,7 +273,7 @@ The code for `receiveLogs`:
 
     NSLog(@"Waiting for logs.");
 
-    [q subscribe:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
+    [q subscribe:^(RMQMessage * _Nonnull message) {
         NSLog(@"Received %@", message);
     }];
 

--- a/site/tutorials/tutorial-two-objectivec.md
+++ b/site/tutorials/tutorial-two-objectivec.md
@@ -64,7 +64,7 @@ fake a second of work for every dot in the message body. It will help us
 understand what's going on if each worker has a name, and each will need to pop
 messages from the queue and perform the task, so let's call it `workerNamed:`:
 
-    [q subscribe:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
+    [q subscribe:^(RMQMessage * _Nonnull message) {
         NSLog(@"%@: Received %@", name, message.content);
         // imitate some work
         unsigned int sleepTime = (unsigned int)[message.content componentsSeparatedByString:@"."].count - 1;
@@ -169,7 +169,7 @@ explicitly setting `AMQBasicConsumeNoOptions` and sending a proper
 acknowledgment from the worker once we're done with a task.
 
     RMQBasicConsumeOptions manualAck = RMQBasicConsumeNoOptions;
-    [q subscribe:manualAck handler:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
+    [q subscribe:manualAck handler:^(RMQMessage * _Nonnull message) {
         NSLog(@"%@: Received %@", name, message.content);
         // imitate some work
         unsigned int sleepTime = (unsigned int)[message.content componentsSeparatedByString:@"."].count - 1;
@@ -333,7 +333,7 @@ And our `workerNamed:`:
         NSLog(@"%@: Waiting for messages", name);
 
         RMQBasicConsumeOptions manualAck = RMQBasicConsumeNoOptions;
-        [q subscribe:manualAck handler:^(RMQDeliveryInfo * _Nonnull deliveryInfo, RMQMessage * _Nonnull message) {
+        [q subscribe:manualAck handler:^(RMQMessage * _Nonnull message) {
             NSLog(@"%@: Received %@", name, message.content);
             // imitate some work
             unsigned int sleepTime = (unsigned int)[message.content componentsSeparatedByString:@"."].count - 1;


### PR DESCRIPTION
Also:

- Correct a call to outdated `createChannelWithError`
- Fix a part-untranslated method name that still contained an
  underscore.

[#120637007]