### PR TITLE
Added keep-alive interval to Web-MQTT Javascript demo code

### DIFF
--- a/site/web-mqtt.md
+++ b/site/web-mqtt.md
@@ -87,6 +87,7 @@ connection with the broker:
 
 var options = {
     timeout: 3,
+    keepAliveInterval: 30,
     onSuccess: function () {
         debug("CONNECTION SUCCESS");
         client.subscribe('/topic/test', {qos: 1});


### PR DESCRIPTION
I used the Paho example code for the Web-MQTT plugin in a project, but in my case the code did not work well with the server's default values (Websocket timeout). If the default keep-alive interval of Paho (60 seconds) is used, the connection is closed by the server after some minutes. After some debugging I changed that interval to 30 seconds and the connection remained stable.

I added this parameter to the example Javascript code on the website in order to save others from this issue.