### PR TITLE
Prometheus exporter docs: Add mgmt prefix note

### DIFF
--- a/site/prometheus.md
+++ b/site/prometheus.md
@@ -179,6 +179,11 @@ curl --verbose http://localhost:15672/api/metrics
 If the response is similar to that in the example above, the node is exposing metrics in a way that
 Prometheus can consume and store.
 
+If you get a HTTP 404 error message, the management plugin may have
+been configured to use a custom [path prefix](https://www.rabbitmq.com/management.html#path-prefix).
+For example, if the path prefix is set to `mgmt`, the metrics will be available via
+[http://localhost:15672/mgmt/api/metrics](http://localhost:15672/mgmt/api/metrics).
+
 
 ## <a id="store-metrics-in-prometheus" class="anchor" href="#store-metrics-in-prometheus">Storing Metrics in Prometheus</a>
 


### PR DESCRIPTION
This adds a note regarding the path for the metrics endpoint when using a custom `mgmt` path prefix. 