### PR TITLE
Set Erlang version to 20.2.3 for MacOS standalone package

### DIFF
--- a/site/rabbit.ent
+++ b/site/rabbit.ent
@@ -21,7 +21,7 @@ limitations under the License.
 <!ENTITY version-server-series "v3.7.x">
 <!ENTITY version-erlang-client "3.7.3">
 <!ENTITY version-server-tag "v3.7.3">
-<!ENTITY standalone-otp-version "20.1">
+<!ENTITY standalone-otp-version "20.2.3">
 
 <!ENTITY serverDebMinorVersion "1">
 <!ENTITY serverRPMMinorVersion "1">


### PR DESCRIPTION
Fixes rabbitmq/rabbitmq-server-release#77