### PR TITLE
Document passwordless users and their upcoming limitations in 3.7.3

### DIFF
--- a/site/access-control.xml
+++ b/site/access-control.xml
@@ -31,6 +31,10 @@ limitations under the License.
         <a href="http://www.rabbitmq.com/authentication.html">authentication mechanisms</a>
         in AMQP 0-9-1.
       </p>
+      <p>
+        A separate guide covers multiple topics around <a href="/passwords.html">passwords</a>.
+        It is only applicable to the internal authentication backend.
+      </p>
     </doc:section>
 
     <doc:section name="terminology-and-definitions">

--- a/site/authentication.xml
+++ b/site/authentication.xml
@@ -43,7 +43,7 @@ limitations under the License.
         </p>
         <p>
           A separate guide covers <a href="/access-control.html">authentication and authorisation backends in RabbitMQ</a>
-          and how they are configured.
+          and how they are configured. There's also a guide on <a href="/passwords.html">passwords</a>.
         </p>
       </doc:section>
 

--- a/site/passwords.xml
+++ b/site/passwords.xml
@@ -251,7 +251,7 @@ rabbitmqctl clear_password passwordless-user
           <li>Create a passwordless user (see above)</li>
           <li>Enable the <a href="https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl">rabbitmq-auth-mechanism-ssl</a> plugin</li>
           <li>Follow the plugin's configuration instructions</li>
-          <li>Configure client connections to use TLS and the <code>EXTERNAL</code>  authentication mechanism</li>
+          <li>Configure client connections to use TLS and the <code>EXTERNAL</code> authentication mechanism</li>
           <li>
             Configure client connections to provide a certificate/key pair and a CA certificate (or chain of certificates). The chain of certificates will be
             verified by the server and thus at least one certificate in it must be trusted by the target node.

--- a/site/passwords.xml
+++ b/site/passwords.xml
@@ -209,8 +209,35 @@ credential_validator.regexp = ^[a-bA-Z0-9$]{20,100}
       </doc:subsection>
     </doc:section>
 
+    <doc:section name="passwordless-users">
+      <doc:heading>Passwordless Users and Authentication Using TLS (x509) Certificates</doc:heading>
+      <p>
+        <a href="/access-control.html">Internal authentication backend</a> allows for users without a password
+        or with a blank one (assuming credential validator also allows it). Such users are only mean to be used
+        with passwordless <a href="/authentication.html">authentication mechanisms</a> such as <a href="https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl">authentication using x509 certificates</a>.
+      </p>
+
+      <p>
+        In order to create a passwordless user, create one with any password that passes validation and clear
+        the password using <a href="/cli.html">rabbitmqctl</a>'s <code>clear_password</code> command:
+
+        <pre class="sourcecode bash">
+rabbitmqctl add_user passwordless-user "pa$$wordless"
+rabbitmqctl clear_password passwordless-user
+# don't forget to grant the user virtual host access permissions using set_permissions
+# ...
+        </pre>
+      </p>
+
+      <p>
+        Starting with version <code>3.7.3</code>, authentication attempts that use a blank password
+        will be rejected by the <a href="/access-control.html">internal authentication backend</a> with a distinctive error
+        message in the <a href="/logging.html">server log</a>.
+      </p>
+    </doc:section>
+
     <doc:section name="computing-password-hash">
-      <doc:heading>Computing Password Hash</doc:heading>
+      <doc:heading>Computing Password Hashes</doc:heading>
       <p>
         In order to update a user's password hash via the <a href="management.html">HTTP API</a>,
         the password hash must be generated using the following algorithm:

--- a/site/passwords.xml
+++ b/site/passwords.xml
@@ -27,8 +27,8 @@ limitations under the License.
       <p>
         This guide covers a variety of topics related to credentials
         and passwords used by the internal authentication backend. If
-        a different authentication backend (or mechanism) is used, the
-        material in this guide is not applicable.
+        a different authentication backend is used, most
+        material in this guide will not be applicable.
       </p>
       <p>
         RabbitMQ supports multiple <a href="/authentication.html">authentication mechanisms</a>. Some of them use
@@ -210,7 +210,7 @@ credential_validator.regexp = ^[a-bA-Z0-9$]{20,100}
     </doc:section>
 
     <doc:section name="passwordless-users">
-      <doc:heading>Passwordless Users and Authentication Using TLS (x509) Certificates</doc:heading>
+      <doc:heading>Passwordless Users</doc:heading>
       <p>
         <a href="/access-control.html">Internal authentication backend</a> allows for users without a password
         or with a blank one (assuming credential validator also allows it). Such users are only mean to be used
@@ -231,10 +231,35 @@ rabbitmqctl clear_password passwordless-user
 
       <p>
         Starting with version <code>3.7.3</code>, authentication attempts that use a blank password
-        will be rejected by the <a href="/access-control.html">internal authentication backend</a> with a distinctive error
-        message in the <a href="/logging.html">server log</a>.
+        will be unconditionally rejected by the <a href="/access-control.html">internal authentication backend</a> with a distinctive error
+        message in the <a href="/logging.html">server log</a>. Connections that authenticate using x509 certificates or use an external service
+        for authentication (e.g. <a href="/ldap.html">LDAP</a>) can use blank passwords.
       </p>
     </doc:section>
+
+    <doc:section name="x509-certificate-authentication">
+      <doc:heading>Authentication Using TLS (x509) Certificates</doc:heading>
+      <p>
+        It is possible to <a href="https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl">authenticate connections using x509 certificates</a> and avoid
+        using passwords entirely. The authentication process then will rely on TLS <a href="https://tools.ietf.org/html/rfc5280#section-6">peer certificate chain validation</a>.
+      </p>
+
+      <p>
+        To do so:
+
+        <ul>
+          <li>Create a passwordless user (see above)</li>
+          <li>Enable the <a href="https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl">rabbitmq-auth-mechanism-ssl</a> plugin</li>
+          <li>Follow the plugin's configuration instructions</li>
+          <li>Configure client connections to use TLS and the <code>EXTERNAL</code>  authentication mechanism</li>
+          <li>
+            Configure client connections to provide a certificate/key pair and a CA certificate (or chain of certificates). The chain of certificates will be
+            verified by the server and thus at least one certificate in it must be trusted by the target node.
+          </li>
+        </ul>
+      </p>
+    </doc:section>
+
 
     <doc:section name="computing-password-hash">
       <doc:heading>Computing Password Hashes</doc:heading>


### PR DESCRIPTION
This started an an attempt to document https://github.com/rabbitmq/rabbitmq-server/pull/1466 and friends but since we didn't have a lot of docs around the topic of passwordless users or x509 certificate authentication, I decided to add a couple of sections around the topic.