### PR TITLE
Correct typo in tutorial

### DIFF
--- a/site/tutorials/tutorial-three-dotnet.md
+++ b/site/tutorials/tutorial-three-dotnet.md
@@ -309,7 +309,7 @@ value is ignored for `fanout` exchanges. Here goes the code for
 [(EmitLog.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/EmitLog/EmitLog.cs)
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,

--- a/site/tutorials/tutorial-three-elixir.md
+++ b/site/tutorials/tutorial-three-elixir.md
@@ -271,7 +271,7 @@ value is ignored for `fanout` exchanges. Here goes the code for
 [(emit_log.exs source)](http://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/emit_log.exs)
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,

--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -374,7 +374,7 @@ value is ignored for `fanout` exchanges. Here goes the code for
 [(emit_log.go source)](http://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/emit_log.go)
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,

--- a/site/tutorials/tutorial-three-java.md
+++ b/site/tutorials/tutorial-three-java.md
@@ -290,7 +290,7 @@ value is ignored for `fanout` exchanges. Here goes the code for
 [(EmitLog.java source)](http://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/EmitLog.java)
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,

--- a/site/tutorials/tutorial-three-objectivec.md
+++ b/site/tutorials/tutorial-three-objectivec.md
@@ -254,7 +254,7 @@ nameless one. Here goes the code for
     [conn close];
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,

--- a/site/tutorials/tutorial-three-python.md
+++ b/site/tutorials/tutorial-three-python.md
@@ -279,7 +279,7 @@ value is ignored for `fanout` exchanges. Here goes the code for
 [(emit_log.py source)](http://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/emit_log.py)
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,

--- a/site/tutorials/tutorial-three-swift.md
+++ b/site/tutorials/tutorial-three-swift.md
@@ -251,7 +251,7 @@ nameless one. Here goes the code for
 
 
 As you see, after establishing the connection we declared the
-exchange. This step is neccesary as publishing to a non-existing
+exchange. This step is necessary as publishing to a non-existing
 exchange is forbidden.
 
 The messages will be lost if no queue is bound to the exchange yet,


### PR DESCRIPTION
Replace 'neccesary' with 'necessary' in the tutorial.