### PR TITLE
[Obvious Fix] Mention that the build process requires Elixir

### DIFF
--- a/site/build-erlang-prerequisites.xml.inc
+++ b/site/build-erlang-prerequisites.xml.inc
@@ -48,6 +48,10 @@ limitations under the License.
     </li>
 
     <li>
+      a recent version of <a href="https://elixir-lang.org/">Elixir</a>
+    </li>
+      
+    <li>
       a recent version of <a
       href="http://www.gnu.org/software/make/">GNU make</a>
     </li>


### PR DESCRIPTION
Strictly speaking at the moment the build process requires 1.6.0 or newer, but I didn't want to be over-specific (which would just require constantly updating the docs)