### PR TITLE
Add trademark guidelines, reorganise footer.

### DIFF
--- a/site/css/rabbit.css
+++ b/site/css/rabbit.css
@@ -158,13 +158,19 @@ ol.plain li, ul.plain li {
 	padding: 0px 0px 0px 0px;
 	border-bottom: none;
 }
-ul.plain li {
-	list-style-type : disc !important;	
+ul.plain>li {
+	list-style-type : disc !important;
 }
-ol.plain li {
-	list-style-type : decimal !important;	
+ol.plain>li {
+	list-style-type : decimal !important;
 }
-	
+ol.alpha>li {
+    list-style-type : lower-alpha !important;
+}
+ol.roman>li {
+    list-style-type : lower-roman !important;
+}
+
 .col li {
 	border-bottom: #e4e4e4 1px solid;
 }

--- a/site/page.xsl
+++ b/site/page.xsl
@@ -122,16 +122,17 @@ limitations under the License.
   <xsl:template name="page-footer">
     <div class="clear"/>
     <div class="pageFooter">
-      <p class="righter">
+      <p>
         <a href="/sitemap.html">Sitemap</a> |
-        <a href="/contact.html">Contact</a>
+        <a href="/contact.html">Contact</a> |
+        <a href="https://github.com/rabbitmq/rabbitmq-website/">This Site is Open Source</a> |
+        <a href="https://pivotal.io/careers/engineering">Pivotal is Hiring</a>
       </p>
       <p id="copyright">
-        Copyright &#169; 2007-2016 Pivotal Software, Inc. All rights reserved
-        |&#160;<a href="https://pivotal.io/terms-of-use">Terms of Use</a>
-        |&#160;<a href="https://pivotal.io/privacy-policy">Privacy</a>
-        |&#160;<a href="https://github.com/rabbitmq/rabbitmq-website/">This Site is Open Source</a>
-        |&#160;<a href="https://pivotal.io/careers/engineering">Pivotal is Hiring</a>
+        Copyright &#169; 2007-2016 <a href="https://pivotal.io/">Pivotal Software</a>, Inc. All rights reserved.
+        <a href="https://pivotal.io/terms-of-use">Terms of Use</a>,
+        <a href="https://pivotal.io/privacy-policy">Privacy</a> and
+        <a href="/trademark-guidelines.html">Trademark Guidelines</a>
       </p>
     </div>
   </xsl:template>

--- a/site/page.xsl
+++ b/site/page.xsl
@@ -129,7 +129,7 @@ limitations under the License.
         <a href="https://pivotal.io/careers/engineering">Pivotal is Hiring</a>
       </p>
       <p id="copyright">
-        Copyright &#169; 2007-2016 <a href="https://pivotal.io/">Pivotal Software</a>, Inc. All rights reserved.
+        Copyright &#169; 2007-Present <a href="https://pivotal.io/">Pivotal Software</a>, Inc. All rights reserved.
         <a href="https://pivotal.io/terms-of-use">Terms of Use</a>,
         <a href="https://pivotal.io/privacy-policy">Privacy</a> and
         <a href="/trademark-guidelines.html">Trademark Guidelines</a>

--- a/site/trademark-guidelines.xml
+++ b/site/trademark-guidelines.xml
@@ -1,0 +1,396 @@
+<?xml-stylesheet type="text/xml" href="page.xsl"?>
+<!--
+Copyright (c) 2007-2016 Pivotal Software, Inc.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
+  xmlns:x="http://www.rabbitmq.com/2011/extensions">
+  <head>
+    <title>RabbitMQ Trademark Guidelines</title>
+  </head>
+  <body>
+    <ol class="plain">
+      <li>
+        <p>
+          <strong>PURPOSE.</strong> Pivotal Software, Inc. (“Pivotal”) owns a number of
+          international trademarks and logos that identify the RabbitMQ community
+          and individual RabbitMQ projects (“RabbitMQ Marks”). These trademarks
+          include:
+        </p>
+        <ol class="alpha">
+          <li>
+            <p>
+              <strong>Word: RABBITMQ</strong>
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Logos:</strong>
+            </p>
+            <img src="/img/rabbitmq_logo_strap.png"/>
+          </li>
+        </ol>
+        <p>
+          This policy outlines Pivotal’s policy and guidelines about the use of
+          the RabbitMQ trademarks by members of the RabbitMQ development and
+          user community.
+        </p>
+      </li>
+      <li>
+        <p>
+          <strong>
+            WHY HAVE TRADEMARK GUIDELINES?
+          </strong> The RabbitMQ Marks are a symbol of the
+          quality and community support associated with the RabbitMQ open
+          source software. Trademarks protect not only those using the marks,
+          but the entire community as well. Our community members need to know
+          that they can rely on the quality and capabilities represented by the
+          brand. We also want to provide a level playing field. No one should
+          use the RabbitMQ marks in ways that mislead or take advantage of the
+          community, or make unfair use of the trademarks. Also, use of the
+          RabbitMQ Marks should not be in a disparaging manner because we
+          prefer that our marks not be used to be rude about the RabbitMQ open
+          source project or its members.
+        </p>
+      </li>
+      <li>
+        <p>
+          <strong>
+            OPEN SOURCE LICENSE VS. TRADEMARKS.
+          </strong> The Apache 2.0 license gives you
+          the right to use, copy, distribute and modify the RabbitMQ software.
+          However, open source licenses like the Apache 2.0 license do not
+          address trademarks. RabbitMQ Marks need to be used in a way
+          consistent with trademark law, and that is why we have prepared this
+          policy – to help you understand what branding is allowed or required
+          when using our software under the Apache license.
+        </p>
+      </li>
+      <li>
+        <p>
+          <strong>
+            PROPER USE OF THE RabbitMQ MARKS.
+          </strong> We want to encourage a robust
+          community for the RabbitMQ open source project. Therefore, you may do
+          any of the following, as long as you do so in a way that does not
+          devalue, dilute, or disparage the RabbitMQ brand. In other words,
+          when you do these things, you should behave responsibly and
+          reasonably in the interest of the community, but you do not need a
+          trademark license from us to do them.
+        </p>
+        <ol class="alpha">
+          <li>
+            <p>
+              <strong>
+                Nominative Use.
+              </strong> You may engage in “nominative use” of the
+              RabbitMQ name, but this does not allow you to use the logo.
+              Nominative use is sometimes called “fair use” of a trademark, and
+              does not require a trademark license from us.  Here are examples:
+            </p>
+            <ol class="roman">
+              <li>
+                <p>
+                  You may use the RabbitMQ Marks in connection with development
+                  of tools, add-ons, or utilities that are compatible with
+                  bit-for-bit identical copies of official RabbitMQ software.
+                  For example:  For example, if you are developing a Foobar
+                  tool for RabbitMQ, acceptable project titles would be “Foobar
+                  for RabbitMQ".
+                </p>
+              </li>
+              <li>
+                <p>
+                  You may use the RabbitMQ Marks in connection with your
+                  noncommercial redistribution of (1) bit-for-bit identical
+                  copies of official RabbitMQ software, and (2) unmodified
+                  copies of official RabbitMQ source packages.  For example, if
+                  your Foobar product included a full redistribution of
+                  official RabbitMQ Software or source code packages:
+                  "RabbitMQ-powered Foobar Product". We strongly discourage,
+                  and likely would consider it a trademark problem, to use a
+                  name such as “RabbitMQ Foobar.”
+                </p>
+              </li>
+              <li>
+                <p>
+                  If you offer maintenance, support, or hosting services for
+                  RabbitMQ software, you may accurately state that in your
+                  marketing materials or portfolio, without using the RabbitMQ
+                  logo.
+                </p>
+              </li>
+              <li>
+                <p>
+                  You may modify the RabbitMQ software and state that your
+                  modified software is “based on the RabbitMQ software” or a
+                  similar accurate statement, without using the RabbitMQ logo.
+                </p>
+              </li>
+              <li>
+                <p>
+                  You may engage in community advocacy. The RabbitMQ software
+                  is developed by and for its community. We will allow the use
+                  of the word trademark in this context, provided:
+                </p>
+                <ol class="plain">
+                  <li>
+                    <p>
+                      The trademark is used in a manner consistent with this
+                      policy
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      There is no commercial purpose behind the use
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      There is no suggestion that your project is approved,
+                      sponsored, or affiliated with Pivotal.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      User or Development Groups. You may create RabbitMQ user
+                      or development groups, and publicize meetings or
+                      discussions for those groups.  Please consider joining
+                      our official group.
+                    </p>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Attribution.
+              </strong> Identify the trademarks as trademarks of Pivotal, as
+              set forth in Section 7.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Redistribution of Binaries.
+              </strong> If you redistribute binaries that you have downloaded
+              from the RabbitMQ repository, you should retain the logos and
+              name of the product.  However, if you make any changes to the
+              binaries (other than configuration or installation changes that
+              do not involve changes to the source code), or if you re-build
+              binaries from our source code, you should not use our logos.  Our
+              logos represent our quality control, so they should be retained
+              where the product has been built by us, but not otherwise.  Our
+              source code does not include logo image files, to remind you to
+              follow this rule.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Capitalization.
+              </strong> “RabbitMQ” should always be capitalized and one
+              words.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Adjectives.
+              </strong> Use the RabbitMQ mark as an adjective, not a noun or
+              verb.
+            </p>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <p>
+          <strong>
+            IMPROPER USE OF THE TRADEMARKS AND LOGOS.
+          </strong> Use of the logos is
+          reserved solely for use by Pivotal in its unaltered form. Examples of
+          unauthorized use of the RabbitMQ trademarks include:
+        </p>
+        <ol class="alpha">
+          <li>
+            <p>
+              <strong>
+                Commercial Use:
+              </strong> You may not use the RabbitMQ Marks in connection
+              with commercial redistribution of RabbitMQ software (commercial
+              redistribution includes, but is not limited to, redistribution in
+              connection with any commercial business activities or
+              revenue-generating business activities) regardless of whether the
+              RabbitMQ software is unmodified.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Entity Names.
+              </strong> You may not form a company, use a company name, or
+              create a software product name that includes the “RabbitMQ”
+              trademark, or implies any foundational or authorship role. If you
+              have a software product that works with RabbitMQ, it is suggested
+              you use terms such as ‘&lt;product name> for RabbitMQ’ or
+              ‘&lt;product name>, RabbitMQ Edition.” If you wish to form an
+              entity for a user or developer group, please contact us and we
+              will be glad to discuss a license for a suitable name.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Class or Quality.
+              </strong> You may not imply that you are providing a
+              class or quality of RabbitMQ (e.g., "enterprise-class" or
+              "commercial quality") in a way that implies RabbitMQ is not of
+              that class, grade or quality, nor that other parties are not of
+              that class, grade, or quality.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Combinations.
+              </strong> Use of the RabbitMQ Marks to identify software that
+              combines any portion of the RabbitMQ software with any other
+              software, unless the combined distribution is an official
+              RabbitMQ distribution. For example, you may not distribute a
+              combination of the RabbitMQ  software with software released by
+              the Foobar project under the name “RabbitMQ Foobar Distro”.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                False or Misleading Statements.
+              </strong> You may not make false or
+              misleading statements regarding your use of RabbitMQ (e.g., "we
+              wrote the majority of the code" or "we are major contributors" or
+              "we are committers").
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Domain Names.
+              </strong> You must not use RabbitMQ or any confusingly
+              similar phrase in a domain name. For instance
+              “www.rabbitmqhost.com” is not allowed. If you wish to use such a
+              domain name for a non-commercial user or developer group to
+              engage in community advocacy, please contact us and we will be
+              glad to discuss a license for a suitable domain name.  Because of
+              the many persons who, unfortunately, seek to spoof, swindle or
+              deceive the community by using confusing domain names, we must be
+              very strict about this rule.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Merchandise.
+              </strong> You must not manufacture, sell or give away
+              merchandise items, such as T-shirts and mugs, bearing the
+              RabbitMQ logo, or create any mascot for the project.  If you wish
+              to use the logo to do this for a non-commerical user or developer
+              group to engage in community advocacy, please contact us and we
+              will be glad to discuss a license to do this.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Variations, takeoffs or abbreviations.
+              </strong> You may not use a
+              variation of the RabbitMQ name or logo for any purpose other than
+              common usage of these in community communications. For example,
+              the following are not acceptable:
+            </p>
+            <ol class="roman">
+              <li><p>RMQ</p></li>
+              <li><p>MyRabbitMQ</p></li>
+              <li><p>RabbitMQ Messaging</p></li>
+              <li><p>RabbitMQ Guru</p></li>
+            </ol>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Endorsement or Sponsorship.
+              </strong> You may not use the RabbitMQ
+              trademarks in a manner that would imply Pivotal’s affiliation
+              with or endorsement, sponsorship, or support of a product or
+              service.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Rebranding.
+              </strong> You may not change the trademark on unmodified
+              RabbitMQ software to your own brand.  You may not hold yourself
+              out as the source of the RabbitMQ software, except to the extent
+              you have modified it as allowed under the Apache 2.0 license, and
+              you make it clear that you are the source only of the
+              modification.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Combination Marks.
+              </strong> Do not use our trademarks in combination with
+              any other marks or logos (for example Foobar RabbitMQ, or the
+              name of your company or product typeset to look like the RabbitMQ
+              logo).
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>
+                Web Tags.
+              </strong> Do not use the RabbitMQ trademark in a title or metatag
+              of a web page to influence search engine rankings or result
+              listings, rather than for discussion or advocacy of the RabbitMQ
+              project.
+            </p>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <p>
+          <strong>
+            PROPER NOTICE AND ATTRIBUTION.
+          </strong> The appropriate trademark symbol
+          (i.e.,  ®) should appear at least with the first use of the RabbitMQ
+          trademarks (for example, RABBITMQ®). When you use a RabbitMQ
+          trademark you should include a statement attributing the trademark to
+          Pivotal. For example, "RabbitMQ is a trademark of Pivotal Software,
+          Inc. in the U.S. and other countries."
+        </p>
+      </li>
+      <li>
+        <p>
+          MORE QUESTIONS? If you have questions about this policy, please
+          contact us at <a href="mailto:info@rabbitmq.com">info@rabbitmq.com</a>.
+        </p>
+      </li>
+    </ol>
+  </body>
+</html>

--- a/wordpress-theme/footer.php
+++ b/wordpress-theme/footer.php
@@ -3,17 +3,18 @@
       <p><small>The postings on this site are by individual members of the
           RabbitMQ team, and do not represent Pivotal’s positions, strategies
           or opinions.</small></p>
-        <p class="righter">
-          <a href="/sitemap.html">Sitemap</a> |
-          <a href="/contact.html">Contact</a>
-        </p>
-        <p id="copyright">
-          Copyright &#169; 2007-2016 Pivotal Software, Inc. All rights reserved
-          |&#160;<a href="https://pivotal.io/terms-of-use">Terms of Use</a>
-          |&#160;<a href="https://pivotal.io/privacy-policy">Privacy</a>
-          |&#160;<a href="https://github.com/rabbitmq/rabbitmq-website/">This Site is Open Source</a>
-          |&#160;<a href="https://pivotal.io/careers/engineering">Pivotal is Hiring</a>
-        </p>
+      <p>
+        <a href="/sitemap.html">Sitemap</a> |
+        <a href="/contact.html">Contact</a> |
+        <a href="https://github.com/rabbitmq/rabbitmq-website/">This Site is Open Source</a> |
+        <a href="https://pivotal.io/careers/engineering">Pivotal is Hiring</a>
+      </p>
+      <p id="copyright">
+        Copyright &#169; 2007-2016 <a href="https://pivotal.io/">Pivotal Software</a>, Inc. All rights reserved.
+        <a href="https://pivotal.io/terms-of-use">Terms of Use</a>,
+        <a href="https://pivotal.io/privacy-policy">Privacy</a> and
+        <a href="/trademark-guidelines.html">Trademark Guidelines</a>
+      </p>
       </div>
     </div>
   </div>

--- a/wordpress-theme/footer.php
+++ b/wordpress-theme/footer.php
@@ -10,7 +10,7 @@
         <a href="https://pivotal.io/careers/engineering">Pivotal is Hiring</a>
       </p>
       <p id="copyright">
-        Copyright &#169; 2007-2016 <a href="https://pivotal.io/">Pivotal Software</a>, Inc. All rights reserved.
+        Copyright &#169; 2007-Present <a href="https://pivotal.io/">Pivotal Software</a>, Inc. All rights reserved.
         <a href="https://pivotal.io/terms-of-use">Terms of Use</a>,
         <a href="https://pivotal.io/privacy-policy">Privacy</a> and
         <a href="/trademark-guidelines.html">Trademark Guidelines</a>


### PR DESCRIPTION
* Move to a two line footer
* Move open source and hiring link to top line, use spring.io's
  Copyright line.

[#127911299]