### PR TITLE
Use consistent example host names in clustering guide

### DIFF
--- a/site/clustering.xml
+++ b/site/clustering.xml
@@ -790,7 +790,7 @@ rabbitmqctl reset
 # => Resetting node rabbit@rabbit1 ...done.
 
 rabbitmqctl start_app
-# => Starting node rabbit@mcnulty ...
+# => Starting node rabbit@rabbit1 ...
 # => ...done.
 </pre>
           <p>


### PR DESCRIPTION
The documentation randomly switches from `rabbit1` to `mcnulty` and then back. Let's clean up that inconsistency.

This is a pretty trivial change, so I don't _think_ a contributor agreement is necessary.