### PR TITLE
Document LDAP plugin idle timeout option

### DIFF
--- a/site/ldap.xml
+++ b/site/ldap.xml
@@ -253,6 +253,17 @@ limitations under the License.
           no timeout. Default:
           <code>infinity</code>.
         </dd>
+        <dt><code>pool_size</code></dt>
+        <dd>
+          LDAP queries worker pool size. Default:
+          <code>64</code>.
+        </dd>
+        <dt><code>idle_timeout</code></dt>
+        <dd>
+          Time in milliseconds after which inactive LDAP connections
+          are closed. Set to 'infinity' for no timeout. Default:
+          <code>infinity</code>.
+        </dd>
         <dt><code>log</code></dt>
         <dd>
           <p>


### PR DESCRIPTION
And worker pool size option as well.

References rabbitmq/rabbitmq-auth-backend-ldap#7