### PR TITLE
Update incorrect link to Message Ordering

### DIFF
--- a/site/queues.md
+++ b/site/queues.md
@@ -104,7 +104,7 @@ to client library but is usually an argument next to the <code>durable</code>,
 declares queues.
 
 
-## <a id="server-named-queues" class="anchor" href="#server-named-queues">Message Ordering</a>
+## <a id="message-ordering" class="anchor" href="#message-ordering">Message Ordering</a>
 
 Queues in RabbitMQ are ordered collections of messages. Messages
 are enqueued and dequeued (consumed) in the [FIFO manner](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)),


### PR DESCRIPTION
Update an incorrect link to the _Message Ordering_ section in the queues.md page.

Reading briefly about the master -> stable -> live branch hierarchy, it seems the master branch was the correct branch to merge into. If there are any problems with my PR I would be glad to close this and create a new one.

Thanks!