### PR TITLE
Add note about expiring queues to DLX documentation

### DIFF
--- a/site/dlx.xml
+++ b/site/dlx.xml
@@ -38,6 +38,10 @@ limitations under the License.
       </p>
 
       <p>
+        Messages from <a href="/ttl.html#queue-ttl">an expiring queue</a> are not dead-lettered.
+      </p>
+
+      <p>
         Dead letter exchanges (DLXs) are normal exchanges. They can be
         any of the usual types and are declared as usual.
       </p>


### PR DESCRIPTION
The current DLX documentation states that a message will be dead-lettered when:

> The message expires due to TTL;

This statement is ambiguous, as this only applies to messages that expire due to a `message-ttl` argument. Messages on a queue that `expires` are not dead-lettered.

A PR ["Expiring queues should dead-letter messages when a dead-letter-exchange is defined"](https://github.com/rabbitmq/rabbitmq-server/pull/29) was closed, but the limitation it addresses is not currently mentioned in the documentation. 