### PR TITLE
Remove openssl from ssl:cipher_suites() command

### DIFF
--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -615,7 +615,7 @@ file or the <a href="/configure.html#erlang-term-config-file">classic config for
           <p>To list all cipher suites supported by installed Erlang runtime, use</p>
 
 <pre class="sourcecode">
-rabbitmqctl eval 'ssl:cipher_suites(openssl).'
+rabbitmqctl eval 'ssl:cipher_suites().'
 </pre>
         </doc:subsection>
       </doc:section>


### PR DESCRIPTION
What
====
Remove `openssl` from the command `rabbitmqctl eval 'ssl:cipher_suites().'` when listing out cipher suites supported

Why
===

When listing the cipher suites with `rabbitmqctl eval 'ssl:cipher_suites(openssl).'` it outputs the list in OpenSSL format:

```
# rabbitmqctl eval 'ssl:cipher_suites(openssl).'
["ECDHE-ECDSA-AES256-GCM-SHA384","ECDHE-RSA-AES256-GCM-SHA384",
 "ECDHE-ECDSA-AES256-SHA384","ECDHE-RSA-AES256-SHA384",
 "ECDH-ECDSA-AES256-GCM-SHA384","ECDH-RSA-AES256-GCM-SHA384",
 "ECDH-ECDSA-AES256-SHA384","ECDH-RSA-AES256-SHA384",
 "DHE-RSA-AES256-GCM-SHA384","DHE-DSS-AES256-GCM-SHA384",
 "DHE-RSA-AES256-SHA256","DHE-DSS-AES256-SHA256","AES256-GCM-SHA384",
 "AES256-SHA256","ECDHE-ECDSA-AES128-GCM-SHA256",
 "ECDHE-RSA-AES128-GCM-SHA256","ECDHE-ECDSA-AES128-SHA256",
 "ECDHE-RSA-AES128-SHA256","ECDH-ECDSA-AES128-GCM-SHA256",
 "ECDH-RSA-AES128-GCM-SHA256","ECDH-ECDSA-AES128-SHA256",
 "ECDH-RSA-AES128-SHA256","DHE-RSA-AES128-GCM-SHA256",
 "DHE-DSS-AES128-GCM-SHA256","DHE-RSA-AES128-SHA256","DHE-DSS-AES128-SHA256",
 "AES128-GCM-SHA256","AES128-SHA256","ECDHE-ECDSA-AES256-SHA",
 "ECDHE-RSA-AES256-SHA","DHE-RSA-AES256-SHA","DHE-DSS-AES256-SHA",
 "ECDH-ECDSA-AES256-SHA","ECDH-RSA-AES256-SHA","AES256-SHA",
 "ECDHE-ECDSA-DES-CBC3-SHA","ECDHE-RSA-DES-CBC3-SHA","EDH-RSA-DES-CBC3-SHA",
 "EDH-DSS-DES-CBC3-SHA","ECDH-ECDSA-DES-CBC3-SHA","ECDH-RSA-DES-CBC3-SHA",
 "DES-CBC3-SHA","ECDHE-ECDSA-AES128-SHA","ECDHE-RSA-AES128-SHA",
 "DHE-RSA-AES128-SHA","DHE-DSS-AES128-SHA","ECDH-ECDSA-AES128-SHA",
 "ECDH-RSA-AES128-SHA","AES128-SHA"]
```

Which doesn't appear to be compatible when used in `rabbitmq.config`. Issuing `rabbitmqctl eval 'ssl:cipher_suites().'` results in a list in this format:

```
# rabbitmqctl eval 'ssl:cipher_suites().'
[{ecdhe_ecdsa,aes_256_gcm,null,sha384},
 {ecdhe_rsa,aes_256_gcm,null,sha384},
 {ecdhe_ecdsa,aes_256_cbc,sha384,sha384},
 {ecdhe_rsa,aes_256_cbc,sha384,sha384},
 {ecdh_ecdsa,aes_256_gcm,null,sha384},
 {ecdh_rsa,aes_256_gcm,null,sha384},
 {ecdh_ecdsa,aes_256_cbc,sha384,sha384},
 {ecdh_rsa,aes_256_cbc,sha384,sha384},
 {dhe_rsa,aes_256_gcm,null,sha384},
 {dhe_dss,aes_256_gcm,null,sha384},
 {dhe_rsa,aes_256_cbc,sha256},
 {dhe_dss,aes_256_cbc,sha256},
 {rsa,aes_256_gcm,null,sha384},
 {rsa,aes_256_cbc,sha256},
 {ecdhe_ecdsa,aes_128_gcm,null,sha256},
 {ecdhe_rsa,aes_128_gcm,null,sha256},
 {ecdhe_ecdsa,aes_128_cbc,sha256,sha256},
 {ecdhe_rsa,aes_128_cbc,sha256,sha256},
 {ecdh_ecdsa,aes_128_gcm,null,sha256},
 {ecdh_rsa,aes_128_gcm,null,sha256},
 {ecdh_ecdsa,aes_128_cbc,sha256,sha256},
 {ecdh_rsa,aes_128_cbc,sha256,sha256},
 {dhe_rsa,aes_128_gcm,null,sha256},
 {dhe_dss,aes_128_gcm,null,sha256},
 {dhe_rsa,aes_128_cbc,sha256},
 {dhe_dss,aes_128_cbc,sha256},
 {rsa,aes_128_gcm,null,sha256},
 {rsa,aes_128_cbc,sha256},
 {ecdhe_ecdsa,aes_256_cbc,sha},
 {ecdhe_rsa,aes_256_cbc,sha},
 {dhe_rsa,aes_256_cbc,sha},
 {dhe_dss,aes_256_cbc,sha},
 {ecdh_ecdsa,aes_256_cbc,sha},
 {ecdh_rsa,aes_256_cbc,sha},
 {rsa,aes_256_cbc,sha},
 {ecdhe_ecdsa,'3des_ede_cbc',sha},
 {ecdhe_rsa,'3des_ede_cbc',sha},
 {dhe_rsa,'3des_ede_cbc',sha},
 {dhe_dss,'3des_ede_cbc',sha},
 {ecdh_ecdsa,'3des_ede_cbc',sha},
 {ecdh_rsa,'3des_ede_cbc',sha},
 {rsa,'3des_ede_cbc',sha},
 {ecdhe_ecdsa,aes_128_cbc,sha},
 {ecdhe_rsa,aes_128_cbc,sha},
 {dhe_rsa,aes_128_cbc,sha},
 {dhe_dss,aes_128_cbc,sha},
 {ecdh_ecdsa,aes_128_cbc,sha},
 {ecdh_rsa,aes_128_cbc,sha},
 {rsa,aes_128_cbc,sha}]
```

Which is usable in `rabbitmq.config`