### PR TITLE
Add distclean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,5 @@ run:
 	./driver.py
 
 clean: ;
+
+distclean: ;


### PR DESCRIPTION
Cloning the public umbrella and running `make distclean` errors out because this Makefile does not have that target.

@michaelklishin let me know if `stable` is the correct base. I'll correct it if not.