### PR TITLE
Replace <support@rabbitmq.com> and <sales@rabbitmq.com>

### DIFF
--- a/site/contact.xml
+++ b/site/contact.xml
@@ -26,7 +26,7 @@ limitations under the License.
     <p>
       For enquiries about commercial licensing, support, training, and
       consulting, please <a
-      href="mailto:sales@rabbitmq.com">contact sales</a>.
+      href="mailto:rabbitmq-sales@pivotal.io">contact sales</a>.
 
       Alternatively, if you already have a support contract established
       with Pivotal, please see the

--- a/site/release-notes/README-1.1.0-alpha.txt
+++ b/site/release-notes/README-1.1.0-alpha.txt
@@ -56,7 +56,7 @@ messages.
 The upgrade process will be much improved in future releases, to the
 point where a running RabbitMQ cluster can be upgraded without service
 interruption. Meanwhile, if you need assistance in migration please
-contact the RabbitMQ team at support@rabbitmq.com.
+contact the RabbitMQ team at rabbitmq-sales@pivotal.io.
 
 
 Credits

--- a/site/release-notes/README-1.5.0.txt
+++ b/site/release-notes/README-1.5.0.txt
@@ -96,7 +96,7 @@ database, and logs a warning.
 
 If your RabbitMQ installation contains important data, such as user
 accounts, durable exchanges and queues, or persistent messages, then
-we recommend you contact support@rabbitmq.com for assistance with the
+we recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.
 
 

--- a/site/release-notes/README-1.5.1.txt
+++ b/site/release-notes/README-1.5.1.txt
@@ -63,7 +63,7 @@ a fresh, empty database, and logs a warning.
 
 If your RabbitMQ installation contains important data, such as user
 accounts, durable exchanges and queues, or persistent messages, then
-we recommend you contact support@rabbitmq.com for assistance with the
+we recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.
 
 

--- a/site/release-notes/README-1.5.2.txt
+++ b/site/release-notes/README-1.5.2.txt
@@ -58,7 +58,7 @@ a fresh, empty database, and logs a warning.
 
 If your RabbitMQ installation contains important data, such as user
 accounts, durable exchanges and queues, or persistent messages, then
-we recommend you contact support@rabbitmq.com for assistance with the
+we recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.
 
 

--- a/site/release-notes/README-1.5.3.txt
+++ b/site/release-notes/README-1.5.3.txt
@@ -58,7 +58,7 @@ a fresh, empty database, and logs a warning.
 
 If your RabbitMQ installation contains important data, such as user
 accounts, durable exchanges and queues, or persistent messages, then
-we recommend you contact support@rabbitmq.com for assistance with the
+we recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.
 
 

--- a/site/release-notes/README-1.5.4.txt
+++ b/site/release-notes/README-1.5.4.txt
@@ -67,7 +67,7 @@ presence of an old database, it moves it to a backup location, creates
 a fresh, empty database, and logs a warning. If your RabbitMQ
 installation contains important data, such as user accounts, durable
 exchanges and queues, or persistent messages, then we recommend you
-contact support@rabbitmq.com for assistance with the upgrade.
+contact rabbitmq-sales@pivotal.io for assistance with the upgrade.
 
 
 Credits

--- a/site/release-notes/README-1.5.5.txt
+++ b/site/release-notes/README-1.5.5.txt
@@ -73,7 +73,7 @@ presence of an old database, it moves it to a backup location, creates
 a fresh, empty database, and logs a warning. If your RabbitMQ
 installation contains important data, such as user accounts, durable
 exchanges and queues, or persistent messages, then we recommend you
-contact support@rabbitmq.com for assistance with the upgrade.
+contact rabbitmq-sales@pivotal.io for assistance with the upgrade.
 
 
 Credits

--- a/site/release-notes/README-1.6.0.txt
+++ b/site/release-notes/README-1.6.0.txt
@@ -83,4 +83,4 @@ presence of an old database, it moves it to a backup location, creates
 a fresh, empty database, and logs a warning. If your RabbitMQ
 installation contains important data, such as user accounts, durable
 exchanges and queues, or persistent messages, then we recommend you
-contact support@rabbitmq.com for assistance with the upgrade.
+contact rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-1.7.0.txt
+++ b/site/release-notes/README-1.7.0.txt
@@ -101,5 +101,5 @@ If, however, you are upgrading from a release prior to 1.6.0, when the
 RabbitMQ server detects the presence of an old database, it moves it
 to a backup location, creates a fresh, empty database, and logs a
 warning. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-1.7.1.txt
+++ b/site/release-notes/README-1.7.1.txt
@@ -119,5 +119,5 @@ If, however, you are upgrading from a release prior to 1.6.0, when the
 RabbitMQ server detects the presence of an old database, it moves it
 to a backup location, creates a fresh, empty database, and logs a
 warning. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-1.7.2.txt
+++ b/site/release-notes/README-1.7.2.txt
@@ -71,5 +71,5 @@ If, however, you are upgrading from a release prior to 1.6.0, when the
 RabbitMQ server detects the presence of an old database, it moves it
 to a backup location, creates a fresh, empty database, and logs a
 warning. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-1.8.0.txt
+++ b/site/release-notes/README-1.8.0.txt
@@ -123,7 +123,7 @@ starting, the RabbitMQ server will detect the existence of an old
 database and will move it to a backup location, before creating a
 fresh, empty database, and will log a warning. If your RabbitMQ
 installation contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.
 
 
 Important notes on the AMQP 0-9-1 semantic changes

--- a/site/release-notes/README-1.8.1.txt
+++ b/site/release-notes/README-1.8.1.txt
@@ -65,5 +65,5 @@ If, however, you are upgrading from a release prior to 1.8.0, when the
 RabbitMQ server detects the presence of an old database, it moves it to a
 backup location, creates a fresh, empty database, and logs a warning. If
 your RabbitMQ installation contains important data then we recommend you
-contact support@rabbitmq.com for assistance with the upgrade.
+contact rabbitmq-sales@pivotal.io for assistance with the upgrade.
 

--- a/site/release-notes/README-2.0.0.txt
+++ b/site/release-notes/README-2.0.0.txt
@@ -95,4 +95,4 @@ starting, the RabbitMQ server will detect the existence of an old
 database and will move it to a backup location, before creating a
 fresh, empty database, and will log a warning. If your RabbitMQ
 installation contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.1.0.txt
+++ b/site/release-notes/README-2.1.0.txt
@@ -50,4 +50,4 @@ starting, the RabbitMQ server will detect the existence of an old
 database and will move it to a backup location, before creating a
 fresh, empty database, and will log a warning. If your RabbitMQ
 installation contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.1.1.txt
+++ b/site/release-notes/README-2.1.1.txt
@@ -57,4 +57,4 @@ If, however, you are upgrading from a release prior to 2.1.0, when the
 RabbitMQ server detects the presence of an old database, it moves it to a
 backup location, creates a fresh, empty database, and logs a warning. If
 your RabbitMQ installation contains important data then we recommend you
-contact support@rabbitmq.com for assistance with the upgrade.
+contact rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.2.0.txt
+++ b/site/release-notes/README-2.2.0.txt
@@ -103,4 +103,4 @@ simply install the new version. RabbitMQ will move the existing data
 to a backup location before creating a fresh, empty database. A
 warning is recorded in the logs. If your RabbitMQ installation
 contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.3.0.txt
+++ b/site/release-notes/README-2.3.0.txt
@@ -160,4 +160,4 @@ simply install the new version. RabbitMQ will move the existing data
 to a backup location before creating a fresh, empty database. A
 warning is recorded in the logs. If your RabbitMQ installation
 contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.3.1.txt
+++ b/site/release-notes/README-2.3.1.txt
@@ -33,4 +33,4 @@ simply install the new version. RabbitMQ will move the existing data
 to a backup location before creating a fresh, empty database. A
 warning is recorded in the logs. If your RabbitMQ installation
 contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.4.0.txt
+++ b/site/release-notes/README-2.4.0.txt
@@ -140,4 +140,4 @@ simply install the new version. RabbitMQ will move the existing data
 to a backup location before creating a fresh, empty database. A
 warning is recorded in the logs. If your RabbitMQ installation
 contains important data then we recommend you contact
-support@rabbitmq.com for assistance with the upgrade.
+rabbitmq-sales@pivotal.io for assistance with the upgrade.

--- a/site/release-notes/README-2.4.1.txt
+++ b/site/release-notes/README-2.4.1.txt
@@ -83,5 +83,5 @@ contain any important data then simply install the new
 version. RabbitMQ will move the existing data to a backup location
 before creating a fresh, empty database. A warning is recorded in the
 logs. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-2.5.0.txt
+++ b/site/release-notes/README-2.5.0.txt
@@ -131,5 +131,5 @@ contain any important data then simply install the new
 version. RabbitMQ will move the existing data to a backup location
 before creating a fresh, empty database. A warning is recorded in the
 logs. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-2.5.1.txt
+++ b/site/release-notes/README-2.5.1.txt
@@ -30,5 +30,5 @@ contain any important data then simply install the new
 version. RabbitMQ will move the existing data to a backup location
 before creating a fresh, empty database. A warning is recorded in the
 logs. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-2.6.0.txt
+++ b/site/release-notes/README-2.6.0.txt
@@ -177,5 +177,5 @@ contain any important data then simply install the new
 version. RabbitMQ will move the existing data to a backup location
 before creating a fresh, empty database. A warning is recorded in the
 logs. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.

--- a/site/release-notes/README-2.6.1.txt
+++ b/site/release-notes/README-2.6.1.txt
@@ -55,5 +55,5 @@ contain any important data then simply install the new
 version. RabbitMQ will move the existing data to a backup location
 before creating a fresh, empty database. A warning is recorded in the
 logs. If your RabbitMQ installation contains important data then we
-recommend you contact support@rabbitmq.com for assistance with the
+recommend you contact rabbitmq-sales@pivotal.io for assistance with the
 upgrade.


### PR DESCRIPTION
... by <rabbitmq-sales@pivotal.io>.

We must use a @pivotal.io address directly because the rabbitmq.com MTA is not allowed to relay emails to pivotal.io when the email sender's domain has a restrictive SPF record (`-all`).

[#131102253]