### PR TITLE
Adds 3.5.8 to change log

### DIFF
--- a/site/changelog.xml
+++ b/site/changelog.xml
@@ -42,17 +42,6 @@ limitations under the License.
       </tr>
 
       <tr>
-        <td class="centre">3.5.8</td>
-        <td class="centre">21 November 2016</td>
-        <td>
-          <ul>
-            <li>Security vulnerability fix</li>
-          </ul>
-        </td>
-        <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_5_8">(changes)</a></td>
-      </tr>
-
-      <tr>
         <td class="centre">3.6.5</td>
         <td class="centre">5 August 2016</td>
         <td>
@@ -133,6 +122,17 @@ limitations under the License.
           </ul>
         </td>
         <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_6_0">(changes)</a></td>
+      </tr>
+
+      <tr>
+        <td class="centre">3.5.8</td>
+        <td class="centre">3 November 2016</td>
+        <td>
+          <ul>
+            <li>Security vulnerability fix</li>
+          </ul>
+        </td>
+        <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_5_8">(changes)</a></td>
       </tr>
 
       <tr>


### PR DESCRIPTION
We were upgrading a rabbit 3.5.2 installation to 3.5.7 and did not see 3.5.8 since it is not listed near the 3.5.x releases. We expect releases to be sorted by release number then date. 

Fixes https://github.com/rabbitmq/rabbitmq-website/issues/307