### PR TITLE
Fix typo from 'customer' to 'consumer'

### DIFF
--- a/site/tutorials/tutorial-two-elixir.md
+++ b/site/tutorials/tutorial-two-elixir.md
@@ -175,7 +175,7 @@ Message acknowledgment
 
 Doing a task can take a few seconds. You may wonder what happens if
 one of the consumers starts a long task and dies with it only partly done.
-With our current code once RabbitMQ delivers message to the customer it
+With our current code once RabbitMQ delivers message to the consumer it
 immediately marks it for deletion. In this case, if you kill a worker
 we will lose the message it was just processing. We'll also lose all
 the messages that were dispatched to this particular worker but were not

--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -172,7 +172,7 @@ Message acknowledgment
 
 Doing a task can take a few seconds. You may wonder what happens if
 one of the consumers starts a long task and dies with it only partly done.
-With our current code once RabbitMQ delivers message to the customer it
+With our current code once RabbitMQ delivers message to the consumer it
 immediately marks it for deletion. In this case, if you kill a worker
 we will lose the message it was just processing. We'll also lose all
 the messages that were dispatched to this particular worker but were not


### PR DESCRIPTION
Change other occurrences of 'customer' to 'consumer'.

Note: There's a merge and another commit, because I used tilda (`) in the commit message the first time and it turned into a space.