### PR TITLE
Removing duplicate "the the" occurrences.

### DIFF
--- a/site/how.xml
+++ b/site/how.xml
@@ -498,7 +498,7 @@ limitations under the License.
     </li>
     <li>
       <a href="http://bunnyamqp.wordpress.com/">Of Bunny and AMQP</a><br />
-      The blog of Chris Duncan, author the the Bunny AMQP client for Ruby. Good place
+      The blog of Chris Duncan, author of the Bunny AMQP client for Ruby. Good place
       to look if you're using AMQP with Ruby.
     </li>
     <li>
@@ -567,7 +567,7 @@ limitations under the License.
     <li>
       <a href="http://hpts.ws/papers/2009/session5/das.pdf">Advanced Message Queueing Protocol</a><br />
       Presentation from Pranta Das from Cisco giving a good background on AMQP, an
-      overview of the the new information model in AMQP 1.0 and some general use
+      overview of the new information model in AMQP 1.0 and some general use
       cases for AMQP messaging.
     </li>
     <li>

--- a/site/logging.md
+++ b/site/logging.md
@@ -32,7 +32,7 @@ Starting with 3.7.0, RabbitMQ uses a single log file by default.
 
 Please see the [File and Directory Location](/relocate.html) guide to find default log file location for various platforms.
 
-There are two ways to configure log file location. One is the [configuration file](/configure.html). The other is the the `RABBITMQ_LOGS` environment variable. Use [RabbitMQ management UI](/management.html) or `[rabbitmqctl](/cli.html) environment` to find when a node stores its log file(s).
+There are two ways to configure log file location. One is the [configuration file](/configure.html). The other is the `RABBITMQ_LOGS` environment variable. Use [RabbitMQ management UI](/management.html) or `[rabbitmqctl](/cli.html) environment` to find when a node stores its log file(s).
 
 The `RABBITMQ_LOGS` variable value can be either a file path or a hyphen (`-`), which means all log
 messages will be printed to standard output.

--- a/site/management.xml
+++ b/site/management.xml
@@ -113,7 +113,7 @@ rabbitmq-plugins enable rabbitmq_management
         <doc:subsection name="usage-highlights">
           <doc:heading>Notable Features</doc:heading>
           <p>
-            The management UI is implemented as a single page application which relies on the the <a href="#http-api">HTTP API</a>.
+            The management UI is implemented as a single page application which relies on the <a href="#http-api">HTTP API</a>.
             Some of the features include:
 
             <ul>

--- a/site/memory.xml
+++ b/site/memory.xml
@@ -88,7 +88,7 @@ limitations under the License.
         <pre class="lang-ini">vm_memory_high_watermark.absolute = 1073741824</pre>
         Same example, but using memory units:
         <pre class="lang-ini">vm_memory_high_watermark.absolute = 1024MB</pre>
-        Same example using the the <a href="/configure.html#erlang-term-config-file">classic config format</a>:
+        Same example using the <a href="/configure.html#erlang-term-config-file">classic config format</a>:
         <pre class="lang-erlang">[{rabbit, [{vm_memory_high_watermark, {absolute, 1073741824}}]}].</pre>
         Using memory units:
         <pre class="lang-erlang">[{rabbit, [{vm_memory_high_watermark, {absolute, "1024MiB"}}]}].</pre>

--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -1545,7 +1545,7 @@ ssl_options.honor_cipher_order = true
 ssl_options.honor_ecc_order    = true
 </pre>
 
-          In the the <a href="/configure.html#erlang-term-config-file">classic config format</a>:
+          In the <a href="/configure.html#erlang-term-config-file">classic config format</a>:
 
 <pre class="lang-erlang">
 %% list allowed ciphers

--- a/site/tutorials/amqp-concepts.xml
+++ b/site/tutorials/amqp-concepts.xml
@@ -23,7 +23,7 @@ limitations under the License.
         <doc:section name="about-this-guide">
         <doc:heading>About This Guide</doc:heading>
             <p>
-              This guide provides an overview of the the AMQP 0-9-1 protocol, one of the protocols
+              This guide provides an overview of the AMQP 0-9-1 protocol, one of the protocols
               supported by RabbitMQ.
             </p>
            </doc:section>

--- a/site/tutorials/tutorial-three-dotnet.md
+++ b/site/tutorials/tutorial-three-dotnet.md
@@ -130,7 +130,7 @@ queues it knows. And that's exactly what we need for our logger.
 >                          body: body);
 > </pre>
 >
-> The first parameter is the the name of the exchange.
+> The first parameter is the name of the exchange.
 > The empty string denotes the default or _nameless_ exchange: messages are
 > routed to the queue with the name specified by `routingKey`, if it exists.
 

--- a/site/tutorials/tutorial-three-elixir.md
+++ b/site/tutorials/tutorial-three-elixir.md
@@ -124,7 +124,7 @@ queues it knows. And that's exactly what we need for our logger.
 >     AMQP.Basic.publish(channel, "", "hello", message)
 > </pre>
 >
-> The [second parameter](http://hexdocs.pm/amqp/AMQP.Basic.html#publish/5) is the the name of the exchange.
+> The [second parameter](http://hexdocs.pm/amqp/AMQP.Basic.html#publish/5) is the name of the exchange.
 > The empty string denotes the default or _nameless_ exchange: messages are
 > routed to the queue with the name specified by `routing_key`, if it exists.
 

--- a/site/tutorials/tutorial-three-java.md
+++ b/site/tutorials/tutorial-three-java.md
@@ -124,7 +124,7 @@ queues it knows. And that's exactly what we need for our logger.
 > channel.basicPublish("", "hello", null, message.getBytes());
 > </pre>
 >
-> The first parameter is the the name of the exchange.
+> The first parameter is the name of the exchange.
 > The empty string denotes the default or _nameless_ exchange: messages are
 > routed to the queue with the name specified by `routingKey`, if it exists.
 


### PR DESCRIPTION
Reading through the docs and came across instances where "the the" was used.