### PR TITLE
Removed wrong closing brackets

### DIFF
--- a/site/api-guide.xml
+++ b/site/api-guide.xml
@@ -439,7 +439,7 @@ channel.basicPublish(exchangeName, routingKey,
                .deliveryMode(2)
                .priority(1)
                .userId("bob")
-               .build()),
+               .build(),
                messageBodyBytes);</pre>
 
       <p>
@@ -454,7 +454,7 @@ headers.put("longitude", -0.0905493);
 channel.basicPublish(exchangeName, routingKey,
              new AMQP.BasicProperties.Builder()
                .headers(headers)
-               .build()),
+               .build(),
                messageBodyBytes);</pre>
 
       <p>
@@ -465,7 +465,7 @@ channel.basicPublish(exchangeName, routingKey,
 channel.basicPublish(exchangeName, routingKey,
              new AMQP.BasicProperties.Builder()
                .expiration("60000")
-               .build()),
+               .build(),
                messageBodyBytes);</pre>
 
       <p>


### PR DESCRIPTION
There was a minor typo, appearing three times, in the [Java Client API Guide](https://www.rabbitmq.com/api-guide.html). An extra closing bracket was added after _AMQP.BasicProperties.Builder().build()_.