### PR TITLE
typed routing key instead of binding key

### DIFF
--- a/site/tutorials/amqp-concepts.xml
+++ b/site/tutorials/amqp-concepts.xml
@@ -167,7 +167,7 @@ limitations under the License.
                  For example, when you declare a queue with the name of
                  "search-indexing-online", the AMQP 0-9-1 broker will bind it
                  to the default exchange using "search-indexing-online" as
-                 the routing key. Therefore, a message published to the default
+                 the binding key. Therefore, a message published to the default
                  exchange with the routing key "search-indexing-online"
                  will be routed to the queue "search-indexing-online". In
                  other words, the default exchange makes it seem like it


### PR DESCRIPTION
When i went through amqp-concepts it says, 

> when you declare a queue with the name of "search-indexing-online", the AMQP 0-9-1 broker will bind it to the default exchange using **"search-indexing-online" as the routing key.**

If i understood correctly it should be 
> **"search-indexing-online" as the binding key.**

See here : https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default 