### PR TITLE
Update Java Client doc after separate distribution

### DIFF
--- a/site/api-guide.xml
+++ b/site/api-guide.xml
@@ -42,8 +42,8 @@ limitations under the License.
             href="&dir-current-javadoc;">documentation</a>.
         </p>
         <p class="intro">
-            The Java client also ships with
-            some <a href="java-tools.html">command line tools</a>.
+            There are also Java <a href="java-tools.html">command line tools</a>
+            based on the Java client.
         </p>
 
     <p>

--- a/site/api-guide.xml
+++ b/site/api-guide.xml
@@ -42,8 +42,8 @@ limitations under the License.
             href="&dir-current-javadoc;">documentation</a>.
         </p>
         <p class="intro">
-            There are also Java <a href="java-tools.html">command line tools</a>
-            based on the Java client.
+            There are also <a href="java-tools.html">command line tools</a>
+            that used to be shipped with the Java client.
         </p>
 
     <p>

--- a/site/build-java-client.xml
+++ b/site/build-java-client.xml
@@ -38,17 +38,14 @@ limitations under the License.
 
 	  <li>Check the code out directly from <a href="github.html">our GitHub repositories</a>:
 	    <pre class="sourcecode">$ git clone https://github.com/rabbitmq/rabbitmq-codegen.git rabbitmq_codegen
-$ git clone https://github.com/rabbitmq/rabbitmq-java-client.git
-$ cd rabbitmq-java-client
-$ ant dist</pre>
+$ git clone https://github.com/rabbitmq/rabbitmq-java-client.git</pre>
 	  </li>
 	</ul>
 
 	<p>
-	  If you choose to check the code out using Git, be
+	  If you choose to download a released source code distribution, be
 	  aware that the code-generation module is a dependency of
-	  the Java client library. If you're  working with a released
-	  source code distribution, though, the code-generation module is included.
+	  the Java client library.
 	</p>
       </doc:section>
 
@@ -76,17 +73,13 @@ $ ant dist</pre>
 	<ul class="compact">
 	  <li>
 	    a <a
-	    href="http://java.sun.com/javase/downloads/index.jsp">Java
-	    compiler</a>, for Java language version 1.5 or newer
+	    href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Java
+	    compiler</a>, for Java language version 1.6 or newer
 	  </li>
 
 	  <li>
-	    <a href="http://ant.apache.org/">Ant</a>, version 1.6 or
-	    newer, including the optional <code>ant-trax.jar</code>
-	    (if you download ant from the above then this is included;
-	    if you are using the <code>ant</code> Debian/Ubuntu package then
-	    you also need to install the <code>ant-optional</code>
-	    package).
+	    <a href="http://maven.apache.org/">Maven</a>, version 3.3.x or
+	    newer.
 	  </li>
 	</ul>
 
@@ -96,50 +89,27 @@ $ ant dist</pre>
 	  <doc:heading>Building the Java client libraries</doc:heading>
 
 	  <p>
-	    Ensure <code>JAVA_HOME</code> is correctly set. Change to
-	    the <code>rabbitmq-java-client</code> directory and type
-	    <code>ant</code>.
-	  </p>
+		Ensure <code>JAVA_HOME</code> is correctly set and
+		that the <code>rabbitmq-java-client</code> and
+		<code>rabbitmq_codegen</code> directories are in
+		the same directory. Change to
+		the <code>rabbitmq-java-client</code> directory and launch
+		the build:
+		<pre class="sourcecode">
+$ cd rabbitmq-java-client
+$ mvn clean package -Ddeps.dir=../ -DskipTests</pre>
+		The generated JAR file will be in <code>target</code>.
+      </p>
 
 	  <p>
-	    Other interesting <code>build.xml</code> targets include
+		This procedure is enough if you want to build the Java Client
+	  	yourself. If you want to make significant changes or contribute
+		to the Java Client, please follow the
+	    <a href="https://github.com/rabbitmq/rabbitmq-java-client#contributing">instructions
+		on the library repository</a>. They cover among others how to properly
+	  	run the test suite.
 	  </p>
 
-	  <p>
-	    <dl>
-	      <dt>build</dt>
-	      <dd>
-		    The default target. Builds the client library classes
-		    into <code>build/classes</code>.
-	      </dd>
-
-	      <dt>clean</dt>
-	      <dd>
-	        Removes the entire <code>build</code> directory,
-	        including compiled classes, built jar files, and any
-	        distributions placed under <code>build/dist</code>.
-	      </dd>
-
-	      <dt>jar</dt>
-	      <dd>
-	        Builds a jar file from the client library classes into
-	        <code>build/lib</code>.
-	      </dd>
-
-	      <dt>dist</dt>
-	      <dd>
-	        Constructs a directory, by default <code>build/dist</code>,
-	        containing the RabbitMQ Java AMQP client jar files as well
-	        as all the libraries the AMQP client depends on from
-	        <code>lib</code>. The distribution output directory can be
-	        overridden by setting the Ant property <code>dist.out</code>
-	        to a new location:
-	        <p>
-	          <code>ant -Ddist.out=/some/place/to/put/a/distribution dist</code>
-	        </p>
-	      </dd>
-	    </dl>
-	  </p>
       </doc:section>
   </body>
 </html>

--- a/site/build-java-client.xml
+++ b/site/build-java-client.xml
@@ -61,7 +61,7 @@ $ git clone https://github.com/rabbitmq/rabbitmq-java-client.git</pre>
 	  href="http://www.python.org/download/">Python</a>  and
 	  <a href="http://pypi.python.org/pypi/simplejson">simplejson.py</a>
 	  (an implementation of a <a href="http://json.org">JSON</a>
-	  reader and writer in Python), for generating AMQP framing code.
+	  reader and writer in Python), for generating AMQP 0-9-1 framing code.
           simplejson.py is included as a standard json library in the Python
           core since 2.6 release. 
 	</p>
@@ -73,8 +73,7 @@ $ git clone https://github.com/rabbitmq/rabbitmq-java-client.git</pre>
 	<ul class="compact">
 	  <li>
 	    a <a
-	    href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Java
-	    compiler</a>, for Java language version 1.6 or newer
+	    href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">JDK 6</a> or newer
 	  </li>
 
 	  <li>

--- a/site/download.xml
+++ b/site/download.xml
@@ -113,18 +113,15 @@ limitations under the License.
         </li>
         <li>
           Quick download:
-          Binary
-          <a href="/releases/&dir-java-client;/rabbitmq-java-client-bin-&version-java-client;.tar.gz">.tar.gz</a>
-          <a href="/releases/&dir-java-client;/rabbitmq-java-client-bin-&version-java-client;.zip">.zip</a> |
-          Source
-          <a href="/releases/&dir-java-client;/rabbitmq-java-client-&version-java-client;.tar.gz">.tar.gz</a>
-          <a href="/releases/&dir-java-client;/rabbitmq-java-client-&version-java-client;.zip">.zip</a>
+          <a href="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&dir-java-client;/amqp-client-&version-java-client;.jar">Binary</a>
+          |
+          <a href="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&dir-java-client;/amqp-client-&version-java-client;-sources.jar">Source</a>
         </li>
         <li>
           <a href="java-client.html">All Java client downloads</a>
         </li>
         <li>
-          <a href="/releases/rabbitmq-java-client/">Older versions</a>
+          <a href="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/">Older versions</a>
         </li>
       </ul>
       <h3>.NET/C# Client</h3>

--- a/site/java-client.xml
+++ b/site/java-client.xml
@@ -58,31 +58,55 @@ limitations under the License.
       &version-java-client;</b>.
     </p>
 
+    <h2>Dependency management</h2>
+    <p>
+      The recommended way to get started using the RabbitMQ Java AMQP
+      in your project is with a dependency management system.
+    </p>
+    <p>
+      The snippet below can be copied and pasted into your build
+      if you're using Maven:
+      <pre class="sourcecode">
+&lt;dependency&gt;
+  &lt;groupId&gt;com.rabbitmq&lt;/groupId&gt;
+  &lt;artifactId&gt;amqp-client&lt;/artifactId&gt;
+  &lt;version&gt;&version-java-client;&lt;/version&gt;
+&lt;/dependency&gt;</pre>
+    </p>
+    <p>
+      Alternatively, if you're using Gradle:
+      <pre class="sourcecode">
+dependencies {
+  compile 'com.rabbitmq:amqp-client:&version-java-client;'
+}
+</pre>
+    </p>
+    <p>
+      We attempt to upload new versions of the Java client on the day
+      of release; however the Maven servers are sometimes unavailable,
+      so there may be a delay of a few days between a new release and
+      its appearance in the central Maven repository. Please be patient.
+    </p>
+
     <h2>Download the library and documentation</h2>
 
     <h3>The library</h3>
 
     <p>
-      The library is available in several compiled forms, and as
-      source. The precompiled archives include example source code.
+      The library is available in compiled form, and as
+      source.
     </p>
 
     <r:downloads signature="yes">
-      <r:download downloadfile="rabbitmq-java-client-bin-&version-java-client;.zip"
-		  downloadpath="&dir-java-client;">
-	Binary, compiled for JDK 6 or newer (zip)
+      <r:download url="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&version-java-client;/amqp-client-&version-java-client;.jar"
+                  downloadfile="amqp-client-&version-java-client;.jar"
+                  absolute="yes">
+	Binary, compiled for JDK 6 or newer
       </r:download>
-      <r:download downloadfile="rabbitmq-java-client-bin-&version-java-client;.tar.gz"
-		  downloadpath="&dir-java-client;">
-	Binary, compiled for JDK 6 or newer (tar.gz)
-      </r:download>
-      <r:download downloadfile="rabbitmq-java-client-&version-java-client;.zip"
-		  downloadpath="&dir-java-client;">
-	Source code and tools (zip)
-      </r:download>
-      <r:download downloadfile="rabbitmq-java-client-&version-java-client;.tar.gz"
-		  downloadpath="&dir-java-client;">
-	Source code and tools (tar.gz)
+      <r:download url="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&version-java-client;/amqp-client-&version-java-client;-sources.jar"
+                  downloadfile="amqp-client-&version-java-client;-sources.jar"
+                  absolute="yes">
+	Source code
       </r:download>
     </r:downloads>
 
@@ -104,20 +128,17 @@ limitations under the License.
     </p>
 
     <r:downloads signature="yes">
-      <r:download downloadfile="rabbitmq-java-client-javadoc-&version-java-client;.zip"
-		  downloadpath="&dir-java-client;">
-	A zip file containing generated Javadoc documentation
-      </r:download>
-      <r:download downloadfile="rabbitmq-java-client-javadoc-&version-java-client;.tar.gz"
-		  downloadpath="&dir-java-client;">
-	A tar.gz file containing generated Javadoc documentation
+      <r:download url="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&version-java-client;/amqp-client-&version-java-client;-javadoc.jar"
+                  downloadfile="amqp-client-&version-java-client;-javadoc.jar"
+                  absolute="yes">
+	A JAR file containing generated Javadoc documentation
       </r:download>
     </r:downloads>
 
     <h3>Other versions</h3>
 
     <p>
-      Consult <a href="/releases/rabbitmq-java-client/">the
+      Consult <a href="http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/">the
       archive</a> if you want to download a version of the RabbitMQ
       Java Client library or documentation other than the above.
     </p>
@@ -131,31 +152,9 @@ limitations under the License.
       <i>OSGiefy</i> the jar prior to using it in an OSGi container.
     </p>
 
-    <h2>Maven Artifact</h2>
-    <p>
-      The RabbitMQ Java AMQP library is available as a Maven artifact
-      on the <a href="http://repo1.maven.org/maven2/">central Maven
-      repository</a> and mirrors thereof.
-    </p>
-    <p>
-      To include it in your project, add this dependency to your pom:
-      <pre class="sourcecode">
-&lt;dependency&gt;
-  &lt;groupId&gt;com.rabbitmq&lt;/groupId&gt;
-  &lt;artifactId&gt;amqp-client&lt;/artifactId&gt;
-  &lt;version&gt;&version-java-client;&lt;/version&gt;
-&lt;/dependency&gt;</pre>
-    </p>
-    <p>
-      We attempt to upload new versions of the Java client on the day
-      of release; however the Maven servers are sometimes unavailable,
-      so there may be a delay of a few days between a new release and
-      its appearance in the central Maven repository. Please be patient.
-    </p>
-
     <h2>GitHub repositories</h2>
     <p>
-      The Java AMQP client library and example programs. Depends on
+      The Java AMQP client library depends on
       the code-generation library module. Please see the <a
       href="build-java-client.html">build page</a> for instructions on
       compiling from source code.

--- a/site/java-client.xml
+++ b/site/java-client.xml
@@ -29,7 +29,7 @@ limitations under the License.
   <body>
     <p>
       The RabbitMQ Java client library allows Java code to interface
-      to AMQP servers. The library is platform neutral; the binary
+      with RabbitMQ. The library is platform neutral; the binary
       distributions listed below differ only in the version of Java
       they are intended for use with. Please see the <a
       href="specification.html">specification</a> page for more
@@ -58,7 +58,7 @@ limitations under the License.
       &version-java-client;</b>.
     </p>
 
-    <h2>Dependency management</h2>
+    <h2>Adding Library Dependency</h2>
     <p>
       The recommended way to get started using the RabbitMQ Java AMQP
       in your project is with a dependency management system.
@@ -145,7 +145,7 @@ dependencies {
 
     <h2>OSGi Ready</h2>
     <p>
-      The RabbitMQ Java AMQP library jar comes ready with an OSGi
+      The RabbitMQ Java client jar comes ready with an OSGi
       manifest (with bundle version and package dependencies correctly
       set) so it can be deployed in an OSGi environment.
       This means it is no longer necessary to <i>bundleise</i> or
@@ -154,8 +154,8 @@ dependencies {
 
     <h2>GitHub repositories</h2>
     <p>
-      The Java AMQP client library depends on
-      the code-generation library module. Please see the <a
+      The RabbitMQ Java client depends on
+      the code generation library module. Please see the <a
       href="build-java-client.html">build page</a> for instructions on
       compiling from source code.
     </p>
@@ -166,10 +166,5 @@ dependencies {
       <repository type="github" shortname="rabbitmq-codegen"
         url="https://github.com/rabbitmq/rabbitmq-codegen"/>
     </repositories>
-
-    <h2>Support</h2>
-    <p>
-      For help compiling or installing RabbitMQ, or for general queries, please <a href="contact.html"> contact us</a>.
-    </p>
   </body>
 </html>

--- a/site/rabbit.ent
+++ b/site/rabbit.ent
@@ -36,7 +36,7 @@ limitations under the License.
 <!ENTITY version-dotnet-client-tag "rabbitmq_v3_6_5">
 
 <!ENTITY dir-java-client "rabbitmq-java-client/v&version-java-client;">
-<!ENTITY dir-current-javadoc "/releases/&dir-java-client;/rabbitmq-java-client-javadoc-&version-java-client;/">
+<!ENTITY dir-current-javadoc "/releases/rabbitmq-java-client/current-javadoc/">
 
 <!ENTITY dir-current-erlang-client "/releases/rabbitmq-erlang-client/v&version-server;/">
 


### PR DESCRIPTION
Fixes #288

This PR changes Java-related links to point to Maven Central instead of the `releases/rabbitmq-java-client` directory (for binaries, Javadoc, sources).

The binary/source distribution archives (`zip`/`tar.gz`) no longer appear in the links.

Build instructions are also updated to use Maven.