### PR TITLE
Clarify memory alarm description

### DIFF
--- a/site/memory.xml
+++ b/site/memory.xml
@@ -35,9 +35,9 @@ limitations under the License.
       set_vm_memory_high_watermark <em>fraction</em></code> is
       executed. By default, when the RabbitMQ server uses above 40%
       of the installed RAM, it raises a memory alarm and blocks all
-      connections. Once the memory alarm has cleared (e.g. due
+      connections that are publishing messages. Once the memory alarm has cleared (e.g. due
       to the server paging messages to disk or delivering them to
-      clients) normal service resumes.
+      clients that use their connections in a consume-only fashion) normal service resumes.
     </p>
 
     <p>


### PR DESCRIPTION
The original "blocks all connections" is a bit misleading, as it implies that the connections are blocked indiscriminately.