### PR TITLE
Uncomment valid command in ssl doc

### DIFF
--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -304,8 +304,8 @@ openssl x509 -in cacert.pem -out cacert.cer -outform DER
 <pre class="sourcecode bash">
 cd ..
 ls
-testca
-# => mkdir server
+# => testca
+mkdir server
 cd server
 openssl genrsa -out key.pem 2048
 openssl req -new -key key.pem -out req.pem -outform PEM \


### PR DESCRIPTION
On the SSL page of the website (https://www.rabbitmq.com/ssl.html), the result of a command should be commented and the next command should not be commented. I've reversed these so they are displaying correctly.