### PR TITLE
Add Bunnicula (a Clojure client) to devtools page

### DIFF
--- a/site/devtools.xml
+++ b/site/devtools.xml
@@ -222,6 +222,9 @@ limitations under the License.
               <li>
                 <a href="http://clojurerabbitmq.info">Langohr, a Clojure RabbitMQ client</a>
               </li>
+              <li>
+                <a href="https://github.com/nomnom-insights/nomnom.bunnicula">Bunnicula, Component based framework for Clojure. Built on top of official Java client</a>
+              </li>
             </ul>
             <h4>JRuby</h4>
             <ul class="plain">


### PR DESCRIPTION
Hi! 👋 

I'm part of the team which created Bunnicula (you can [read the backstory here](https://blog.nomnominsights.com/bunnicula-asynchronous-messaging-with-rabbitmq-for-clojure/) - and I'd like to share it with the broader community. 
Internally we've been using it for over a year and lost count of how many jobs have been processed ;-)

Thanks