### PR TITLE
Update .NET client nightly link to point to AppVeyor NuGet feed

### DIFF
--- a/site/nightly-builds.xml
+++ b/site/nightly-builds.xml
@@ -88,7 +88,7 @@ limitations under the License.
           <a href="/nightlies/rabbitmq-java-client">Java Client</a>
         </li>
         <li id="rabbitmq-dotnet-client">
-            <a href="/nightlies/rabbitmq-dotnet-client">.NET/C# Client</a>
+            <a href="https://ci.appveyor.com/nuget/rabbitmq-dotnet-client-ci">.NET/C# Client (AppVeyor NuGet feed)</a>
         </li>
         <li id="rabbitmq-erlang-client">
           <a href="/nightlies/rabbitmq-erlang-client">Erlang Client</a>


### PR DESCRIPTION
Fixes #22