### PR TITLE
manpages: HTML conversion is done by rabbitmq-server/Makefile

### DIFF
--- a/site/css/rabbit.css
+++ b/site/css/rabbit.css
@@ -209,9 +209,13 @@ ol.roman>li {
 }
 
 p {
-	clear:left;
-	}
-	
+    clear:left;
+}
+
+.Pp, dt.It-tag {
+    margin-top: 16px;
+}
+
 .logos {
 	text-align: center;
 	margin-top: 3ex;
@@ -367,7 +371,7 @@ pre span.code, pre.code, pre.example, pre.ec2_sourcecode, .docSection div.cmdsyn
 	border: 1px solid #ddd;
 }
 
-pre span.code, pre.code, pre.example, pre.ec2_sourcecode, span.code, span.path {
+pre span.code, pre.code, pre.example, pre.ec2_sourcecode, span.code, span.path, i.Pa {
     color: #333;
     font-family: "Courier New", Courier, monospace;
     font-size: small;
@@ -387,13 +391,20 @@ pre span.code {
   white-space: pre;
   display: block;
 }
-	
-span.envvar {
+
+/* Used in manpages. */
+.D1 span.code {
+    color: inherit;
+    white-space: nowrap;
+}
+
+span.envvar, span.Ev {
   color: black;
   /*white-space: nowrap;*/
 }
-span.path {
-	/*white-space: nowrap;*/
+span.path, i.Pa {
+    font-style: normal;
+    /*white-space: nowrap;*/
 }
 
 .sourcecode i {
@@ -435,7 +446,20 @@ th, td {
 	font-size: .9em;
 }
 
-div.auto-index table, div.auto-index th, div.auto-index td { border: none; }
+div.auto-index table,
+div.auto-index th,
+div.auto-index td,
+table.Nm,
+table.Nm th,
+table.Nm td {
+    border: none;
+}
+
+table.Nm,
+table.Nm th,
+table.Nm td {
+    padding: 0px;
+}
 
 tr {
 	vertical-align: top;

--- a/site/pages.xml.dat
+++ b/site/pages.xml.dat
@@ -121,12 +121,12 @@ limitations under the License.
        <x:page url="/event-exchange.html" text="Internal Event Exchange"/>
        <x:page url="/firehose.html" text="Firehose (Message Tracing)"/>
        <x:page url="/manpages.html" text="Manual Pages">
-         <x:page url="/man/rabbitmqctl.1.man.html" text="rabbitmqctl"/>
-         <x:page url="/man/rabbitmq-plugins.1.man.html" text="rabbitmq-plugins"/>
-         <x:page url="/man/rabbitmq-server.1.man.html" text="rabbitmq-server"/>
-         <x:page url="/man/rabbitmq-service.man.html" text="rabbitmq-service"/>
-         <x:page url="/man/rabbitmq-echopid.man.html" text="rabbitmq-echopid"/>
-         <x:page url="/man/rabbitmq-env.conf.5.man.html" text="rabbitmq-env.conf">
+         <x:page url="/rabbitmqctl.8.html" text="rabbitmqctl"/>
+         <x:page url="/rabbitmq-plugins.8.html" text="rabbitmq-plugins"/>
+         <x:page url="/rabbitmq-server.8.html" text="rabbitmq-server"/>
+         <x:page url="/rabbitmq-service.8.html" text="rabbitmq-service"/>
+         <x:page url="/rabbitmq-echopid.8.html" text="rabbitmq-echopid"/>
+         <x:page url="/rabbitmq-env.conf.5.html" text="rabbitmq-env.conf">
            <x:related url="/configure.html"/>
          </x:page>
        </x:page>

--- a/site/rabbitmq-echopid.8.xml
+++ b/site/rabbitmq-echopid.8.xml
@@ -19,33 +19,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
-      xmlns:x="http://www.rabbitmq.com/2011/extensions">
+      xmlns:xi="http://www.w3.org/2003/XInclude">
   <head>
-    <title>Manual Pages</title>
+    <title>rabbitmq-echopid(8)</title>
   </head>
   <body>
-      <p class="intro">
-        This page lists the available manual pages taken from the latest server release.
-      </p>
-
-      <doc:section name="section5">
-        <doc:heading>Section 5 - File formats</doc:heading>
-        <ul>
-          <li><a href="rabbitmq-env.conf.5.html">rabbitmq-env.conf</a></li>
-        </ul>
-      </doc:section>
-
-      <doc:section name="section8">
-        <doc:heading>Section 8 - System Management Commands</doc:heading>
-        <ul>
-          <li><a href="rabbitmqctl.8.html">rabbitmqctl</a></li>
-          <li><a href="rabbitmq-plugins.8.html">rabbitmq-plugins</a></li>
-          <li><a href="rabbitmq-server.8.html">rabbitmq-server</a></li>
-          <li><a href="rabbitmq-service.8.html">rabbitmq-service</a></li>
-          <li><a href="rabbitmq-echopid.8.html">rabbitmq-echopid</a></li>
-        </ul>
-      </doc:section>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-echopid.8.html"/>
+    </doc:section>
   </body>
 </html>

--- a/site/rabbitmq-env.conf.5.xml
+++ b/site/rabbitmq-env.conf.5.xml
@@ -19,33 +19,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
-      xmlns:x="http://www.rabbitmq.com/2011/extensions">
+      xmlns:xi="http://www.w3.org/2003/XInclude">
   <head>
-    <title>Manual Pages</title>
+    <title>rabbitmq-env.conf(5)</title>
   </head>
   <body>
-      <p class="intro">
-        This page lists the available manual pages taken from the latest server release.
-      </p>
-
-      <doc:section name="section5">
-        <doc:heading>Section 5 - File formats</doc:heading>
-        <ul>
-          <li><a href="rabbitmq-env.conf.5.html">rabbitmq-env.conf</a></li>
-        </ul>
-      </doc:section>
-
-      <doc:section name="section8">
-        <doc:heading>Section 8 - System Management Commands</doc:heading>
-        <ul>
-          <li><a href="rabbitmqctl.8.html">rabbitmqctl</a></li>
-          <li><a href="rabbitmq-plugins.8.html">rabbitmq-plugins</a></li>
-          <li><a href="rabbitmq-server.8.html">rabbitmq-server</a></li>
-          <li><a href="rabbitmq-service.8.html">rabbitmq-service</a></li>
-          <li><a href="rabbitmq-echopid.8.html">rabbitmq-echopid</a></li>
-        </ul>
-      </doc:section>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-env.conf.5.html"/>
+    </doc:section>
   </body>
 </html>

--- a/site/rabbitmq-plugins.8.xml
+++ b/site/rabbitmq-plugins.8.xml
@@ -19,33 +19,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
-      xmlns:x="http://www.rabbitmq.com/2011/extensions">
+      xmlns:xi="http://www.w3.org/2003/XInclude">
   <head>
-    <title>Manual Pages</title>
+    <title>rabbitmq-plugins(8)</title>
   </head>
   <body>
-      <p class="intro">
-        This page lists the available manual pages taken from the latest server release.
-      </p>
-
-      <doc:section name="section5">
-        <doc:heading>Section 5 - File formats</doc:heading>
-        <ul>
-          <li><a href="rabbitmq-env.conf.5.html">rabbitmq-env.conf</a></li>
-        </ul>
-      </doc:section>
-
-      <doc:section name="section8">
-        <doc:heading>Section 8 - System Management Commands</doc:heading>
-        <ul>
-          <li><a href="rabbitmqctl.8.html">rabbitmqctl</a></li>
-          <li><a href="rabbitmq-plugins.8.html">rabbitmq-plugins</a></li>
-          <li><a href="rabbitmq-server.8.html">rabbitmq-server</a></li>
-          <li><a href="rabbitmq-service.8.html">rabbitmq-service</a></li>
-          <li><a href="rabbitmq-echopid.8.html">rabbitmq-echopid</a></li>
-        </ul>
-      </doc:section>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-plugins.8.html"/>
+    </doc:section>
   </body>
 </html>

--- a/site/rabbitmq-server.8.xml
+++ b/site/rabbitmq-server.8.xml
@@ -19,33 +19,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
-      xmlns:x="http://www.rabbitmq.com/2011/extensions">
+      xmlns:xi="http://www.w3.org/2003/XInclude">
   <head>
-    <title>Manual Pages</title>
+    <title>rabbitmq-server(8)</title>
   </head>
   <body>
-      <p class="intro">
-        This page lists the available manual pages taken from the latest server release.
-      </p>
-
-      <doc:section name="section5">
-        <doc:heading>Section 5 - File formats</doc:heading>
-        <ul>
-          <li><a href="rabbitmq-env.conf.5.html">rabbitmq-env.conf</a></li>
-        </ul>
-      </doc:section>
-
-      <doc:section name="section8">
-        <doc:heading>Section 8 - System Management Commands</doc:heading>
-        <ul>
-          <li><a href="rabbitmqctl.8.html">rabbitmqctl</a></li>
-          <li><a href="rabbitmq-plugins.8.html">rabbitmq-plugins</a></li>
-          <li><a href="rabbitmq-server.8.html">rabbitmq-server</a></li>
-          <li><a href="rabbitmq-service.8.html">rabbitmq-service</a></li>
-          <li><a href="rabbitmq-echopid.8.html">rabbitmq-echopid</a></li>
-        </ul>
-      </doc:section>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-server.8.html"/>
+    </doc:section>
   </body>
 </html>

--- a/site/rabbitmq-service.8.xml
+++ b/site/rabbitmq-service.8.xml
@@ -19,33 +19,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
-      xmlns:x="http://www.rabbitmq.com/2011/extensions">
+      xmlns:xi="http://www.w3.org/2003/XInclude">
   <head>
-    <title>Manual Pages</title>
+    <title>rabbitmq-service(8)</title>
   </head>
   <body>
-      <p class="intro">
-        This page lists the available manual pages taken from the latest server release.
-      </p>
-
-      <doc:section name="section5">
-        <doc:heading>Section 5 - File formats</doc:heading>
-        <ul>
-          <li><a href="rabbitmq-env.conf.5.html">rabbitmq-env.conf</a></li>
-        </ul>
-      </doc:section>
-
-      <doc:section name="section8">
-        <doc:heading>Section 8 - System Management Commands</doc:heading>
-        <ul>
-          <li><a href="rabbitmqctl.8.html">rabbitmqctl</a></li>
-          <li><a href="rabbitmq-plugins.8.html">rabbitmq-plugins</a></li>
-          <li><a href="rabbitmq-server.8.html">rabbitmq-server</a></li>
-          <li><a href="rabbitmq-service.8.html">rabbitmq-service</a></li>
-          <li><a href="rabbitmq-echopid.8.html">rabbitmq-echopid</a></li>
-        </ul>
-      </doc:section>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-service.8.html"/>
+    </doc:section>
   </body>
 </html>

--- a/site/rabbitmqctl.8.xml
+++ b/site/rabbitmqctl.8.xml
@@ -19,33 +19,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
-      xmlns:x="http://www.rabbitmq.com/2011/extensions">
+      xmlns:xi="http://www.w3.org/2003/XInclude">
   <head>
-    <title>Manual Pages</title>
+    <title>rabbitmqctl(8)</title>
   </head>
   <body>
-      <p class="intro">
-        This page lists the available manual pages taken from the latest server release.
-      </p>
-
-      <doc:section name="section5">
-        <doc:heading>Section 5 - File formats</doc:heading>
-        <ul>
-          <li><a href="rabbitmq-env.conf.5.html">rabbitmq-env.conf</a></li>
-        </ul>
-      </doc:section>
-
-      <doc:section name="section8">
-        <doc:heading>Section 8 - System Management Commands</doc:heading>
-        <ul>
-          <li><a href="rabbitmqctl.8.html">rabbitmqctl</a></li>
-          <li><a href="rabbitmq-plugins.8.html">rabbitmq-plugins</a></li>
-          <li><a href="rabbitmq-server.8.html">rabbitmq-server</a></li>
-          <li><a href="rabbitmq-service.8.html">rabbitmq-service</a></li>
-          <li><a href="rabbitmq-echopid.8.html">rabbitmq-echopid</a></li>
-        </ul>
-      </doc:section>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmqctl.8.html"/>
+    </doc:section>
   </body>
 </html>


### PR DESCRIPTION
The generated HTML manpages only have the content, not the `<head>` and `<body>` elements. We include those HTML chunks in XML files to render the final HTML pages.

This depends on rabbitmq-server#1201 which must be merged first.

[#143563295]