### PR TITLE
Fix typo in tutorials

### DIFF
--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -125,7 +125,7 @@ q, err := ch.QueueDeclare(
 )
 failOnError(err, "Failed to declare a queue")
 
-body := "hello"
+body := "Hello World!"
 err = ch.Publish(
   "",     // exchange
   q.Name, // routing key


### PR DESCRIPTION
In [part 2](https://github.com/rabbitmq/rabbitmq-website/blob/live/site/tutorials/tutorial-two-go.md), the document described `In the previous part of this tutorial we sent a message containing "Hello World!".`