### PR TITLE
Fix explanation of consumer

### DIFF
--- a/site/tutorials/tutorial-one-ruby.md
+++ b/site/tutorials/tutorial-one-ruby.md
@@ -136,7 +136,7 @@ connection.close
 
 ### Receiving
 
-That's it for our producer. Our consumer is listening for pushed messages from
+That's it for our producer. Our consumer is listening for messages from
 RabbitMQ, so unlike the producer which publishes a single message, we'll
 keep it running to listen for messages and print them out.
 

--- a/site/tutorials/tutorial-one-ruby.md
+++ b/site/tutorials/tutorial-one-ruby.md
@@ -136,7 +136,7 @@ connection.close
 
 ### Receiving
 
-That's it for our producer. Our consumer is pushed messages from
+That's it for our producer. Our consumer is listening for pushed messages from
 RabbitMQ, so unlike the producer which publishes a single message, we'll
 keep it running to listen for messages and print them out.
 


### PR DESCRIPTION
Why: so it makes sense grammatically. 

Part of the explanation was missing