### PR TITLE
replace `new Buffer` with `Buffer.from`

### DIFF
--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -82,7 +82,7 @@ var msg = process.argv.slice(2).join(' ') || "Hello World!";
 channel.assertQueue(queue, {
   durable: true
 });
-channel.sendToQueue(queue, new Buffer(msg), {
+channel.sendToQueue(queue, Buffer.from(msg), {
   persistent: true
 });
 console.log(" [x] Sent '%s'", msg);


### PR DESCRIPTION
Maintains consistency with Part1 and uses current Buffer API instead of `new Buffer`, which is deprecated