### PR TITLE
how to mark message as acknowledged in .NET api

### DIFF
--- a/site/dotnet-api-guide.xml
+++ b/site/dotnet-api-guide.xml
@@ -345,7 +345,7 @@ consumer.Received += (ch, ea) =>
                 {
                     var body = ea.Body;
                     // ... process the message
-                    ch.BasicAck(ea.DeliveryTag, false);
+                    channel.BasicAck(ea.DeliveryTag, false);
                 };
 String consumerTag = channel.BasicConsume(queueName, false, consumer);
 </pre>


### PR DESCRIPTION
I noticed a problem - when I subscribe to `consumer.Received` event, delegate's first argument is of type Object, and I found out it's a reference to `IBasicConsumer` implementation. 
So, I see at least two options for acknowledging the message:
 - make use of channel to call `BasicAck` method
 - get reference to `IModel` object and then call `BasicAck` on it like this: `(model as IBasicConsumer).Model.BasicAck(...);`
Can you advise me on which one is the best?