### PR TITLE
Typo on variable name - tutorial-one-ruby.md 

### DIFF
--- a/site/tutorials/tutorial-one-ruby.md
+++ b/site/tutorials/tutorial-one-ruby.md
@@ -179,7 +179,7 @@ begin
     puts " [x] Received #{body}"
   end
 rescue Interrupt => _
-  conn.close
+  connection.close
 
   exit(0)
 end


### PR DESCRIPTION
Matching the variable name to the example above.