### PR TITLE
MOD: fix build error in golang tutorial code

### DIFF
--- a/site/tutorials/tutorial-five-go.md
+++ b/site/tutorials/tutorial-five-go.md
@@ -160,7 +160,6 @@ The code for `emit_log_topic.go`:
 package main
 
 import (
-        "fmt"
         "log"
         "os"
         "strings"
@@ -236,7 +235,6 @@ The code for `receive_logs_topic.go`:
 package main
 
 import (
-        "fmt"
         "log"
         "os"
 

--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -318,7 +318,6 @@ The code for `emit_log_direct.go` script:
 package main
 
 import (
-        "fmt"
         "log"
         "os"
         "strings"
@@ -394,7 +393,6 @@ The code for `receive_logs_direct.go`:
 package main
 
 import (
-        "fmt"
         "log"
         "os"
 

--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -73,7 +73,6 @@ we need to import the library first:
 package main
 
 import (
-  "fmt"
   "log"
 
   "github.com/streadway/amqp"
@@ -171,7 +170,6 @@ The code (in [`receive.go`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/
 package main
 
 import (
-  "fmt"
   "log"
 
   "github.com/streadway/amqp"

--- a/site/tutorials/tutorial-six-go.md
+++ b/site/tutorials/tutorial-six-go.md
@@ -229,7 +229,6 @@ The code for our RPC server [rpc_server.go](https://github.com/rabbitmq/rabbitmq
 package main
 
 import (
-        "fmt"
         "log"
         "strconv"
 
@@ -337,7 +336,6 @@ The code for our RPC client [rpc_client.go](https://github.com/rabbitmq/rabbitmq
 package main
 
 import (
-        "fmt"
         "log"
         "math/rand"
         "os"

--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -309,7 +309,6 @@ value is ignored for `fanout` exchanges. Here goes the code for
 package main
 
 import (
-        "fmt"
         "log"
         "os"
         "strings"
@@ -384,7 +383,6 @@ The code for `receive_logs.go`:
 package main
 
 import (
-        "fmt"
         "log"
 
         "github.com/streadway/amqp"

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -438,7 +438,6 @@ Final code of our `new_task.go` class:
 package main
 
 import (
-        "fmt"
         "log"
         "os"
         "strings"
@@ -506,7 +505,6 @@ package main
 
 import (
         "bytes"
-        "fmt"
         "github.com/streadway/amqp"
         "log"
         "time"


### PR DESCRIPTION
In golang, if the import is not used, the code will not compile successfully.
So the "fmt" in the golang sample code must be removed, then it can be compiled successfully.
