### PR TITLE
Rabbitmq upgrade guide

### DIFF
--- a/site/admin-guide.xml
+++ b/site/admin-guide.xml
@@ -174,6 +174,7 @@ limitations under the License.
         <li>
           <a href="/reliability.html">Reliable Message Delivery</a>
         </li>
+        <li><a href="upgrade.html">Upgrade</a></li>
       </ul>
     </div>
 

--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -502,54 +502,8 @@ Starting node rabbit@rabbit2 ...done.</pre>
 
       <doc:section name="upgrading">
           <doc:heading>Upgrading clusters</doc:heading>
-          <p>
-            When upgrading from one major or minor version of RabbitMQ
-            to another (i.e. from 3.0.x to 3.1.x, or from 2.x.x to
-            3.x.x), or when upgrading Erlang, the whole cluster must
-            be taken down for the upgrade (since clusters cannot run
-            mixed versions like this). This will generally not be the
-            case when upgrading from one patch version to another (i.e.
-            from 3.0.x to 3.0.y), except when indicated otherwise in
-            the release notes; these versions can be mixed in a cluster.
-            Therefore, it is strongly recommended to consult release
-            notes before upgrading.
-          </p>
-          <p>
-            Some patch releases known to require a cluster-wide
-            restart:
-
-            <ul>
-              <li>3.0.0 cannot be mixed with later
-                  versions from the 3.0.x series</li>
-              <li>3.6.6 and later cannot
-                  be mixed with earlier versions from the 3.6.x series</li>
-              <li>3.6.7 and later cannot
-                  be mixed with earlier versions from the 3.6.x series</li>
-            </ul>
-          </p>
-          <p>
-            RabbitMQ will automatically update its persistent data
-            structures if necessary when upgrading between major /
-            minor versions. In a cluster, this task is performed by
-            the first disc node to be started (the "upgrader"
-            node). Therefore when upgrading a RabbitMQ cluster, you
-            should not attempt to start any RAM nodes first; any RAM
-            nodes started will emit an error message and fail to start
-            up.
-          </p>
-          <p>
-            While not strictly necessary, it is a good idea to decide
-            ahead of time which disc node will be the upgrader, stop
-            that node last, and start it first. Otherwise changes to
-            the cluster configuration that were made between the
-            upgrader node stopping and the last node stopping will be
-            lost.
-          </p>
-          <p>
-            Automatic upgrades are only possible from RabbitMQ
-            versions 2.1.1 and later. If you have an earlier cluster,
-            you will need to rebuild it to upgrade.
-          </p>
+          You can find instructions for upgrading a cluster in
+          <a href="/upgrade.html">the upgrade guide</a>.
       </doc:section>
 
       <doc:section name="single-machine">

--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -503,7 +503,7 @@ Starting node rabbit@rabbit2 ...done.</pre>
       <doc:section name="upgrading">
           <doc:heading>Upgrading clusters</doc:heading>
           You can find instructions for upgrading a cluster in
-          <a href="/upgrade.html">the upgrade guide</a>.
+          <a href="/upgrade.html#cluster">the upgrade guide</a>.
       </doc:section>
 
       <doc:section name="single-machine">

--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -503,7 +503,7 @@ Starting node rabbit@rabbit2 ...done.</pre>
       <doc:section name="upgrading">
           <doc:heading>Upgrading clusters</doc:heading>
           You can find instructions for upgrading a cluster in
-          <a href="/upgrade.html#cluster">the upgrade guide</a>.
+          <a href="/upgrade.html#rabbitmq-cluster-configuration">the upgrade guide</a>.
       </doc:section>
 
       <doc:section name="single-machine">

--- a/site/css/rabbit.css
+++ b/site/css/rabbit.css
@@ -176,9 +176,12 @@ table#changelog .centre { text-align: center; }
 table#changelog .centre a { font-size: 80%; }
 
 li {
-  list-style-type: none; 
   margin: 0;
   padding: 3px 0 2px 10px;
+}
+
+ul li {
+  list-style-type: none;
 }
 
 ol.plain, ul.plain {

--- a/site/documentation.xml
+++ b/site/documentation.xml
@@ -88,6 +88,7 @@ limitations under the License.
               <li><a href="/install-homebrew.html">MacOS via Homebrew</a></li>
               <li><a href="/ec2.html">Amazon EC2</a></li>
               <li><a href="/install-solaris.html">Solaris</a></li>
+              <li><a href="/upgrade.html">Upgrade</a></li>
               <li><a href="/signatures.html">Package Signatures</a></li>
               <li><a href="/which-erlang.html">Supported Erlang/OTP Versions</a></li>
               <li><a href="/changelog.html">Change log</a></li>

--- a/site/pages.xml.dat
+++ b/site/pages.xml.dat
@@ -56,6 +56,7 @@ limitations under the License.
      <x:page url="/install-generic-unix.html" text="Install: Generic Unix"/>
      <x:page url="/install-solaris.html" text="Install: Solaris"/>
      <x:page url="/ec2.html" text="Install: EC2" gap-after="true"/>
+     <x:page url="/upgrade.html" text="Upgrade" gap-after="true"/>
      <x:page url="/platforms.html" text="Supported Platforms"/>
      <x:page url="/changelog.html" text="Changelog"/>
      <x:page url="/which-erlang.html" text="Erlang Versions"/>

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -2,7 +2,7 @@
 
 ## Before you upgrade
 
-### Erlang version
+### <a id="erlang"/> Erlang version
 
 Different versions of RabbtiMQ support different versions of Erlang.
 It's recommended to upgrade Erlang version when upgrading a RabbitMQ version
@@ -10,7 +10,7 @@ if it possible.
 
 Erlang version compatibility chart can be found [here](/which-erlang.html).
 
-### Compatible versions
+### <a id="aompatibility"/> Compatible versions
 
 Some version changes require intermediate upgrade. To upgrade to the latest version
 from some old versions, you should first upgrade to an intermediate version.
@@ -26,7 +26,7 @@ Current version upgrade compatibility:
 To upgrade RabbitMQ from version `3.4.x` or earlier to version `3.7.0`,
 you should first upgrade to `3.6.14`, then to `3.7.0`.
 
-### Plugin compatibility
+### <a id="plugins"/> Plugin compatibility
 
 RabbitMQ plugins API is supposed to be compatible in a single minor version track
 (e.g. between `3.6.11` and `3.6.14`). If upgrading to a new minor version
@@ -39,7 +39,7 @@ Please consult with release notes.
 [Community plugins page](/community-plugins.html) contains information on RabbitMQ
 version support for plugins.
 
-## Single node upgrade.
+## <a id="single-node"/> Single node upgrade.
 
 To upgrade a single node RabbitMQ broker, the server running the old version
 should be stopped, and the new version started.
@@ -54,7 +54,7 @@ You should make sure the new version points to the same data directory.
 RabbitMQ does not support downgrades; it's strongly advised to backup data before
 performing an upgrade.
 
-## Cluster upgrades
+## <a id="cluster"/> Cluster upgrades
 
 RabbitMQ cluster *may* provide an opportunity to perform upgrades
 without cluster downtime using so-called rolling upgrade.
@@ -69,7 +69,7 @@ put more load on the broker. This can impact performance and stability
 of the cluster. It's not recommended to perform rolling upgrades
 under high load.
 
-### Version limitations for rolling upgrades
+### <a id="cluster-versions"/> Version limitations for rolling upgrades
 
 Rolling upgrades are possible only between some RabbitMQ and Erlang versions.
 
@@ -100,7 +100,7 @@ which happened in the past every 3-5 major Erlang releases.
 It should be possible to upgrade to a newer minor Erlang version without stopping
 entire cluster.
 
-### Full-stop upgrades
+### <a id="cluster-full-stop"/> Full-stop upgrades
 
 When entire cluster is stopped for upgrade, the order in which nodes are
 stopped and started is important.

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -1,0 +1,127 @@
+# Upgrading RabbitMQ.
+
+## Before you upgrade
+
+### Erlang version
+
+Different versions of RabbtiMQ support different versions of Erlang.
+It's recommended to upgrade Erlang version when upgrading a RabbitMQ version
+if it possible.
+
+Erlang version compatibility chart can be found [here](/which-erlang.html).
+
+### Compatible versions
+
+Some version changes require intermediate upgrade. To upgrade to the latest version
+from some old versions, you should first upgrade to an intermediate version.
+
+Current version upgrade compatibility:
+
+| From     | To     |
+|----------|--------|
+| 3.5.x    | 3.7.0  |
+| 3.6.x    | 3.7.0  |
+| =< 3.4.x | 3.6.14 |
+
+To upgrade RabbitMQ from version `3.4.x` or earlier to version `3.7.0`,
+you should first upgrade to `3.6.14`, then to `3.7.0`.
+
+### Plugin compatibility
+
+RabbitMQ plugins API is supposed to be compatible in a single minor version track
+(e.g. between `3.6.11` and `3.6.14`). If upgrading to a new minor version
+(e.g. `3.7.0`), you should upgrade plugins to versions, which support the
+new RabbitMQ minor version track.
+
+Sometimes patch versions of RabbitMQ (e.g. 3.6.7) can break some plugin APIs.
+Please consult with release notes.
+
+[Community plugins page](/community-plugins.html) contains information on RabbitMQ
+version support for plugins.
+
+## Single node upgrade.
+
+To upgrade a single node RabbitMQ broker, the server running the old version
+should be stopped, and the new version started.
+The broker will handle data upgrade on startup.
+During data upgrade RabbitMQ will create a data backup,
+which will be deleted after a successful upgrade.
+
+On some distributions (e.g. generic unix) you can install a newer version of
+RabbitMQ without removing or replacing the old one, which can make upgrade faster.
+You should make sure the new version points to the same data directory.
+
+RabbitMQ does not support downgrades; it's strongly advised to backup data before
+performing an upgrade.
+
+## Cluster upgrades
+
+RabbitMQ cluster *may* provide an opportunity to perform upgrades
+without cluster downtime using so-called rolling upgrade.
+
+Rolling upgrade is when nodes are stopped, upgraded and restarted
+one-by-one, so the cluster is still running while each node is upgrading.
+It is important to let an upgrading node fully start and sync all the mirrored
+queues before upgrading the next node.
+
+During a rolling upgrade connections and queues will be rebalanced. This will
+put more load on the broker. This can impact performance and stability
+of the cluster. It's not recommended to perform rolling upgrades
+under high load.
+
+### Version limitations for rolling upgrades
+
+Rolling upgrades are possible only between some RabbitMQ and Erlang versions.
+
+When upgrading from one major or minor version of RabbitMQ to another
+(i.e. from 3.0.x to 3.1.x, or from 2.x.x to 3.x.x),
+the whole cluster must be taken down for the upgrade
+(since clusters cannot run mixed versions like this).
+This will generally not be the case when upgrading from one patch version to
+another (i.e. from 3.0.x to 3.0.y), except when indicated otherwise
+in the release notes; these versions can be mixed in a cluster.
+Therefore, it is strongly recommended to consult release notes before upgrading.
+
+Some patch releases known to require a cluster-wide restart:
+
+* 3.0.0 cannot be mixed with later versions from the 3.0.x series
+* 3.6.6 and later cannot be mixed with earlier versions from the 3.6.x series
+* 3.6.7 and later cannot be mixed with earlier versions from the 3.6.x series
+
+***A RabbitMQ node will fail to join a cluster with incompatible versions***
+
+When upgrading Erlang, it's advised to run all nodes on the same major series
+(e.g. 19.x or 20.x), because even though you can start a cluster with different
+versions, they can have incompatibilities hard to predict.
+
+A RabbitMQ node will fail to join a cluster only of mnesia protocol is incompatible,
+which happened in the past every 3-5 major Erlang releases.
+
+It should be possible to upgrade to a newer minor Erlang version without stopping
+entire cluster.
+
+### Full-stop upgrades
+
+When entire cluster is stopped for upgrade, the order in which nodes are
+stopped and started is important.
+
+RabbitMQ will automatically update its persistent data structures
+if necessary when upgrading between major / minor versions.
+In a cluster, this task is performed by the first disc node to be started
+(the "upgrader" node).
+Therefore when upgrading a RabbitMQ cluster, you should not attempt to start
+any RAM nodes first; any RAM nodes started will emit an error message
+and fail to start up.
+
+During an upgrade, the last disc node to go down must be the first node to
+be brought online. Otherwise the started node will emit an error message and
+fail to start up. Unlike an ordinary cluster restart, upgrading nodes will not wait
+for the last disc node to come back online.
+
+While not strictly necessary, it is a good idea to decide ahead of time
+which disc node will be the upgrader, stop that node last, and start it first.
+Otherwise changes to the cluster configuration that were made between the
+upgrader node stopping and the last node stopping will be lost.
+
+Automatic upgrades are only possible from RabbitMQ versions 2.1.1 and later.
+If you have an earlier cluster, you will need to rebuild it to upgrade.

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -1,21 +1,14 @@
-# Upgrading RabbitMQ.
+# Upgrading RabbitMQ
 
-## Before you upgrade
+## <a id="rabbitmq-version-compatibility"/> RabbitMQ version compatibility
 
-### <a id="erlang"/> Erlang version
+The upgrade path will depend on your current RabbitMQ version, the RabbitMQ version that you want to upgrade to.
 
-Different versions of RabbtiMQ support different versions of Erlang.
-It's recommended to upgrade Erlang version when upgrading a RabbitMQ version
-if it possible.
+Some version changes require intermediate upgrades.
+For example, to upgrade from version `3.4.x` or earlier to version `3.7.0`,
+you must upgrade to `3.6.14`, and then to `3.7.0`.
 
-Erlang version compatibility chart can be found [here](/which-erlang.html).
-
-### <a id="aompatibility"/> Compatible versions
-
-Some version changes require intermediate upgrade. To upgrade to the latest version
-from some old versions, you should first upgrade to an intermediate version.
-
-Current version upgrade compatibility:
+Upgrade paths:
 
 | From     | To     |
 |----------|--------|
@@ -23,8 +16,6 @@ Current version upgrade compatibility:
 | 3.6.x    | 3.7.0  |
 | =< 3.4.x | 3.6.14 |
 
-To upgrade RabbitMQ from version `3.4.x` or earlier to version `3.7.0`,
-you should first upgrade to `3.6.14`, then to `3.7.0`.
 
 ### <a id="plugins"/> Plugin compatibility
 
@@ -38,6 +29,20 @@ Please consult with release notes.
 
 [Community plugins page](/community-plugins.html) contains information on RabbitMQ
 version support for plugins.
+
+
+## Erlang
+
+## RabbitMQ setup
+
+
+If you are upgrading within the same minor version, e.g. 3.6
+
+Based on your current RabbitMQ version, the upgrade path
+
+## Before you upgrade
+
+We recommended that you upgrade Erlang together with RabbitMQ. Please refer to [RabbitMQ Erlang Version Requirements](/which-erlang.html).
 
 ## <a id="single-node"/> Single node upgrade.
 

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -1,14 +1,18 @@
 # Upgrading RabbitMQ
 
-## <a id="rabbitmq-version-compatibility"/> RabbitMQ version compatibility
+Things to consider before upgrading:
 
-The upgrade path will depend on your current RabbitMQ version, the RabbitMQ version that you want to upgrade to.
+* RabbitMQ version compatibility (version upgrading from, version upgrading to)
+* RabbitMQ Erlang version requirement
+* RabbitMQ plugins compatiblity
+* cluster configuration (1 node vs multiple nodes)
 
-Some version changes require intermediate upgrades.
-For example, to upgrade from version `3.4.x` or earlier to version `3.7.0`,
-you must upgrade to `3.6.14`, and then to `3.7.0`.
+## <a id="rabbitmq-version-compatibility"/>RabbitMQ version compatibility
 
-Upgrade paths:
+Some version changes require intermediate upgrade.
+To upgrade to the latest version from some old versions, you should first upgrade to an intermediate version.
+
+Current version upgrade compatibility:
 
 | From     | To     |
 |----------|--------|
@@ -16,8 +20,13 @@ Upgrade paths:
 | 3.6.x    | 3.7.0  |
 | =< 3.4.x | 3.6.14 |
 
+To upgrade RabbitMQ from version `3.4.x` or earlier to version `3.7.0`, you should first upgrade to `3.6.14`, then to `3.7.0`.
 
-### <a id="plugins"/> Plugin compatibility
+## <a id="rabbitmq-erlang-version-requirement"/>RabbitMQ Erlang version requirement
+
+We recommended that you upgrade Erlang together with RabbitMQ. Please refer to [RabbitMQ Erlang Version Requirements](/which-erlang.html).
+
+## <a id="rabbitmq-plugins-compatibility"/> RabbitMQ plugins compatibility
 
 RabbitMQ plugins API is supposed to be compatible in a single minor version track
 (e.g. between `3.6.11` and `3.6.14`). If upgrading to a new minor version
@@ -30,21 +39,9 @@ Please consult with release notes.
 [Community plugins page](/community-plugins.html) contains information on RabbitMQ
 version support for plugins.
 
+## <a id="cluster-configuration"/> RabbitMQ cluster configuration
 
-## Erlang
-
-## RabbitMQ setup
-
-
-If you are upgrading within the same minor version, e.g. 3.6
-
-Based on your current RabbitMQ version, the upgrade path
-
-## Before you upgrade
-
-We recommended that you upgrade Erlang together with RabbitMQ. Please refer to [RabbitMQ Erlang Version Requirements](/which-erlang.html).
-
-## <a id="single-node"/> Single node upgrade.
+### <a id="single-node"/> Single node upgrade
 
 To upgrade a single node RabbitMQ broker, the server running the old version
 should be stopped, and the new version started.
@@ -59,7 +56,7 @@ You should make sure the new version points to the same data directory.
 RabbitMQ does not support downgrades; it's strongly advised to backup data before
 performing an upgrade.
 
-## <a id="cluster"/> Cluster upgrades
+### <a id="cluster"/> Multiple nodes upgrade
 
 RabbitMQ cluster *may* provide an opportunity to perform upgrades
 without cluster downtime using so-called rolling upgrade.
@@ -74,7 +71,7 @@ put more load on the broker. This can impact performance and stability
 of the cluster. It's not recommended to perform rolling upgrades
 under high load.
 
-### <a id="cluster-versions"/> Version limitations for rolling upgrades
+#### <a id="cluster-versions"/> Version limitations for rolling upgrades
 
 Rolling upgrades are possible only between some RabbitMQ and Erlang versions.
 
@@ -105,7 +102,7 @@ which happened in the past every 3-5 major Erlang releases.
 It should be possible to upgrade to a newer minor Erlang version without stopping
 entire cluster.
 
-### <a id="cluster-full-stop"/> Full-stop upgrades
+#### <a id="cluster-full-stop"/> Full-stop upgrades
 
 When entire cluster is stopped for upgrade, the order in which nodes are
 stopped and started is important.

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -1,13 +1,13 @@
 # Upgrading RabbitMQ
 
-Things to consider before upgrading:
+Things to consider before upgrading RabbitMQ:
 
-* RabbitMQ version compatibility (version upgrading from, version upgrading to)
-* RabbitMQ Erlang version requirement
-* RabbitMQ plugins compatiblity
-* cluster configuration (1 node vs multiple nodes)
+1. RabbitMQ version compatibility, version upgrading from &amp; version upgrading to
+1. RabbitMQ Erlang version requirement
+1. RabbitMQ plugins compatiblity between versions
+1. RabbitMQ cluster configuration, single node vs multiple nodes
 
-## <a id="rabbitmq-version-compatibility"/>RabbitMQ version compatibility
+## <a id="rabbitmq-version-compatibility" class="anchor" /> [RabbitMQ version compatibility](#rabbitmq-version-compatibility)
 
 Some version changes require intermediate upgrade.
 To upgrade to the latest version from some old versions, you should first upgrade to an intermediate version.
@@ -22,11 +22,11 @@ Current version upgrade compatibility:
 
 To upgrade RabbitMQ from version `3.4.x` or earlier to version `3.7.0`, you should first upgrade to `3.6.14`, then to `3.7.0`.
 
-## <a id="rabbitmq-erlang-version-requirement"/>RabbitMQ Erlang version requirement
+## <a id="rabbitmq-erlang-version-requirement" class="anchor" /> [RabbitMQ Erlang version requirement](#rabbitmq-erlang-version-requirement)
 
 We recommended that you upgrade Erlang together with RabbitMQ. Please refer to [RabbitMQ Erlang Version Requirements](/which-erlang.html).
 
-## <a id="rabbitmq-plugins-compatibility"/> RabbitMQ plugins compatibility
+## <a id="rabbitmq-plugins-compatibility" class="anchor" /> [RabbitMQ plugins compatibility between versions](#rabbitmq-plugins-compatibility)
 
 RabbitMQ plugins API is supposed to be compatible in a single minor version track
 (e.g. between `3.6.11` and `3.6.14`). If upgrading to a new minor version
@@ -39,9 +39,9 @@ Please consult with release notes.
 [Community plugins page](/community-plugins.html) contains information on RabbitMQ
 version support for plugins.
 
-## <a id="cluster-configuration"/> RabbitMQ cluster configuration
+## <a id="rabbitmq-cluster-configuration" class="anchor" /> [RabbitMQ cluster configuration](#rabbitmq-cluster-configuration)
 
-### <a id="single-node"/> Single node upgrade
+### <a id="single-node-upgrade" class="anchor" /> [Single node upgrade](#single-node-upgrade)
 
 To upgrade a single node RabbitMQ broker, the server running the old version
 should be stopped, and the new version started.
@@ -56,7 +56,7 @@ You should make sure the new version points to the same data directory.
 RabbitMQ does not support downgrades; it's strongly advised to backup data before
 performing an upgrade.
 
-### <a id="cluster"/> Multiple nodes upgrade
+### <a id="multiple-nodes-upgrade" class="anchor" /> [Multiple nodes upgrade](#multiple-nodes-upgrade)
 
 RabbitMQ cluster *may* provide an opportunity to perform upgrades
 without cluster downtime using so-called rolling upgrade.
@@ -71,7 +71,7 @@ put more load on the broker. This can impact performance and stability
 of the cluster. It's not recommended to perform rolling upgrades
 under high load.
 
-#### <a id="cluster-versions"/> Version limitations for rolling upgrades
+#### <a id="rolling-upgrades-version-limitations" class="anchor" /> [Version limitations for rolling upgrades](#rolling-upgrades-version-limitations)
 
 Rolling upgrades are possible only between some RabbitMQ and Erlang versions.
 
@@ -102,7 +102,7 @@ which happened in the past every 3-5 major Erlang releases.
 It should be possible to upgrade to a newer minor Erlang version without stopping
 entire cluster.
 
-#### <a id="cluster-full-stop"/> Full-stop upgrades
+#### <a id="full-stop-upgrades" class="anchor" /> [Full-stop upgrades](#full-stop-upgrades)
 
 When entire cluster is stopped for upgrade, the order in which nodes are
 stopped and started is important.

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -280,7 +280,8 @@ limitations under the License.
 
       <p>
         RabbitMQ requires that the same major and minor version of
-        Erlang is used across all <a href="clustering.html#upgrading">cluster nodes</a>
+        Erlang is used across all
+        <a href="upgrade.html#cluster-versions">cluster nodes</a>
         (e.g. 19.3.x). RabbitMQ will check for protocol versions of
         Erlang and its distributed libraries when a node joins a
         cluster, refusing to cluster if there's a potentially

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -281,7 +281,7 @@ limitations under the License.
       <p>
         RabbitMQ requires that the same major and minor version of
         Erlang is used across all
-        <a href="upgrade.html#cluster-versions">cluster nodes</a>
+        <a href="upgrade.html#rolling-upgrades-version-limitations">cluster nodes</a>
         (e.g. 19.3.x). RabbitMQ will check for protocol versions of
         Erlang and its distributed libraries when a node joins a
         cluster, refusing to cluster if there's a potentially

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -19,12 +19,12 @@ limitations under the License.
       xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
       xmlns:x="http://www.rabbitmq.com/2011/extensions">
   <head>
-    <title>Erlang Version Requirements</title>
+    <title>RabbitMQ Erlang Version Requirements</title>
   </head>
   <body>
 
     <doc:section name="requirements-and-recommendations">
-      <doc:subsection name="rabbitmq-erlang-compability">
+      <doc:subsection name="rabbitmq-erlang-version-requirements">
         <table>
           <th>RabbitMQ</th>
           <th>Minimum required Erlang/OTP</th>


### PR DESCRIPTION
Moved upgrade instructions from clustering guide to a new page.
