### PR TITLE
Add note about x- headers

### DIFF
--- a/site/tutorials/amqp-concepts.xml
+++ b/site/tutorials/amqp-concepts.xml
@@ -299,6 +299,8 @@ limitations under the License.
                  hash (dictionary) for example.
                </p>
                <p>
+                 Note that headers beginning with the string <code>x-</code>
+                 will not be used to evaluate matches.
                </p>
                </doc:subsection>
             </doc:section>


### PR DESCRIPTION
`x-*` headers are not used for matching.

Fixes #701