### PR TITLE
XSLT: Make all headings for named sections into links

### DIFF
--- a/site/access-control.xml
+++ b/site/access-control.xml
@@ -112,7 +112,7 @@ loopback_users = none
 </pre>
       </doc:section>
 
-      <doc:section name="access-control">
+      <doc:section name="permissions">
         <doc:heading>How Permissions Work</doc:heading>
         <p>
           When a RabbitMQ client establishes a connection to a

--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -24,7 +24,7 @@ limitations under the License.
   </head>
 
   <body show-in-this-page="true">
-      <doc:section name="ovreview">
+      <doc:section name="overview">
         <doc:heading>Overview</doc:heading>
         <p>
           A RabbitMQ <i>broker</i> is a logical grouping of one or

--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -24,7 +24,7 @@ limitations under the License.
   </head>
 
   <body show-in-this-page="true">
-      <doc:section name="clustering">
+      <doc:section name="ovreview">
         <doc:heading>Overview</doc:heading>
         <p>
           A RabbitMQ <i>broker</i> is a logical grouping of one or

--- a/site/css/rabbit.css
+++ b/site/css/rabbit.css
@@ -77,8 +77,12 @@ h2 a,
 h3 a {
   font-weight: bold;
 }
-a.anchor + a {
+a.anchor {
+  color: #808080;
   text-decoration: none;
+}
+.anchor:hover, .anchor:active {
+  text-decoration: underline;
 }
 
 a:active, a:hover {

--- a/site/ec2.xml
+++ b/site/ec2.xml
@@ -28,7 +28,7 @@ limitations under the License.
     <title>Amazon EC2</title>
   </head>
   <body>
-<doc:section name="ec2">
+<doc:section>
 
   <p>This guide assumes familiarity with the general <a href="/clustering.html">clustering guide</a>.</p>
 

--- a/site/install-generic-unix.xml
+++ b/site/install-generic-unix.xml
@@ -44,7 +44,7 @@ limitations under the License.
 
       <doc:heading>Generic Unix or Linux (BSD, Mac OS X)</doc:heading>
 
-      <doc:subsection name="install-generic-unix">
+      <doc:subsection name="install">
         <doc:heading>Install the Server</doc:heading>
         <p>
           Install a <a href="/which-erlang.html">supported version of Erlang</a>.

--- a/site/install-windows.xml
+++ b/site/install-windows.xml
@@ -42,7 +42,7 @@ limitations under the License.
         </r:download>
       </r:downloads>
 
-      <doc:subsection name="install-windows">
+      <doc:subsection name="install">
         <doc:heading>Install the Server</doc:heading>
         <p>
           First you need to install a <a href="/which-erlang.html">supported version of Erlang</a> for Windows.

--- a/site/installing-plugins.xml
+++ b/site/installing-plugins.xml
@@ -28,7 +28,7 @@ limitations under the License.
     <title>Installing Additional Plugins</title>
   </head>
   <body show-in-this-page="true">
-      <doc:section name="installing-plugins">
+      <doc:section>
       <p>
         Any plugins that do not ship with the server will need to be
         installed as .ez archives by copying them to one of the plugins

--- a/site/page.xsl
+++ b/site/page.xsl
@@ -212,7 +212,7 @@ limitations under the License.
     <h2 class="docHeading">
       <xsl:choose>
         <xsl:when test="../@name">
-          <a href="#{../@name}"><xsl:apply-templates/></a>
+          <a class="anchor" href="#{../@name}"><xsl:apply-templates/></a>
         </xsl:when>
         <xsl:otherwise>
           <xsl:apply-templates/>
@@ -225,7 +225,7 @@ limitations under the License.
     <h3 class="docHeading">
       <xsl:choose>
         <xsl:when test="../@name">
-          <a href="#{../@name}"><xsl:apply-templates/></a>
+          <a class="anchor" href="#{../@name}"><xsl:apply-templates/></a>
         </xsl:when>
         <xsl:otherwise>
           <xsl:apply-templates/>

--- a/site/page.xsl
+++ b/site/page.xsl
@@ -182,21 +182,21 @@ limitations under the License.
 
   <xsl:template match="doc:section">
     <div class="docSection">
-      <xsl:if test="@name"><a name="{@name}"/></xsl:if>
+      <xsl:if test="@name"><a name="{@name}" class="anchor"/></xsl:if>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
 
   <xsl:template match="doc:subsection">
     <div class="docSubsection">
-      <xsl:if test="@name"><a name="{@name}"/></xsl:if>
+      <xsl:if test="@name"><a name="{@name}" class="anchor"/></xsl:if>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
 
   <xsl:template match="doc:subsubsection">
     <div class="docSubsection">
-      <xsl:if test="@name"><a name="{@name}"/></xsl:if>
+      <xsl:if test="@name"><a name="{@name}" class="anchor"/></xsl:if>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
@@ -209,15 +209,41 @@ limitations under the License.
   </xsl:template>
 
   <xsl:template match="doc:section/doc:heading">
-    <h2 class="docHeading"><xsl:apply-templates/></h2>
+    <h2 class="docHeading">
+      <xsl:choose>
+        <xsl:when test="../@name">
+          <a href="#{../@name}"><xsl:apply-templates/></a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </h2>
   </xsl:template>
 
   <xsl:template match="doc:subsection/doc:heading">
-    <h3 class="docHeading"><xsl:apply-templates/></h3>
+    <h3 class="docHeading">
+      <xsl:choose>
+        <xsl:when test="../@name">
+          <a href="#{../@name}"><xsl:apply-templates/></a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </h3>
   </xsl:template>
 
   <xsl:template match="doc:subsubsection/doc:heading">
-    <h3 class="docHeading"><xsl:apply-templates/></h3>
+    <h3 class="docHeading"><xsl:choose>
+        <xsl:when test="../@name">
+          <a href="#{../@name}"><xsl:apply-templates/></a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </h3>
   </xsl:template>
 
   <xsl:template match="doc:roadmapentry/doc:heading">


### PR DESCRIPTION
Currently there are anchors, but no links to get the anchors from.
Make it easier to link to specific sections by turning section
headings into links.