### PR TITLE
Clarifies delivery_tag index

### DIFF
--- a/site/confirms.xml
+++ b/site/confirms.xml
@@ -478,7 +478,7 @@ String consumerTag = channel.BasicConsume(queueName, false, consumer);
           not push any more deliveries on <code>Ch</code> unless at
           least one of the outstanding deliveries is acknowledged.
           When an acknowledgement frame arrives on that channel with
-          <code>delivery_tag</code> set to <code>8</code>, RabbitMQ
+          <code>delivery_tag</code> set to <code>5</code>, RabbitMQ
           will notice and deliver one more message.
         </p>
         <p>


### PR DESCRIPTION
Stumbled upon what I think is a typo regarding the prefetching window.

In the example the next unacknowledged index is `5` and not `8` (which is the last) and I assume the intention is to exemplify using `delivery_tag` set to `5`?

“Obvious Fix”