### PR TITLE
Fixed potential typo in queue documentation

### DIFF
--- a/site/queues.md
+++ b/site/queues.md
@@ -281,7 +281,7 @@ the broker.
 Enqueued messages therefore can be in one of two states:
 
  * Ready for delivery
- * Delivered by not yet [acknowledged by consumer](/confirms.html)
+ * Delivered but not yet [acknowledged by consumer](/confirms.html)
 
 Message breakdown by state can be found in the management UI.
 


### PR DESCRIPTION
I could be wrong (please ignore if I am), but I think the second state of an enqueued message should be 'delivered **but** not yet acknowledged by consumer'.