### PR TITLE
Update links for .NET client api docs

### DIFF
--- a/site/amqp-0-9-1-quickref.xsl
+++ b/site/amqp-0-9-1-quickref.xsl
@@ -35,7 +35,7 @@ limitations under the License.
   <xsl:variable name="decorations" select="document('')/xsl:stylesheet/x:decorations" />
   <xsl:variable name="method-decorations" select="$decorations/x:decorate[@target='method']"/>
   <xsl:variable name="javadoc-root" select="'&dir-current-javadoc;com/rabbitmq/client/'"/>
-  <xsl:variable name="dotnetdoc-root" select="'/&dir-current-dotnet-apidoc;/'"/>
+  <xsl:variable name="dotnetdoc-root" select="'&url-dotnet-apidoc;/'"/>
 
   <xsl:key name="domain-key" match="domain" use="@name"/>
 
@@ -270,15 +270,15 @@ limitations under the License.
   <x:decorations>
     <x:decorate target="method" name="basic.ack">
       <x:javadoc href="Channel.html#basicAck(long, boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicAck(System.UInt64,System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicAck_System_UInt64_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.cancel">
       <x:javadoc href="Channel.html#basicCancel(java.lang.String)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicCancel(System.String)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicCancel_System_String_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.consume">
       <x:javadoc href="Channel.html#basicConsume(java.lang.String, boolean, java.lang.String, boolean, boolean, java.util.Map, com.rabbitmq.client.Consumer)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicConsume(System.String,System.Collections.IDictionary,RabbitMQ.Client.IBasicConsumer)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicConsume_System_String_System_Boolean_System_String_System_Boolean_System_Boolean_System_Collections_Generic_IDictionary_System_String_System_Object__RabbitMQ_Client_IBasicConsumer_" />
     </x:decorate>
     <x:decorate target="method" name="basic.deliver">
       <!-- x:javadoc ***not impl*** -->
@@ -286,34 +286,34 @@ limitations under the License.
     </x:decorate>
     <x:decorate target="method" name="basic.get">
       <x:javadoc href="Channel.html#basicGet(java.lang.String, boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicGet(System.String,System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicGet_System_String_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.nack">
       <x:amqp-extension />
       <x:url href="http://www.rabbitmq.com/nack.html" label="RabbitMQ Documentation"/>
       <x:javadoc href="Channel.html#basicNack(long, boolean, boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicNack(System.UInt64,System.Boolean,System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicNack_System_UInt64_System_Boolean_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.publish">
       <x:javadoc href="Channel.html#basicPublish(java.lang.String, java.lang.String, boolean, boolean, com.rabbitmq.client.AMQP.BasicProperties, byte[])"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicPublish(System.String,System.String,System.Boolean,System.Boolean,RabbitMQ.Client.IBasicProperties,System.Byte%5B%5D)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicPublish_System_String_System_String_System_Boolean_RabbitMQ_Client_IBasicProperties_System_Byte___"/>
     </x:decorate>
     <x:decorate target="method" name="basic.qos">
       <x:javadoc href="Channel.html#basicQos(int, int, boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicQos(System.UInt32,System.UInt16,System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicQos_System_UInt32_System_UInt16_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.recover">
       <x:javadoc href="Channel.html#basicRecover(boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicRecover(System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicRecover_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.recover-async">
       <x:javadoc href="Channel.html#basicRecoverAsync(boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicRecoverAsync(System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicRecoverAsync_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.reject">
       <x:url href="http://www.rabbitmq.com/blog/2010/08/03/well-ill-let-you-go-basicreject-in-rabbitmq/" label="RabbitMQ blog post"/>
       <x:javadoc href="Channel.html#basicReject(long, boolean)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.BasicReject(System.UInt64,System.Boolean)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_BasicReject_System_UInt64_System_Boolean_"/>
     </x:decorate>
     <x:decorate target="method" name="basic.return">
       <!-- x:javadoc ***not impl*** -->
@@ -321,7 +321,7 @@ limitations under the License.
     </x:decorate>
     <x:decorate target="method" name="channel.close">
       <x:javadoc href="Channel.html#close(int, java.lang.String)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.Close(System.UInt16,System.String)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_Close"/>
     </x:decorate>
     <x:decorate target="method" name="channel.open">
       <!-- x:javadoc ***not impl*** -->
@@ -333,14 +333,14 @@ limitations under the License.
     <x:decorate target="method" name="confirm.select">
       <x:url href="http://www.rabbitmq.com/confirms.html" label="RabbitMQ Documentation"/>
       <x:javadoc href="Channel.html#confirmSelect()"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.ConfirmSelect"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_ConfirmSelect"/>
     </x:decorate>
     <x:decorate target="method" name="exchange.bind">
       <x:amqp-extension />
       <x:url href="http://www.rabbitmq.com/e2e.html" label="RabbitMQ Documentation"/>
       <x:url href="http://www.rabbitmq.com/blog/2010/10/19/exchange-to-exchange-bindings/" label="RabbitMQ blog post"/>
       <x:javadoc href="Channel.html#exchangeBind(java.lang.String, java.lang.String, java.lang.String, java.util.Map)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.ExchangeBind(System.String,System.String,System.String,System.Boolean,System.Collections.IDictionary)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_ExchangeBind_System_String_System_String_System_String_System_Collections_Generic_IDictionary_System_String_System_Object__"/>
     </x:decorate>
     <x:decorate target="method" name="exchange.declare">
       <x:field override="auto-delete" name="auto-delete" domain="bit"/>
@@ -355,20 +355,20 @@ limitations under the License.
       </x:doc>
       <x:url href="http://www.rabbitmq.com/ae.html" label="AE documentation" />
       <x:javadoc href="Channel.html#exchangeDeclare(java.lang.String, java.lang.String, boolean, boolean, java.util.Map)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.ExchangeDeclare(System.String,System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Collections.IDictionary)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_ExchangeDeclare_System_String_System_String_System_Boolean_System_Boolean_System_Collections_Generic_IDictionary_System_String_System_Object__" />
     </x:decorate>
     <x:decorate target="method" name="exchange.delete">
       <x:javadoc href="Channel.html#exchangeDelete(java.lang.String, boolean)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.ExchangeDelete(System.String,System.Boolean,System.Boolean)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_ExchangeDelete_System_String_System_Boolean_" />
     </x:decorate>
     <x:decorate target="method" name="exchange.unbind">
       <x:amqp-extension />
       <x:javadoc href="Channel.html#exchangeUnbind(java.lang.String, java.lang.String, java.lang.String, java.util.Map)"/>
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.ExchangeUnbind(System.String,System.String,System.String,System.Boolean,System.Collections.IDictionary)"/>
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_ExchangeUnbind_System_String_System_String_System_String_System_Collections_Generic_IDictionary_System_String_System_Object__"/>
     </x:decorate>
     <x:decorate target="method" name="queue.bind">
       <x:javadoc href="Channel.html#queueBind(java.lang.String, java.lang.String, java.lang.String, java.util.Map)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.QueueBind(System.String,System.String,System.String,System.Boolean,System.Collections.IDictionary)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_QueueBind_System_String_System_String_System_String_System_Collections_Generic_IDictionary_System_String_System_Object__" />
     </x:decorate>
     <x:decorate target="method" name="queue.declare">
       <x:doc>
@@ -392,31 +392,31 @@ limitations under the License.
       <x:url href="http://www.rabbitmq.com/ttl.html#per-queue-message-ttl" label="x-message-ttl documentation"/>
       <x:url href="http://www.rabbitmq.com/ttl.html#queue-ttl" label="x-expires documentation"/>
       <x:javadoc href="Channel.html#queueDeclare(java.lang.String, boolean, boolean, boolean, java.util.Map)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.QueueDeclare(System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Collections.IDictionary)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_QueueDeclare_System_String_System_Boolean_System_Boolean_System_Boolean_System_Collections_Generic_IDictionary_System_String_System_Object__" />
     </x:decorate>
     <x:decorate target="method" name="queue.delete">
       <x:javadoc href="Channel.html#queueDelete(java.lang.String, boolean, boolean)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.QueueDelete(System.String,System.Boolean,System.Boolean,System.Boolean)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_QueueDelete_System_String_System_Boolean_System_Boolean_" />
     </x:decorate>
     <x:decorate target="method" name="queue.purge">
       <x:javadoc href="Channel.html#queuePurge(java.lang.String)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.QueuePurge(System.String,System.Boolean)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_QueuePurge_System_String_" />
     </x:decorate>
     <x:decorate target="method" name="queue.unbind">
       <x:javadoc href="Channel.html#queueUnbind(java.lang.String, java.lang.String, java.lang.String, java.util.Map)" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.QueueUnbind(System.String,System.String,System.String,System.Collections.IDictionary)" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_QueueUnbind_System_String_System_String_System_String_System_Collections_Generic_IDictionary_System_String_System_Object__" />
     </x:decorate>
     <x:decorate target="method" name="tx.commit">
       <x:javadoc href="Channel.html#txCommit()" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.TxCommit" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_TxCommit" />
     </x:decorate>
     <x:decorate target="method" name="tx.rollback">
       <x:javadoc href="Channel.html#txRollback()" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.TxRollback" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_TxRollback" />
     </x:decorate>
     <x:decorate target="method" name="tx.select">
       <x:javadoc href="Channel.html#txSelect()" />
-      <x:dotnetdoc href="type-RabbitMQ.Client.IModel.html#method-M:RabbitMQ.Client.IModel.TxSelect" />
+      <x:dotnetdoc href="RabbitMQ.Client.IModel.html#RabbitMQ_Client_IModel_TxSelect" />
     </x:decorate>
   </x:decorations>
 

--- a/site/documentation.xml
+++ b/site/documentation.xml
@@ -445,7 +445,7 @@ limitations under the License.
             <a href="&dir-current-javadoc;">Java</a>
           </li>
           <li>
-            <a href="&dir-current-dotnet-apidoc;/index.html">.NET</a>
+            <a href="&url-dotnet-apidoc-root;/index.html">.NET</a>
           </li>
           <li>
             <a href="&dir-current-edoc;">Erlang</a>

--- a/site/dotnet.xml
+++ b/site/dotnet.xml
@@ -53,9 +53,9 @@ limitations under the License.
     <h3>Version</h3>
 
     <p>
-      The current release of the RabbitMQ .NET/C# client library is <b>
-      &version-dotnet-client;</b>. It is recommended to use the <a href="https://www.nuget.org/packages/RabbitMQ.Client">NuGet package</a>.
-      Release notes can be found on the <a href="/releases/rabbitmq-dotnet-client/">GitHub releases page</a>.
+      The current release of the RabbitMQ .NET/C# client library is <b>&version-dotnet-client;</b>.
+      It is recommended to use the <a href="https://www.nuget.org/packages/RabbitMQ.Client">NuGet package</a>.
+      Release notes can be found on the <a href="https://github.com/rabbitmq/rabbitmq-dotnet-client/releases">GitHub releases page</a>.
     </p>
 
     <h2>
@@ -71,24 +71,19 @@ limitations under the License.
 
     <r:downloads signature="no">
       <tr>
-        <td class="desc">4.x series NuGet package for .NET Core and .NET 4.5.1 (recommended)</td>
+        <td class="desc">4.x series NuGet package for .NET Core and .NET 4.5.1</td>
         <td><a href="https://www.nuget.org/packages/RabbitMQ.Client">4.x NuGet package</a></td>
       </tr>
-      <r:download downloadfile="&nameVersion-dotnet-client;-dotnet-&minimum-dotnet-version;.zip"
-		  downloadpath="&dir-dotnet-client;">
-	Binary, compiled for .NET &minimum-dotnet-version; and newer (zip archive).
-      </r:download>
-
-      <r:download downloadfile="&nameVersion-dotnet-client;.zip"
-		  downloadpath="&dir-dotnet-client;">
-	Source code and tools (zip)
-      </r:download>
+      <tr>
+        <td class="desc">3.x series binary builds</td>
+        <td><a href="releases/&dir-dotnet-client;">3.x builds</a></td>
+      </tr>
     </r:downloads>
 
     <h3>The documentation</h3>
     <p>
       Please refer to the <a href="dotnet-api-guide.html">API guide</a>. There's
-      also <a href="&dir-current-dotnet-apidoc;/index.html">an online API reference</a>.
+      also <a href="&url-dotnet-apidoc-root;/index.html">an online API reference</a>.
     </p>
 
     <h2>Change Log</h2>

--- a/site/download.xml
+++ b/site/download.xml
@@ -178,23 +178,11 @@ limitations under the License.
       <h3>.NET/C# Client</h3>
       <ul>
         <li>
-          On NuGet (<a href="https://groups.google.com/forum/#!searchin/rabbitmq-users/.NET$20client$204.0%7Csort:relevance/rabbitmq-users/mzZ1AoFM4Bk/5ahmQEj6AwAJ">4.x release series</a> for .NET Core and .NET 4.5.1):
+          On NuGet:
           <a href="https://www.nuget.org/packages/RabbitMQ.Client">RabbitMQ .NET Client</a>.
         </li>
         <li>
-          On NuGet (3.6.x series for .NET 4.5.0):
-          <a href="https://www.nuget.org/packages/RabbitMQ.Client">RabbitMQ .NET Client</a>.
-        </li>
-        <li>
-          Quick download:
-          <a href="https://github.com/rabbitmq/rabbitmq-server/releases/download/&version-server-tag;/&nameVersion-dotnet-client;-dotnet-4.5.zip">Latest 3.6.x binary</a> for .NET 4.5.0 |
-          <a href="https://github.com/rabbitmq/rabbitmq-server/releases/download/&version-server-tag;/&nameVersion-dotnet-client;.zip">Source</a>
-        </li>
-        <li>
-          <a href="dotnet.html">All .NET client downloads</a>
-        </li>
-        <li>
-          <a href="/releases/rabbitmq-dotnet-client/">Older versions</a>
+          <a href="releases/&dir-dotnet-client;">Older versions</a>
         </li>
       </ul>
 

--- a/site/how.xml
+++ b/site/how.xml
@@ -348,12 +348,6 @@ limitations under the License.
       RabbitMQ, Celery and Python, all on a Mac.
     </li>
     <li>
-      <a href="/releases/&dir-dotnet-client;/&nameVersion-dotnet-client;-user-guide.pdf">Common Messaging Patterns (.NET Client Library User Guide)</a><br />
-      Whether or not you use .NET, section 3 of this guide describes ways
-      of working with AMQP and a number common messaging patterns and
-      interaction styles.
-    </li>
-    <li>
       <a href="http://enthusiasm.cozy.org/archives/2009/02/listening-to-the-system">Listening to the System</a><br />
       Blog post from Ben Hyde examining some ideas how topic routing in AMQP
       is a good solution for building a message hub for real-time monitoring.

--- a/site/pages.xml.dat
+++ b/site/pages.xml.dat
@@ -157,7 +157,7 @@ limitations under the License.
          <x:page url="/uri-query-parameters.html" text="AMQP 0-9-1 URI Params"/>
        </x:page>
        <x:related url="&dir-current-javadoc;" text="Java Client javadoc"/>
-       <x:related url="&dir-current-dotnet-apidoc;/index.html" text=".NET htmldoc"/>
+       <x:related url="&url-dotnet-apidoc-root;/index.html" text=".NET htmldoc"/>
        <x:related url="&dir-current-edoc;" text="Erlang edoc"/>
      </x:page>
      <x:page url="/plugins.html" text="Plugins">

--- a/site/rabbit.ent
+++ b/site/rabbit.ent
@@ -27,10 +27,9 @@ limitations under the License.
 <!ENTITY serverRPMMinorVersion "1">
 <!ENTITY dir-server "rabbitmq-server/v&version-server;">
 
-<!ENTITY dir-dotnet-client "rabbitmq-dotnet-client/v&version-dotnet-client;">
-<!ENTITY nameVersion-dotnet-client "rabbitmq-dotnet-client-&version-dotnet-client;">
-<!ENTITY dir-current-dotnet-apidoc "/releases/&dir-dotnet-client;/&nameVersion-dotnet-client;-client-htmldoc/html">
-<!ENTITY version-dotnet-client-tag "5.0.1">
+<!ENTITY dir-dotnet-client "releases/rabbitmq-dotnet-client">
+<!ENTITY url-dotnet-apidoc-root "http://rabbitmq.github.io/rabbitmq-dotnet-client">
+<!ENTITY url-dotnet-apidoc "&url-dotnet-apidoc-root;/api">
 
 <!ENTITY dir-java-client "rabbitmq-java-client/v&version-java-client;">
 <!ENTITY dir-current-javadoc "/releases/rabbitmq-java-client/current-javadoc/">

--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -1226,7 +1226,7 @@ mono certcheck.exe /path/to/server/cert.
               the <code>System.Net.Security.SslPolicyErrors.RemoteCertificateNotAvailable</code>
               and <code>System.Net.Security.SslPolicyErrors.RemoteCertificateChainErrors</code>
               flags
-              in <a href="&dir-current-dotnet-apidoc;/type-RabbitMQ.Client.SslOption.html#property-P:RabbitMQ.Client.SslOption.AcceptablePolicyErrors">SslOptions.AcceptablePolicyErrors</a>.
+              in <a href="&url-dotnet-apidoc;/RabbitMQ.Client.SslOption.html">SslOptions</a>.
             </p>
         </doc:subsection>
 


### PR DESCRIPTION
Remove invalid links, and ensure API links point to https://rabbitmq.github.io/rabbitmq-dotnet-client

[154399066]

See rabbitmq/rabbitmq-dotnet-client#390