### PR TITLE
Update required php-amqplib version.

### DIFF
--- a/site/tutorials/tutorial-one-php.md
+++ b/site/tutorials/tutorial-one-php.md
@@ -52,7 +52,7 @@ on behalf of the consumer.
 >     :::javascript
 >     {
 >         "require": {
->             "php-amqplib/php-amqplib": "2.5.*"
+>             "php-amqplib/php-amqplib": ">=2.6.1"
 >         }
 >     }
 >


### PR DESCRIPTION
AMQPMessage::DELIVERY_MODE* constants used in the tutorials are not introduced in php-amqplib until 2.6.1.