### PR TITLE
Add documentation for lazy_queue_explicit_ gc_run_operation_threshold

### DIFF
--- a/site/configure.xml
+++ b/site/configure.xml
@@ -1014,6 +1014,17 @@ CONFIG_FILE=/etc/rabbitmq/testdir/bunnies</pre>
               <p>Default: <code>&lt;&lt;"client-local"&gt;&gt;</code></p>
             </td>
           </tr>
+          <tr>
+            <td><code>lazy_queue_explicit_</code>
+              <code>gc_run_operation_threshold</code></td>
+            <td>
+             Tunable value only for lazy queues when under memory pressure. 
+             This is the threshold at which the garbage collector is triggered.
+             A low value could reduce performance, and a high one can improve performance, but cause higher memory consumption.
+             You almost certainly should not change this.
+            <p>Default: <code>250</code></p>
+            </td>
+          </tr>
         </table>
         <p>
           In addition, many plugins can have sections in the


### PR DESCRIPTION
Add documentation for `lazy_queue_explicit_gc_run_operation_threshold` 
( rabbitmq-server/pull/978/ )

The param name is a bit long, so it is in 2 lines
![screen shot 2016-10-20 at 15 12 08](https://cloud.githubusercontent.com/assets/386987/19561149/ae7e0d42-96d7-11e6-9109-01c0be0f3b39.png)


