### PR TITLE
Use keyword arguments for Markdown generation

### DIFF
--- a/code/render.py
+++ b/code/render.py
@@ -60,11 +60,16 @@ def preprocess_markdown(fpath):
 </html>
 """
     if nosyntax:
-        args = ["tables"]
+        extensionsArg = ["tables"]
+        extensionsConfigArg = {}
     else:
-        args = ["codehilite(css_class=highlight)", "tables"]
+        extensionsArg = ["codehilite", "tables"]
+        extensionsConfigArg = {
+            'codehilite': {
+            'css_class': 'highlight'
+        }}
 
-    processed = markdown.markdown(contents, args)
+    processed = markdown.markdown(contents, extensions=extensionsArg, extension_configs=extensionsConfigArg)
 
     # Unfortunately we can't stop markdown escaping entities. Unescape them.
     processed = re.sub(r'&amp;([a-z0-9-_.:]+);', r'&\1;', processed)


### PR DESCRIPTION
Not using them can make generation fail on some environments.

Happened to me on a new environment (Python 3.6.7, Python Markdown 3.0.1), got the code from [the Python Markdown documentation](https://python-markdown.github.io/reference/), tested on our staging instance.