### PR TITLE
Fixed tutorial-two-java

### DIFF
--- a/site/tutorials/tutorial-two-java.md
+++ b/site/tutorials/tutorial-two-java.md
@@ -464,7 +464,7 @@ And our `Worker.java`:
             }
           }
         };
-        channel.basicConsume(TASK_QUEUE_NAME, false, consumer);
+        channel.basicConsume(TASK_QUEUE_NAME, consumer);
       }
 
       private static void doWork(String task) {

--- a/site/tutorials/tutorial-two-java.md
+++ b/site/tutorials/tutorial-two-java.md
@@ -231,8 +231,8 @@ the consumer dies. It's fine even if processing a message takes a very, very
 long time.
 
 Message acknowledgments are turned on by default. In previous
-examples we explicitly turned them off via the `autoAck=true`
-flag. It's time to remove this flag and send a proper acknowledgment
+examples we explicitly turned them off passing `true` to `autoAck` flag of method
+`basicConsume`. It's time to remove this flag and send a proper acknowledgment
 from the worker, once we're done with a task.
 
     :::java
@@ -252,6 +252,7 @@ from the worker, once we're done with a task.
         }
       }
     };
+    channel.basicConsume(TASK_QUEUE_NAME, consumer);
 
 
 Using this code we can be sure that even if you kill a worker using


### PR DESCRIPTION
Tutorial two for java contains a mistake. This PR fixes it. Closes #204.