### PR TITLE
Installing Plugins page: Update location Homebrew's rabbitmq plugin folder

### DIFF
--- a/site/installing-plugins.xml
+++ b/site/installing-plugins.xml
@@ -61,7 +61,7 @@ limitations under the License.
         <tr>
           <th>Homebrew</th>
           <td>
-            <code>/usr/local/Cellar/rabbitmq/</code><i>version</i><code>/lib/rabbitmq/erlang/lib/rabbitmq-</code><i>version</i><code>/plugins</code>
+            <code>/usr/local/Cellar/rabbitmq/</code><i>version</i><code>/plugins</code>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
This PR updates the documentation for OS X user with Homebrew to reflect a current version of the software.

  - Example value for the .ez files folder `/usr/local/Cellar/rabbitmq/3.6.4/plugins`