### PR TITLE
Update Supported Erlang versions guide to mention OTP 21

### DIFF
--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -68,9 +68,9 @@ limitations under the License.
               <ul class="plain">
                 <li>RabbitMQ 3.7.7 is the first version to support Erlang/OTP 21</li>
                 <li>Erlang/OTP 21 includes file I/O efficiency improvements</li>
+                <li>For the best TLS support, the latest version of Erlang/OTP 21.0.x is recommended</li>
                 <li>Versions prior to 19.3.6.4 have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
-
                 <li>On Windows, Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a></li>
               </ul>
             </td>
@@ -100,10 +100,9 @@ limitations under the License.
             </td>
             <td>
               <ul class="plain">
+                <li>For the best TLS support, the latest version of Erlang/OTP 20.3.x is recommended</li>
                 <li>We recommend Erlang/OTP 19.3.6.4 or later, earlier versions have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
-
-                <li>For the best TLS support, the latest version of Erlang/OTP 20.x is recommended</li>
                 <li>On Windows, Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a></li>
               </ul>
             </td>
@@ -128,10 +127,10 @@ limitations under the License.
             </td>
             <td>
               <ul class="plain">
-                <li><a href="https://groups.google.com/d/msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ">Erlang/OTP versions prior to 19.3 are not supported</a></li>
+                <li>For the best TLS support, the latest version of Erlang/OTP 20.3.x is recommended</li>
                 <li>We recommend Erlang/OTP 19.3.6.4 or later, earlier versions have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
-                <li>For the best TLS support, the latest version of Erlang/OTP 20.x is recommended</li>
+                <li><a href="https://groups.google.com/d/msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ">Erlang/OTP versions prior to 19.3 are not supported</a></li>
                 <li>On Windows, Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a></li>
               </ul>
             </td>
@@ -158,9 +157,9 @@ limitations under the License.
             </td>
             <td>
               <ul class="plain">
+                <li>For the best TLS support, the latest version of Erlang/OTP 20.1.x is recommended</li>
                 <li>We recommend Erlang/OTP 19.3.6.4 or later, earlier versions have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
-                <li>For the best TLS support, the latest version of Erlang/OTP 20.1.x is recommended</li>
               </ul>
             </td>
           </tr>
@@ -189,9 +188,9 @@ limitations under the License.
             </td>
             <td>
               <ul class="plain">
+                <li>For the best TLS support, the latest version of Erlang/OTP 19.3.x is recommended</li>
                 <li>We recommend Erlang/OTP 19.3.6.4 or later, earlier versions have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
-                <li>For the best TLS support, the latest version of Erlang/OTP 19.3.x is recommended</li>
               </ul>
             </td>
           </tr>

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -79,23 +79,23 @@ limitations under the License.
           <tr>
             <td>
               <ul>
-                <li><strong>3.7.6</strong></li>
-                <li><strong>3.7.5</strong></li>
-                <li><strong>3.7.4</strong></li>
-                <li><strong>3.7.3</strong></li>
-                <li><strong>3.7.2</strong></li>
-                <li><strong>3.7.1</strong></li>
-                <li><strong>3.7.0</strong></li>
+                <li>3.7.6</li>
+                <li>3.7.5</li>
+                <li>3.7.4</li>
+                <li>3.7.3</li>
+                <li>3.7.2</li>
+                <li>3.7.1</li>
+                <li>3.7.0</li>
               </ul>
             </td>
             <td>
               <ul>
-                <li><strong>19.3</strong></li>
+                <li>19.3</li>
               </ul>
             </td>
             <td>
               <ul>
-                <li><strong>20.3.x</strong></li>
+                <li>20.3.x</li>
               </ul>
             </td>
             <td>

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -34,11 +34,9 @@ limitations under the License.
 
     <doc:section name="unsupported versions">
       <doc:heading>Unsupported Versions</doc:heading>
-      <p>
-        Erlang/OTP versions <strong>older than 19.3 are not supported</strong> by currently maintained
-        RabbitMQ release series. RabbitMQ <strong>versions prior to <code>3.7.7</code> do not support
-        Erlang/OTP 21</strong> or newer.
-      </p>
+        <p>Erlang/OTP versions <strong>older than 19.3 are not supported</strong> by currently maintained RabbitMQ release series.</p>
+
+        <p>RabbitMQ <strong>versions prior to 3.7.7 do not support Erlang/OTP 21</strong> or newer.</p>
     </doc:section>
 
 

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -35,9 +35,9 @@ limitations under the License.
     <doc:section name="unsupported versions">
       <doc:heading>Unsupported Versions</doc:heading>
       <p>
-        Erlang/OTP versions <strong>older than 19.3 and newer than 20.3.x (including 21.0) are not supported</strong> by currently maintained
-        RabbitMQ release series.
-        OTP 21 support will be <a href="https://github.com/rabbitmq/rabbitmq-server/issues/1616">introduced eventually</a>.
+        Erlang/OTP versions <strong>older than 19.3 are not supported</strong> by currently maintained
+        RabbitMQ release series. RabbitMQ <strong>versions prior to <code>3.7.7</code> do not support
+        Erlang/OTP 21</strong> or newer.
       </p>
     </doc:section>
 
@@ -53,7 +53,41 @@ limitations under the License.
           <tr>
             <td>
               <ul>
-                <li><strong>3.7.x</strong></li>
+                <li><strong>3.7.7</strong></li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li><strong>19.3.6.4</strong></li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li><strong>21.0.x</strong></li>
+              </ul>
+            </td>
+            <td>
+              <ul class="plain">
+                <li>RabbitMQ 3.7.7 is the first version to support Erlang/OTP 21</li>
+                <li>Erlang/OTP 21 includes file I/O efficiency improvements</li>
+                <li>Versions prior to 19.3.6.4 have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
+                <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
+
+                <li>Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a> on Windows</li>
+              </ul>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <ul>
+                <li><strong>3.7.6</strong></li>
+                <li><strong>3.7.5</strong></li>
+                <li><strong>3.7.4</strong></li>
+                <li><strong>3.7.3</strong></li>
+                <li><strong>3.7.2</strong></li>
+                <li><strong>3.7.1</strong></li>
+                <li><strong>3.7.0</strong></li>
               </ul>
             </td>
             <td>
@@ -80,7 +114,7 @@ limitations under the License.
           <tr>
             <td>
               <ul>
-                <li>3.6.16</li>                
+                <li>3.6.16</li>
                 <li>3.6.15</li>
               </ul>
             </td>

--- a/site/which-erlang.xml
+++ b/site/which-erlang.xml
@@ -71,7 +71,7 @@ limitations under the License.
                 <li>Versions prior to 19.3.6.4 have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
 
-                <li>Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a> on Windows</li>
+                <li>On Windows, Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a></li>
               </ul>
             </td>
           </tr>
@@ -103,8 +103,8 @@ limitations under the License.
                 <li>We recommend Erlang/OTP 19.3.6.4 or later, earlier versions have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
 
-                <li>Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a> on Windows</li>
                 <li>For the best TLS support, the latest version of Erlang/OTP 20.x is recommended</li>
+                <li>On Windows, Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a></li>
               </ul>
             </td>
           </tr>
@@ -129,10 +129,10 @@ limitations under the License.
             <td>
               <ul class="plain">
                 <li><a href="https://groups.google.com/d/msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ">Erlang/OTP versions prior to 19.3 are not supported</a></li>
-                <li>Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a> on Windows</li>
                 <li>We recommend Erlang/OTP 19.3.6.4 or later, earlier versions have known bugs (e.g. <a href="https://bugs.erlang.org/browse/ERL-430">ERL-430</a>, <a href="https://bugs.erlang.org/browse/ERL-448">ERL-448</a>) that can prevent RabbitMQ nodes from accepting connections (including from CLI tools) and stopping</li>
                 <li>Versions prior to 19.3.6.4 are vulnerable to the <a href="https://robotattack.org/">ROBOT attack</a> (CVE-2017-1000385)</li>
                 <li>For the best TLS support, the latest version of Erlang/OTP 20.x is recommended</li>
+                <li>On Windows, Erlang/OTP 20.2 changed <a href="/cli.html">default cookie file location</a></li>
               </ul>
             </td>
           </tr>


### PR DESCRIPTION
Note that I now list 19.3.6.4 as the minimum required. Even though nodes will still run on 19.3 we will ask any pre-19.3.6.4 users to upgrade first since [ERL-430](https://bugs.erlang.org/browse/ERL-430) and [ERL-448](https://bugs.erlang.org/browse/ERL-448) are catastrophic and running into them on affected versions is a matter of time. So this is a strong recommendation stated as a requirement, not a breaking change.

References rabbitmq/rabbitmq-server#1616.

[#157964874]