### PR TITLE
add more rabbitMQ saas companies

### DIFF
--- a/site/download.xml
+++ b/site/download.xml
@@ -99,6 +99,8 @@ limitations under the License.
         <li><a href="https://github.com/pivotal-cf/cf-rabbitmq-release">Cloud Foundry</a></li>
         <li><a href="http://docs.pivotal.io/rabbitmq-cf/index.html">Pivotal Cloud Foundry</a></li>
         <li><a href="https://www.cloudamqp.com">CloudAMQP</a>: RabbitMQ-as-a-Service available in multiple clouds</li>
+        <li><a href="https://compose.com/rabbitmq">Compose</a>: Hosted RabbitMQ</li>
+        <li><a href="https://www.rabbitmqhosting.com">RabbitmqHosting</a>: RabbitMQ as a service</li>
       </ul>
 
       <h3>Chef, Puppet, Docker</h3>

--- a/site/index.xml
+++ b/site/index.xml
@@ -202,6 +202,8 @@ limitations under the License.
               <p>
                 The following companies provide free, virtual, or instructor-led support and/or cloud hosting of open source RabbitMQ: <a href="https://network.pivotal.io/" target="_blank">Pivotal Software</a>,
                 <a href="https://www.cloudamqp.com/" target="_blank">CloudAMQP</a>,
+                <a href="https://compose.com/rabbitmq" target="_blank">Compose</a>,
+                <a href="https://www.rabbitmqhosting.com" target="_blank">RabbitmqHosting</a>,
               <a href="https://console.cloud.google.com/launcher/details/click-to-deploy-images/rabbitmq" target="_blank">Google Cloud Platform</a>. RabbitMQ can also be deployed in <a href="/ec2.html">AWS</a>
               and <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/bitnami.rabbitmq?tab=Overview" target="_blank">Microsoft Azure</a>.</p>
               <img src="img/testing-phone.svg" height="109" width="94" />


### PR DESCRIPTION
## What has changed.
- Added links to two more rabbitMQ as a service companies that have emerged in the past few years.

## Why has it changed.
- The rabbitMQ website already contains links to one rabbitMQ as a service company, I think it makes sense for the website to reflect all the rabbitMQ service companies that are available today.
