### PR TITLE
Add amiquip Rust client to devtools

### DIFF
--- a/site/devtools.xml
+++ b/site/devtools.xml
@@ -204,6 +204,9 @@ limitations under the License.
             <ul class="plain">
               <a href="https://github.com/sozu-proxy/lapin">Lapin</a>, a Rust client
             </ul>
+            <ul class="plain">
+              <a href="https://crates.io/crates/amiquip">amiquip</a>, a RabbitMQ client written in pure Rust
+            </ul>
           </doc:section>
 
           <doc:section name="alt-jvm-dev">


### PR DESCRIPTION
Hi! I'm the author of amiquip, and was wondering if it could be added to the devtools list of third-party clients. The biggest difference between it and lapin is that lapin is written for futures, and amiquip is not; there are several other less significant differences, of course.

Thanks!