### PR TITLE
Fix: Add missing option in example openssl.cnf

### DIFF
--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -140,6 +140,7 @@ countryName = optional
 emailAddress = optional
 organizationName = optional
 organizationalUnitName = optional
+domainComponent = optional
 
 [ certificate_extensions ]
 basicConstraints = CA:false


### PR DESCRIPTION
Add `domainComponent = optional` in the `[ testca_policy ]` section of the openssl.cnf. Otherwise ssl/tls connections will fail in some cases. 

See also:
* https://groups.google.com/forum/#!topic/rabbitmq-users/uwRLaKqpha0
* https://github.com/michaelklishin/tls-gen/