### PR TITLE
Fix tutorial-one-javascript. Close #230

### DIFF
--- a/site/tutorials/tutorial-one-javascript.md
+++ b/site/tutorials/tutorial-one-javascript.md
@@ -95,7 +95,7 @@ to the queue:
         var q = 'hello';
 
         ch.assertQueue(q, {durable: false});
-        ch.sendToQueue(q, new Buffer('Hello World!'));
+        ch.sendToQueue(q, Buffer.from('Hello World!'));
         console.log(" [x] Sent 'Hello World!'");
       });
     });


### PR DESCRIPTION
Replace deprecated `new Buffer` instantiation brought up in [#230](https://github.com/rabbitmq/rabbitmq-website/issues/230). 