### PR TITLE
Explain x-death entries are sorted chronologically

### DIFF
--- a/site/dlx.xml
+++ b/site/dlx.xml
@@ -230,9 +230,10 @@ args.put("x-dead-letter-routing-key", "some-routing-key");</pre>
             expiring again in any queues it is routed to.</li>
         </ul>
 
-        In case <code>x-death</code> already contains an entry with
+        New entries are prepended to the beginning of the <code>x-death</code>
+        array. In case <code>x-death</code> already contains an entry with
         the same queue and dead lettering reason, its count field will be
-        incremented.
+        incremented and it will be moved to the beginning of the array.
       </p>
       <p>
         The <code>reason</code> is a name describing why the


### PR DESCRIPTION
I wasn't sure if `x-death` entries were sorted in any way, but found the discussion at https://github.com/rabbitmq/rabbitmq-server/pull/79 and it seems they are sorted by the last time a {queue, reason} happened. This might be useful information for the website.