### PR TITLE
fix documentation to show that the default number of async threads is 64

### DIFF
--- a/site/persistence-conf.xml
+++ b/site/persistence-conf.xml
@@ -227,7 +227,7 @@ limitations under the License.
       href="http://www.erlang.org/doc/man/erl.html#async_thread_pool_size">here</a>,
       and is typically configured through the envirnment variable
       <code>RABBITMQ_SERVER_ERL_ARGS</code>. The default value is
-      <code>+A 30</code>. It is likely to be a good idea to experiment
+      <code>+A 64</code>. It is likely to be a good idea to experiment
       with several different values before changing this.
     </p>
 


### PR DESCRIPTION
**What has changed:**

- updated documentation to reflect the fact that the default number of async threads is now 64 (as opposed to 30)

**Why**

- The default number of async threads was bumped to 64 from 30 in this pull requests;       

1. https://github.com/rabbitmq/rabbitmq-server/pull/212 
2. https://github.com/rabbitmq/rabbitmq-server/pull/704