### PR TITLE
Fix typo on access-control.xml

### DIFF
--- a/site/access-control.xml
+++ b/site/access-control.xml
@@ -509,7 +509,7 @@ auth_backends.1.authz = rabbit_auth_backend_ip_range
 
       <p>
         The following example configures RabbitMQ to use <a href="/ldap.html">LDAP backend</a>
-        for authentication and but internal backend for authorisation:
+        for authentication and internal backend for authorisation:
       </p>
 
 <pre class="sourcecode ini">


### PR DESCRIPTION
Obvious fix.

Replace ```and but``` with ```and``` on 

> "use LDAP backend for authentication **and but** internal backend for authorisation"
