### PR TITLE
Add the instructions to install erlang on openSUSE and SLES distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To run a local copy manually on [localhost:8191](http://localhost:8191), use:
 On Debian and Ubuntu dependencies can be installed via `apt`:
 
 ```sh
-sudo apt-get install python-lxml python-markdown python-pygments
+sudo apt-get install python3-lxml python3-markdown python3-pygments
 ```
 
 To run a local copy manually on [localhost:8191](http://localhost:8191), use:

--- a/site/install-rpm.xml
+++ b/site/install-rpm.xml
@@ -142,6 +142,9 @@ limitations under the License.
           most official packages but tend to be out of date.
           The packages are split into many small pieces.
         </li>
+        <li>
+          <a href="https://www.opensuse.org/">openSUSE</a> produces Erlang packages for each distribution (openSUSE and SLES) 
+        </li> 
       </ul>
 
       <doc:subsection name="install-zero-dependency-rpm">
@@ -190,6 +193,29 @@ yum install erlang
         </p>
       </doc:subsection>
 
+      <doc:subsection name="install-from-suse-repository">
+        <doc:heading>Erlang packages from openSUSE</doc:heading>
+        <p>
+          Install Erlang directly using zypper as root:
+<pre class="sourcecode bash">
+zypper in erlang
+</pre>
+
+          The version may be out-of-date, add the openSUSE 
+          factory <a href="http://download.opensuse.org/repositories/devel:/languages:/erlang:/Factory/"> repositories</a> 
+          to get the last version. For example for leap 15:
+<pre class="sourcecode bash">
+# add the openSUSE erlang factory repository for leap 15
+zypper addrepo http://download.opensuse.org/repositories/devel:/languages:/erlang:/Factory/openSUSE_Leap_15.0/ openSUSE-Erlang-Factory
+
+# import the key and refresh the repository
+zypper --gpg-auto-import-keys refresh
+
+# install the last erlang version
+zypper in erlang
+</pre>         
+        </p>
+      </doc:subsection>
 
       <doc:subsection name="rpm-version-locking">
         <doc:heading>Package Version Locking in Yum</doc:heading>


### PR DESCRIPTION
- Add the instructions to install erlang on openSUSE and SLES 
- Fix the python documentation dependency lib, driver.py uses `python3`