### PR TITLE
Fixing incorrect etcd TTL parameter

### DIFF
--- a/site/cluster-formation.xml
+++ b/site/cluster-formation.xml
@@ -1037,7 +1037,7 @@ cluster_formation.peer_discovery_backend = rabbit_peer_discovery_etcd
 cluster_formation.etcd.host = etcd.eng.example.local
 # node TTL in seconds
 # default: 30
-cluster_formation.etcd.ttl = 40
+cluster_formation.etcd.node_ttl = 40
 </pre>
 
         Key refreshes will be performed every <code>TTL/2</code> seconds.


### PR DESCRIPTION
According to the code of the [etcd peer discovery plugin](https://github.com/rabbitmq/rabbitmq-peer-discovery-etcd/blob/07571d1e9d714236187852f58dfcec0021272d29/priv/schema/rabbitmq_peer_discovery_etcd.schema#L74), the correct parameter is `cluster_formation.etcd.node_ttl` (not `cluster_formation.etcd.ttl`, which raises an error when used on RabbitMQ 3.7.8)

(Obvious Fix)