### PR TITLE
Tutorial fix for golang

### DIFF
--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -228,8 +228,7 @@ There aren't any message timeouts; RabbitMQ will redeliver the message when
 the consumer dies. It's fine even if processing a message takes a very, very
 long time.
 
-Message acknowledgments are turned on by default.
-It's time to turn them off using the `false,  // auto-ack` option and send a proper acknowledgment
+To turn off auto acknowledgment, pass `false, // auto-ack` and send a proper acknowledgment
 from the worker `d.Ack(true)`, once we're done with a task.
 
 <pre class="sourcecode go">

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -228,9 +228,9 @@ There aren't any message timeouts; RabbitMQ will redeliver the message when
 the consumer dies. It's fine even if processing a message takes a very, very
 long time.
 
-Message acknowledgments are turned off by default.
-It's time to turn them on using the `false,  // auto-ack` option and send a proper acknowledgment
-from the worker `d.Ack(false)`, once we're done with a task.
+Message acknowledgments are turned on by default.
+It's time to turn them off using the `false,  // auto-ack` option and send a proper acknowledgment
+from the worker `d.Ack(true)`, once we're done with a task.
 
 <pre class="sourcecode go">
 msgs, err := ch.Consume(
@@ -253,7 +253,7 @@ go func() {
     t := time.Duration(dot_count)
     time.Sleep(t * time.Second)
     log.Printf("Done")
-    d.Ack(false)
+    d.Ack(true)
   }
 }()
 


### PR DESCRIPTION
👨 🐻 🐷 

The tutorial is incorrect because Ack is turned on by default and
when acking a new mesage, `true` must be passed, not `false`.