### PR TITLE
Password generation details

### DIFF
--- a/site/passwords.xml
+++ b/site/passwords.xml
@@ -186,5 +186,21 @@ limitations under the License.
         </p>
       </doc:subsection>
     </doc:section>
+
+    <doc:section name="password-generation">
+      <doc:heading>Password Generation</doc:heading>
+      <p>
+        In order to update a user's password via the <a href="management.html">HTTP API</a>,
+        the password must be generated using the following algorithm:
+        <ul>
+          <li>Generate a random 32 bit salt:<br/><code>908D C60A</code></li>
+          <li>Concatenate that with the UTF-8 representation of the password (in this case <code>test12</code>):<br/><code>908D C60A 7465 7374 3132</code></li>
+          <li>Take the SHA-256 hash:<br/><code>A5B9 24B3 096B 8897 D65A 3B5F 80FA 5DB62 A94 B831 22CD F4F8 FEAD 10D5 15D8 F391</code></li>
+          <li>Concatenate the salt again:<br/><code>908D C60A A5B9 24B3 096B 8897 D65A 3B5F 80FA 5DB62 A94 B831 22CD F4F8 FEAD 10D5 15D8 F391</code></li>
+          <li>Convert to base64 encoding:<br/><code>kI3GCqW5JLMJa4iX1lo7X4D6XbYqlLgxIs30+P6tENUV2POR</code></li>
+          <li>Use the base64-encoded value as the <code>password_hash</code> value in the request JSON.</li>
+        </ul>
+      </p>
+    </doc:section>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a "Password Generation" section with details about the algorithm to generated a correctly salted + hashed password.

Originally part of rabbitmq/rabbitmq-management#386

Screenshot of changes in Chrome 58 on Linux:

![password-generation](https://cloud.githubusercontent.com/assets/514926/25542283/b628056a-2c06-11e7-9e48-8e337eb90066.png)
