### PR TITLE
Use queue name as a parameter in sendToQueue

### DIFF
--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -301,7 +301,7 @@ even if RabbitMQ restarts. Now we need to mark our messages as persistent
 - by using the `persistent` option `Channel.sendToQueue` takes.
 
 <pre class="lang-javascript">
-channel.sendToQueue(q, Buffer.from(msg), {persistent: true});
+channel.sendToQueue(queue, Buffer.from(msg), {persistent: true});
 </pre>
 
 > #### Note on message persistence


### PR DESCRIPTION
This PR adds minor change in NodeJS example. To keep up with the tutorial parameters naming and to be more easier for beginners, the sendToQueue `q` parameter is renamed to follow the naming `queue` as in the whole tutorial.