### PR TITLE
Adding queue name in the javascript tutorial two code example

### DIFF
--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -76,6 +76,7 @@ program will schedule tasks to our work queue, so let's name it
 `new_task.js`:
 
     :::javascript
+    var q = 'task_queue';
     var msg = process.argv.slice(2).join(' ') || "Hello World!";
 
     ch.assertQueue(q, {durable: true});


### PR DESCRIPTION
~~When you use same queue name of the tutorial one, you get problems because the queue already exists.~~

~~See the image below to view the error that occurred when I tried to run the tutorial two with the same queue name as the tutorial one.~~

![captura de tela de 2016-09-23 01 31 57](https://cloud.githubusercontent.com/assets/4651184/18774523/70256aa2-8130-11e6-8cba-2f69460dba57.png)

EDIT: The real issue was with the durable argument, but, I think that is better to show this line as well as the code in the tutorials repo.

https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/worker.js#L7

If this change is "insignificant" for a PR, just tell me and I cancel.