### PR TITLE
Fixed "typo" on Tut3Sender java code link

### DIFF
--- a/site/tutorials/tutorial-three-spring-amqp.md
+++ b/site/tutorials/tutorial-three-spring-amqp.md
@@ -360,7 +360,7 @@ public class Tut3Sender {
 }
 </pre>
 
-[Tut3Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Receiver.java)
+[Tut3Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Sender.java)
 
 As you see, we leverage the beans from the Tut3Config file and
 autowire in the RabbitTemplate along with our configured


### PR DESCRIPTION
It is pointing to the wrong url (To the Receiver code, instead of the Sender
code).