### PR TITLE
Fixing wording about certificates on a .NET client for TLS

### DIFF
--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -984,7 +984,7 @@ factory.useSslProtocol("TLSv1.2");
       <doc:section name="dotnet-client">
         <doc:heading>Using TLS in the .NET client</doc:heading>
         <p>
-          For a server certificate to be understood on the .NET platform, they
+          For a client certificate to be understood on the .NET platform, they
           can be in a number of formats including DER and PKCS#12 but
           not PEM. For the DER format, .NET expects them to
           be stored in files with <code>.cer</code> extension. <a href="#automated-certificate-generation">tls-gen</a>


### PR DESCRIPTION
I suggest we change this wording about certificate format requirements for .NET clients accessing a RabbitMQ server using TLS. This makes it sounds like the certificate on any server that a .NET client will access cannot be PEM, which is not the case. I was able to connect to a .NET client to a RabbitMQ server running on Linux using a PEM certificate. I'm not sure if this current wording means that the *client* certificate on .NET clients (for peer verification going the other way, server authenticating client) can't be PEM, or in the case of the server being a .NET server using mono, then the server certificate can't use PEM. I assumed the former and made the change accordingly. If it is the latter, then I suggest we break out a separate "Setting up a .NET/Mono server for TLS" section and call it out there, since this is currently in a section talking about setting up a .NET client.

This caused our devs greater pain in debugging an issue than would otherwise be needed, so I think it would be beneficial to change/clarify this. Let me know what people think. Thanks!