### PR TITLE
Fix wrong CA certificate name in ssl manual certificate generation guide

### DIFF
--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -1933,7 +1933,7 @@ default_ca = testca
 
 [ testca ]
 dir = .
-certificate = $dir/cacertificate.pem
+certificate = $dir/ca_certificate_bundle.pem
 database = $dir/index.txt
 new_certs_dir = $dir/certs
 private_key = $dir/private/ca_private_key.pem


### PR DESCRIPTION
The CA certificate name specified in openssl.cnf was different from the one in the openssl commands and thus led to errors.