### PR TITLE
Make configuration of sample_retention_policies clearer

### DIFF
--- a/site/management.xml
+++ b/site/management.xml
@@ -471,11 +471,11 @@ management.sample_retention_policies.detailed.10 = 5
   ...
 {rabbitmq_management,
   %% List of {MaxAgeInSeconds, SampleEveryNSeconds}
-  [{global,   [{60, 5}, {3600, 60}, {86400, 1200}]},
-   {basic,    [{60, 5}, {3600, 60}]},
-   {detailed, [{10, 5}]}]
-
- %% , ...
+  {sample_retention_policies,
+    [{global,   [{60, 5}, {3600, 60}, {86400, 1200}]},
+     {basic,    [{60, 5}, {3600, 60}]},
+     {detailed, [{10, 5}]}]}
+   %% , ...
 ].</pre>
 
           <p>


### PR DESCRIPTION
I read the documentation and attempted to apply updated sample_retention_policies to the rabbitmq_management plugin.

Using the current documentation, I (incorrectly) made basic, detailed and global at the first level under rabbitmq_management.

I wondered why it wasn't working, and a `rabbitmqctl environment` showed:
```
{rabbitmq_management,
     [{basic,[{605,5},{3600,60},{29400,600},{86400,1800}]},
      {cors_allow_origins,[]},
      {cors_max_age,1800},
      {detailed,[{10,5}]},
      {global,[{605,5},{3600,60},{29400,600},{86400,1800}]},
      {http_log_dir,none},
      {listener,[{port,15672}]},
      {load_definitions,none},
      {process_stats_gc_timeout,300000},
      {rates_mode,basic},
      {sample_retention_policies,
          [{global,[{605,5},{3660,60},{29400,600},{86400,1800}]},
           {basic,[{605,5},{3600,60}]},
           {detailed,[{10,5}]}]},
      {stats_event_max_backlog,250}]},
```
I'd put it in at the wrong level.

A change to the docs as suggested would make it clearer that they're meant to be underneath the sample_retention_policies.

This also matches the example config in the [rabbitmq.config.example](https://github.com/rabbitmq/rabbitmq-server/blob/stable/docs/rabbitmq.config.example#L347) file.

Cheers,
Michael