### PR TITLE
Fixed 'durable' typo in tutorial-two-javascript.md code snippet

### DIFF
--- a/site/confirms.xml
+++ b/site/confirms.xml
@@ -130,7 +130,7 @@ limitations under the License.
           until the backlog of unprocessed deliveries drops beyond a certain limit).
           Automatic acknolwedgement mode is therefore only recommended for consumers
           that can process deliveries efficiently and at a steady rate.
-        </p>        
+        </p>
       </doc:subsection>
 
       <doc:subsection name="consumer-acks-multiple-parameter">
@@ -207,7 +207,7 @@ limitations under the License.
           optimal throughput and do not run significant risk of overwhelming consumers.
           Higher values often <a href="https://www.rabbitmq.com/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3/">run into the law of diminishing returns</a>.
         </p>
-        
+
         <p>
           The QoS setting has no effect on messages fetched using the <code>basic.get</code>
           ("pull API"), even in manual confirmation mode.

--- a/site/news.xml
+++ b/site/news.xml
@@ -31,6 +31,31 @@ limitations under the License.
        will give you a suitable RFC 3339 value.
       -->
 
+
+   <doc:item>
+      <doc:date iso="2017-11-10T12:00:00+03:00">11 November 2017</doc:date>
+      <doc:title>Dropping support for older Erlang versions</doc:title>
+      <doc:link>https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_6_14</doc:link>
+      <doc:text>
+        <p>
+          RabbitMQ 3.7.0 as well as 3.6.x series starting with 3.6.15 will <a href="https://groups.google.com/d/msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ">drop support for Erlang/OTP versions older than 19.3</a>.
+        </p>
+
+        <p>
+          List of installation options for modern Erlang releases can be found in
+          the <a href="http://www.rabbitmq.com/which-erlang.html">RabbitMQ Erlang compatibility guide</a>.
+        </p>
+
+        <p>
+          As always, we welcome questions and other feedback
+          on this release, as well as general suggestions for features and
+          enhancements in future releases. Contact us via the
+          <a href="https://groups.google.com/forum/#!forum/rabbitmq-users">rabbitmq-users</a>
+          Google group.
+        </p>
+      </doc:text>
+    </doc:item>
+
    <doc:item>
       <doc:date iso="2017-11-07T18:00:00+03:00">7 November 2017</doc:date>
       <doc:title>RabbitMQ 3.6.14 release</doc:title>

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -79,7 +79,7 @@ program will schedule tasks to our work queue, so let's name it
 var q = 'task_queue';
 var msg = process.argv.slice(2).join(' ') || "Hello World!";
 
-ch.assertQueue(q, {durable: true});
+ch.assertQueue(q, {durable: false});
 ch.sendToQueue(q, new Buffer(msg), {persistent: true});
 console.log(" [x] Sent '%s'", msg);
 </pre>


### PR DESCRIPTION
Changed a code snippet from `durable: true` to `durable: false`, where `durable: true` gives an 'inequivalent arg' error when the code is run and `durable: false` queues the message correctly.