### PR TITLE
Update the example code

### DIFF
--- a/site/tutorials/tutorial-five-javascript.md
+++ b/site/tutorials/tutorial-five-javascript.md
@@ -161,19 +161,30 @@ The code for `emit_log_topic.js`:
 
 var amqp = require('amqplib/callback_api');
 
-amqp.connect('amqp://localhost', function(err, conn) {
-  conn.createChannel(function(err, ch) {
-    var ex = 'topic_logs';
+amqp.connect('amqp://localhost', function(error0, connection) {
+  if (error0) {
+    throw error0;
+  }
+  connection.createChannel(function(error1, channel) {
+    if (error1) {
+      throw error1;
+    }
+    var exchange = 'topic_logs';
     var args = process.argv.slice(2);
     var key = (args.length > 0) ? args[0] : 'anonymous.info';
     var msg = args.slice(1).join(' ') || 'Hello World!';
 
-    ch.assertExchange(ex, 'topic', {durable: false});
-    ch.publish(ex, key, new Buffer(msg));
+    channel.assertExchange(exchange, 'topic', {
+      durable: false
+    });
+    channel.publish(exchange, key, Buffer.from(msg));
     console.log(" [x] Sent %s:'%s'", key, msg);
   });
 
-  setTimeout(function() { conn.close(); process.exit(0) }, 500);
+  setTimeout(function() { 
+    conn.close(); 
+    process.exit(0) 
+  }, 500);
 });
 </pre>
 
@@ -191,22 +202,37 @@ if (args.length == 0) {
   process.exit(1);
 }
 
-amqp.connect('amqp://localhost', function(err, conn) {
-  conn.createChannel(function(err, ch) {
-    var ex = 'topic_logs';
+amqp.connect('amqp://localhost', function(error0, connection) {
+  if (error0) {
+    throw error0;
+  }
+  connection.createChannel(function(error1, channel) {
+    if (error1) {
+      throw error1;
+    }
+    var exchange = 'topic_logs';
 
-    ch.assertExchange(ex, 'topic', {durable: false});
+    channel.assertExchange(exchange, 'topic', {
+      durable: false
+    });
 
-    ch.assertQueue('', {exclusive: true}, function(err, q) {
+    channel.assertQueue('', {
+      exclusive: true
+    }, function(error2, q) {
+      if (error2) {
+        throw error2;
+      }
       console.log(' [*] Waiting for logs. To exit press CTRL+C');
 
       args.forEach(function(key) {
-        ch.bindQueue(q.queue, ex, key);
+        channel.bindQueue(q.queue, exchange, key);
       });
 
-      ch.consume(q.queue, function(msg) {
+      channel.consume(q.queue, function(msg) {
         console.log(" [x] %s:'%s'", msg.fields.routingKey, msg.content.toString());
-      }, {noAck: true});
+      }, {
+        noAck: true
+      });
     });
   });
 });

--- a/site/tutorials/tutorial-one-javascript.md
+++ b/site/tutorials/tutorial-one-javascript.md
@@ -77,15 +77,18 @@ var amqp = require('amqplib/callback_api');
 then connect to RabbitMQ server
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(error, connection) {});
+amqp.connect('amqp://localhost', function(error0, connection) {});
 </pre>
 
 Next we create a channel, which is where most of the API for getting
 things done resides:
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(error, connection) {
-  connection.createChannel(function(err, channel) {});
+amqp.connect('amqp://localhost', function(error0, connection) {
+  if (error0) {
+    throw error0;
+  }
+  connection.createChannel(function(error1, channel) {});
 });
 </pre>
 
@@ -93,15 +96,23 @@ To send, we must declare a queue for us to send to; then we can publish a messag
 to the queue:
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(error, connection) {
-  connection.createChannel(function(err, channel) {
+amqp.connect('amqp://localhost', function(error0, connection) {
+  if (error0) {
+    throw error0;
+  }
+  connection.createChannel(function(error1, channel) {
+    if (error1) {
+      throw error1;
+    }
     var queue = 'hello';
-    var message = 'Hello world';
+    var msg = 'Hello world';
 
-    channel.assertQueue(queue, {durable: false});
-    // Note: on Node 6 Buffer.from(msg) should be used
-    ch.sendToQueue(q, Buffer.from(message));
-    console.log(" [x] Sent %s", message);
+    channel.assertQueue(queue, {
+      durable: false
+    });
+
+    channel.sendToQueue(queue, Buffer.from(msg));
+    console.log(" [x] Sent %s", msg);
   });
 });
 </pre>
@@ -113,7 +124,10 @@ whatever you like there.
 Lastly, we close the connection and exit;
 
 <pre class="lang-javascript">
-setTimeout(function() { connection.close(); process.exit(0) }, 500);
+setTimeout(function() { 
+  connection.close(); 
+  process.exit(0) 
+  }, 500);
 </pre>
 
 [Here's the whole send.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/send.js).
@@ -153,11 +167,19 @@ channel, and declare the queue from which we're going to consume.
 Note this matches up with the queue that `sendToQueue` publishes to.
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(error, connection) {
-  connection.createChannel(function(err, channel) {
+amqp.connect('amqp://localhost', function(error0, connection) {
+  if (error0) {
+    throw error0;
+  }
+  connection.createChannel(function(error1, channel) {
+    if (error1) {
+      throw error1;
+    }
     var queue = 'hello';
 
-    channel.assertQueue(queue, {durable: false});
+    channel.assertQueue(queue, {
+      durable: false
+    });
   });
 });
 </pre>
@@ -172,10 +194,12 @@ callback that will be executed when RabbitMQ pushes messages to
 our consumer. This is what `Channel.consume` does.
 
 <pre class="lang-javascript">
-console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", q);
+console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", queue);
 channel.consume(queue, function(msg) {
   console.log(" [x] Received %s", msg.content.toString());
-}, {noAck: true});
+}, {
+    noAck: true
+  });
 </pre>
 
 [Here's the whole receive.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive.js).

--- a/site/tutorials/tutorial-one-javascript.md
+++ b/site/tutorials/tutorial-one-javascript.md
@@ -77,15 +77,15 @@ var amqp = require('amqplib/callback_api');
 then connect to RabbitMQ server
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(err, conn) {});
+amqp.connect('amqp://localhost', function(error, connection) {});
 </pre>
 
 Next we create a channel, which is where most of the API for getting
 things done resides:
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(err, conn) {
-  conn.createChannel(function(err, ch) {});
+amqp.connect('amqp://localhost', function(error, connection) {
+  connection.createChannel(function(err, channel) {});
 });
 </pre>
 
@@ -93,14 +93,15 @@ To send, we must declare a queue for us to send to; then we can publish a messag
 to the queue:
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(err, conn) {
-  conn.createChannel(function(err, ch) {
-    var q = 'hello';
+amqp.connect('amqp://localhost', function(error, connection) {
+  connection.createChannel(function(err, channel) {
+    var queue = 'hello';
+    var message = 'Hello world';
 
-    ch.assertQueue(q, {durable: false});
+    channel.assertQueue(queue, {durable: false});
     // Note: on Node 6 Buffer.from(msg) should be used
-    ch.sendToQueue(q, new Buffer('Hello World!'));
-    console.log(" [x] Sent 'Hello World!'");
+    ch.sendToQueue(q, Buffer.from(message));
+    console.log(" [x] Sent %s", message);
   });
 });
 </pre>
@@ -112,7 +113,7 @@ whatever you like there.
 Lastly, we close the connection and exit;
 
 <pre class="lang-javascript">
-setTimeout(function() { conn.close(); process.exit(0) }, 500);
+setTimeout(function() { connection.close(); process.exit(0) }, 500);
 </pre>
 
 [Here's the whole send.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/send.js).
@@ -152,11 +153,11 @@ channel, and declare the queue from which we're going to consume.
 Note this matches up with the queue that `sendToQueue` publishes to.
 
 <pre class="lang-javascript">
-amqp.connect('amqp://localhost', function(err, conn) {
-  conn.createChannel(function(err, ch) {
-    var q = 'hello';
+amqp.connect('amqp://localhost', function(error, connection) {
+  connection.createChannel(function(err, channel) {
+    var queue = 'hello';
 
-    ch.assertQueue(q, {durable: false});
+    channel.assertQueue(queue, {durable: false});
   });
 });
 </pre>
@@ -172,7 +173,7 @@ our consumer. This is what `Channel.consume` does.
 
 <pre class="lang-javascript">
 console.log(" [*] Waiting for messages in %s. To exit press CTRL+C", q);
-ch.consume(q, function(msg) {
+channel.consume(queue, function(msg) {
   console.log(" [x] Received %s", msg.content.toString());
 }, {noAck: true});
 </pre>


### PR DESCRIPTION
In order to understand more when learning RabbitMQ, we could enhance the variables' names to get a clear vision about different element and the relation between them.
So, instead of declaring `q` we could name it `queue` which is more expressive and helps a person to get the info and understand the principle faster.