### PR TITLE
Flag is `-detached` not `--detached`

### DIFF
--- a/site/man/rabbitmq-server.8.html
+++ b/site/man/rabbitmq-server.8.html
@@ -45,7 +45,7 @@ Running <b class="Nm" title="Nm">rabbitmq-server</b> in the foreground displays
 </dl>
 <h2 class="Sh" title="Sh" id="OPTIONS"><a class="selflink" href="#OPTIONS">OPTIONS</a></h2>
 <dl class="Bl-tag">
-  <dt class="It-tag"><a class="selflink" href="#-detached"><b class="Fl" title="Fl" id="-detached">--detached</b></a></dt>
+  <dt class="It-tag"><a class="selflink" href="#-detached"><b class="Fl" title="Fl" id="-detached">-detached</b></a></dt>
   <dd class="It-tag">Start the server process in the background. Note that this
       will cause the pid not to be written to the pid file.
     <div class="Pp"></div>


### PR DESCRIPTION
The flag `--detached` is ignored by `rabbitmq-server`.  The documentation should consistently use the correct `-detached` flag.  All other occurrences that I could find (including the man page) are correct.