### PR TITLE
reliability fix link to unsynchronised mirrors

### DIFF
--- a/site/reliability.xml
+++ b/site/reliability.xml
@@ -155,8 +155,8 @@ limitations under the License.
       <p>
         Mirrored queues replicate their contents across all configured cluster
         nodes, tolerating node failures seamlessly and without message loss
-        (although see <a href="ha.html#unsynchronised-slaves">this note on
-        unsynchronised slaves</a>). However, consuming applications need to be
+        (although see <a href="ha.html#unsynchronised-mirrors">this note on
+        unsynchronised mirrors</a>). However, consuming applications need to be
         aware that when queues fail their consumers will be cancelled and they
         will need to reconsume - see <a href="ha.html#behaviour">the
         documentation</a> for more details.


### PR DESCRIPTION
Was still referencing "unsynchronised slaves" which was renamed to "unsynchronised mirrors"

Adjusted anchor link, as well as naming in text.