### PR TITLE
Fix typo

### DIFF
--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -341,7 +341,7 @@ to the n-th consumer.
   </div>
 </div>
 
-In order to defeat that we can use the `basic.qos` method with the
+In order to defeat that we can use the `basic_qos` method with the
 `prefetch_count=1` setting. This tells RabbitMQ not to give more than
 one message to a worker at a time. Or, in other words, don't dispatch
 a new message to a worker until it has processed and acknowledged the


### PR DESCRIPTION
Is this a typo? I'm not sure.

<img width="823" alt="screen shot 2019-01-31 at 15 50 09" src="https://user-images.githubusercontent.com/22176164/52039693-2ba04780-2570-11e9-8858-a8cf9b6b2444.png">

feel free to close it 😃 