### PR TITLE
Default heartbeat is 60

### DIFF
--- a/site/configure.xml
+++ b/site/configure.xml
@@ -630,7 +630,7 @@ disk_free_limit.absolute = 2GB
               number of connections, but might lead to connections
               dropping in the presence of network devices that close
               inactive connections.  <p>Default: <code>heartbeat =
-              600</code></p>
+              60</code></p>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Default heartbeat is 60 since v3.5.5 (rabbitmq/rabbitmq-server@c7af785)