### PR TITLE
Review x509 file names used in docs

### DIFF
--- a/site/configure.md
+++ b/site/configure.md
@@ -210,7 +210,7 @@ The new format is easier to generate deployment automation tools.
 Compare
 
 <pre class="sourcecode">
-ssl_options.cacertfile           = /path/to/testca/cacert.pem
+ssl_options.cacertfile           = /path/to/ca_certificate.pem
 ssl_options.certfile             = /path/to/server_certificate.pem
 ssl_options.keyfile              = /path/to/server_key.pem
 ssl_options.verify               = verify_peer
@@ -221,7 +221,7 @@ with
 
 <pre class="sourcecode">
 [
-  {rabbit, [{ssl_options, [{cacertfile,           "/path/to/testca/cacert.pem"},
+  {rabbit, [{ssl_options, [{cacertfile,           "/path/to/ca_certificate.pem"},
                            {certfile,             "/path/to/server_certificate.pem"},
                            {keyfile,              "/path/to/server_key.pem"},
                            {verify,               verify_peer},

--- a/site/ldap.xml
+++ b/site/ldap.xml
@@ -300,7 +300,7 @@ auth_ldap.use_ssl   = true
 <pre class="lang-erlang">
 [
   {rabbitmq_auth_backend_ldap, [
-     {ssl_options, [{cacertfile,"/path/to/testca/cacert.pem"},
+     {ssl_options, [{cacertfile,"/path/to/ca_certificate.pem"},
                     {certfile,"/path/to/server_certificate.pem"},
                     {keyfile,"/path/to/server_key.pem"},
                     {verify, verify_peer},
@@ -316,7 +316,7 @@ auth_ldap.use_ssl   = true
 [
   {rabbitmq_auth_backend_ldap, [
      {use_ssl,     true},
-     {ssl_options, [{cacertfile, "/path/to/testca/cacert.pem"},
+     {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
                     {certfile,   "/path/to/server_certificate.pem"},
                     {keyfile,    "/path/to/server_key.pem"},
                     {verify,               verify_peer},

--- a/site/logging.md
+++ b/site/logging.md
@@ -283,9 +283,9 @@ log.syslog = true
 log.syslog.transport = tls
 log.syslog.protocol = rfc5424
 
-log.syslog.ssl_options.cacertfile = /path/to/tls/cacert.pem
-log.syslog.ssl_options.certfile = /path/to/tls/cert.pem
-log.syslog.ssl_options.keyfile = /path/to/tls/key.pem
+log.syslog.ssl_options.cacertfile = /path/to/ca_certificate.pem
+log.syslog.ssl_options.certfile = /path/to/client_certificate.pem
+log.syslog.ssl_options.keyfile = /path/to/client_key.pem
 </pre>
 
 In the classic config format:
@@ -293,9 +293,9 @@ In the classic config format:
 <pre class="lang-erlang">
 [{rabbit, [{log, [{syslog, [{enabled, true}]}]}]},
  {syslog, [{protocol, {tls, rfc5424,
-                        [{cacertfile,"/path/to/tls/cacert.pem"},
-                         {certfile,"/path/to/tls/cert.pem"},
-                         {keyfile,"/path/to/tls/key.pem"}]}}]}
+                        [{cacertfile,"/path/to/ca_certificate.pem"},
+                         {certfile,"/path/to/client_certificate.pem"},
+                         {keyfile,"/path/to/client_key.pem"}]}}]}
 ].
 </pre>
 

--- a/site/management.xml
+++ b/site/management.xml
@@ -399,9 +399,9 @@ management.ssl.keyfile    = /path/to/server_key.pem
 [{rabbitmq_management,
   [{listener, [{port,     15671},
                {ssl,      true},
-               {ssl_opts, [{cacertfile, "/path/to/cacert.pem"},
-                           {certfile,   "/path/to/cert.pem"},
-                           {keyfile,    "/path/to/key.pem"}]}
+               {ssl_opts, [{cacertfile, "/path/to/ca_certificate.pem"},
+                           {certfile,   "/path/to/server_certificate.pem"},
+                           {keyfile,    "/path/to/server_key.pem"}]}
               ]}
   ]}
 ].</pre>
@@ -448,7 +448,7 @@ management.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
     [
      {listener, [{port,     15671},
                  {ssl,      true},
-                 {ssl_opts, [{cacertfile, "/path/to/ca_certificate_bundle.pem"},
+                 {ssl_opts, [{cacertfile, "/path/to/ca_certificate.pem"},
                              {certfile,   "/path/to/server_certificate.pem"},
                              {keyfile,    "/path/to/server_key.pem"},
 
@@ -492,9 +492,9 @@ management.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
 management.tcp.port       = 15672
 
 management.ssl.port       = 15671
-management.ssl.cacertfile = /path/to/cacert.pem
-management.ssl.certfile   = /path/to/cert.pem
-management.ssl.keyfile    = /path/to/key.pem
+management.ssl.cacertfile = /path/to/ca_certificate.pem
+management.ssl.certfile   = /path/to/server_certificate.pem
+management.ssl.keyfile    = /path/to/server_key.pem
 </pre>
           </p>
 
@@ -941,9 +941,9 @@ management.listener.port = 15672
 management.listener.ip   = 0.0.0.0
 management.listener.ssl  = true
 
-management.listener.ssl_opts.cacertfile = /path/to/cacert.pem
-management.listener.ssl_opts.certfile   = /path/to/cert.pem
-management.listener.ssl_opts.keyfile    = /path/to/key.pem
+management.listener.ssl_opts.cacertfile = /path/to/ca_certificate.pem
+management.listener.ssl_opts.certfile   = /path/to/server_certificate.pem
+management.listener.ssl_opts.keyfile    = /path/to/server_key.pem
 
 management.http_log_dir = /path/to/rabbit/logs/http
 
@@ -985,9 +985,9 @@ management.sample_retention_policies.detailed.10 = 5
    %% {listener, [{port,     15672},
    %%             {ip,       "0.0.0.0"},
    %%             {ssl,      true},
-   %%             {ssl_opts, [{cacertfile, "/path/to/cacert.pem"},
-   %%                         {certfile,   "/path/to/cert.pem"},
-   %%                         {keyfile,    "/path/to/key.pem"}]}]},
+   %%             {ssl_opts, [{cacertfile, "/path/to/ca_certificate.pem"},
+   %%                         {certfile,   "/path/to/server_certificate.pem"},
+   %%                         {keyfile,    "/path/to/server_key.pem"}]}]},
 
    %% One of 'basic', 'detailed' or 'none'.
    {rates_mode, basic},

--- a/site/mqtt.md
+++ b/site/mqtt.md
@@ -284,9 +284,9 @@ The plugin will use core RabbitMQ server
 certificates and key (just like AMQP 0-9-1 and AMQP 1.0 listeners do):
 
 <pre class="lang-ini">
-ssl_options.cacertfile = /path/to/tls/ca_certificate_bundle.pem
-ssl_options.certfile   = /path/to/tls/server_certificate.pem
-ssl_options.keyfile    = /path/to/tls/server_key.pem
+ssl_options.cacertfile = /path/to/ca_certificate.pem
+ssl_options.certfile   = /path/to/server_certificate.pem
+ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert  = true
 
@@ -299,9 +299,9 @@ Or using the <a href="/configure.html#erlang-term-config-file">classic config fo
 
 <pre class="lang-erlang">
 [{rabbit,        [
-                  {ssl_options, [{cacertfile, "/path/to/tls/ca_certificate_bundle.pem"},
-                                 {certfile,   "/path/to/tls/server_certificate.pem"},
-                                 {keyfile,    "/path/to/tls/server_key.pem"},
+                  {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
+                                 {certfile,   "/path/to/server_certificate.pem"},
+                                 {keyfile,    "/path/to/server_key.pem"},
                                  {verify,     verify_peer},
                                  {fail_if_no_peer_cert, true}]}
                  ]},

--- a/site/release-notes/3.7.9.md
+++ b/site/release-notes/3.7.9.md
@@ -122,9 +122,9 @@ See the [Upgrading guide](http://www.rabbitmq.com/upgrade.html) for general docu
    management.tcp.port = 15672
 
    management.ssl.port = 15671
-   management.ssl.cacertfile = /path/to/cacert.pem
-   management.ssl.certfile = /path/to/cert.pem
-   management.ssl.keyfile = /path/to/key.pem   
+   management.ssl.cacertfile = /path/to/ca_certificate.pem
+   management.ssl.certfile = /path/to/server_certificate.pem
+   management.ssl.keyfile = /path/to/server_key.pem   
    ```
 
    GitHub issue: [rabbitmq/rabbitmq-management#563](https://github.com/rabbitmq/rabbitmq-management/issues/563)

--- a/site/ssl.xml
+++ b/site/ssl.xml
@@ -337,7 +337,7 @@ ls -l ./result
 <pre class="lang-ini">
 listeners.ssl.default = 5671
 
-ssl_options.cacertfile = /path/to/ca_certificate_bundle.pem
+ssl_options.cacertfile = /path/to/ca_certificate.pem
 ssl_options.certfile   = /path/to/server_certificate.pem
 ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.verify     = verify_peer
@@ -350,7 +350,7 @@ Below is the same example using the <a href="/configure.html#erlang-term-config-
 [
   {rabbit, [
      {ssl_listeners, [5671]},
-     {ssl_options, [{cacertfile, "/path/to/ca_certificate_bundle.pem"},
+     {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
                     {certfile,   "/path/to/server_certificate.pem"},
                     {keyfile,    "/path/to/server_key.pem"},
                     {verify,     verify_peer},
@@ -372,8 +372,8 @@ Below is the same example using the <a href="/configure.html#erlang-term-config-
             <b>Note to Windows users:</b> backslashes ("\") in the
             configuration file are interpreted as escape sequences -
             so for example to specify the
-            path <code>c:\ca_certificate_bundle.pem</code> for the CA certificate you
-            would need to use <code>"c:\\ca_certificate_bundle.pem"</code> or <code>"c:/ca_certificate_bundle.pem"</code>.
+            path <code>c:\ca_certificate.pem</code> for the CA certificate you
+            would need to use <code>"c:\\ca_certificate.pem"</code> or <code>"c:/ca_certificate.pem"</code>.
           </p>
         </doc:subsection>
 
@@ -543,7 +543,7 @@ ssl_options.password   = t0p$3kRe7
             is to simply concatenate them:
 
 <pre class="lang-bash">
-cat rootca/ca_certificate_bundle.pem otherca/ca_certificate_bundle.pem &gt; all_cacerts.pem
+cat rootca/ca_certificate_bundle.pem otherca/ca_certificate.pem &gt; all_cacerts.pem
 </pre>
           </p>
         </doc:subsection>
@@ -571,7 +571,7 @@ cat rootca/ca_certificate_bundle.pem otherca/ca_certificate_bundle.pem &gt; all_
 <pre class="lang-ini">
 listeners.ssl.default = 5671
 
-ssl_options.cacertfile = /path/to/ca_certificate_bundle.pem
+ssl_options.cacertfile = /path/to/ca_certificate.pem
 ssl_options.certfile = /path/to/server_certificate.pem
 ssl_options.keyfile = /path/to/server_key.pem
 ssl_options.verify = verify_peer
@@ -584,7 +584,7 @@ ssl_options.fail_if_no_peer_cert = true
 [
 {rabbit, [
    {ssl_listeners, [5671]},
-   {ssl_options, [{cacertfile,"/path/to/ca_certificate_bundle.pem"},
+   {ssl_options, [{cacertfile,"/path/to/ca_certificate.pem"},
                   {certfile,"/path/to/server_certificate.pem"},
                   {keyfile,"/path/to/server_key.pem"},
                   {verify, verify_peer},
@@ -653,7 +653,7 @@ ssl_options.fail_if_no_peer_cert = true
 <pre class="lang-ini">
 listeners.ssl.default = 5671
 
-ssl_options.cacertfile = /path/to/ca_certificate_bundle.pem
+ssl_options.cacertfile = /path/to/ca_certificate.pem
 ssl_options.certfile = /path/to/server_certificate.pem
 ssl_options.keyfile = /path/to/server_key.pem
 ssl_options.verify = verify_peer
@@ -667,7 +667,7 @@ ssl_options.fail_if_no_peer_cert = false
 [
   {rabbit, [
      {ssl_listeners, [5671]},
-     {ssl_options, [{cacertfile,"/path/to/ca_certificate_bundle.pem"},
+     {ssl_options, [{cacertfile,"/path/to/ca_certificate.pem"},
                     {certfile,"/path/to/server_certificate.pem"},
                     {keyfile,"/path/to/server_key.pem"},
                     {depth, 2},
@@ -1933,7 +1933,7 @@ default_ca = testca
 
 [ testca ]
 dir = .
-certificate = $dir/ca_certificate_bundle.pem
+certificate = $dir/ca_certificate.pem
 database = $dir/index.txt
 new_certs_dir = $dir/certs
 private_key = $dir/private/ca_private_key.pem
@@ -1992,12 +1992,12 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.1
 <pre class="lang-bash">
 openssl req -x509 -config openssl.cnf -newkey rsa:2048 -days 365 \
     -out ca_certificate_bundle.pem -outform PEM -subj /CN=MyTestCA/ -nodes
-openssl x509 -in ca_certificate_bundle.pem -out ca_certificate_bundle.cer -outform DER
+openssl x509 -in ca_certificate.pem -out ca_certificate.cer -outform DER
 </pre>
 
           <p>
             This is all that is needed to generate a test Certificate
-            Authority. The root certificate is in <code>ca_certificate_bundle.pem</code>
+            Authority. The root certificate is in <code>ca_certificate.pem</code>
             and is also in <code>testca/ca_certificate_bundle.cer</code>. These two files contain the
             same information, but in different formats, PEM and DER.
             Most software uses the former but some tools require the latter.

--- a/site/stomp.md
+++ b/site/stomp.md
@@ -113,7 +113,7 @@ The plugin will use core RabbitMQ server
 certificates and key (just like AMQP 0-9-1 and AMQP 1.0 listeners do):
 
 <pre class="lang-ini">
-ssl_options.cacertfile = /path/to/tls/ca_certificate_bundle.pem
+ssl_options.cacertfile = /path/to/tls/ca_certificate.pem
 ssl_options.certfile   = /path/to/tls/server_certificate.pem
 ssl_options.keyfile    = /path/to/tls/server_key.pem
 ssl_options.verify     =  verify_peer
@@ -128,7 +128,7 @@ Or, using the [classic config format](/configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 [{rabbit,          [
-                    {ssl_options, [{cacertfile, "/path/to/tls/ca_certificate_bundle.pem"},
+                    {ssl_options, [{cacertfile, "/path/to/tls/ca_certificate.pem"},
                                    {certfile,   "/path/to/tls/server_certificate.pem"},
                                    {keyfile,    "/path/to/tls/server_key.pem"},
                                    {verify,     verify_peer},

--- a/site/uri-query-parameters.xml
+++ b/site/uri-query-parameters.xml
@@ -65,9 +65,9 @@ limitations under the License.
       Example (encrypted):
     </p>
 
-    <pre>amqps://myhost?cacertfile=/certs/cacert.pem
-      &amp;certfile=/certs/cert.pem
-      &amp;keyfile=/certs/key.pem
+    <pre>amqps://myhost?cacertfile=/path/to/ca_certificate.pem
+      &amp;certfile=/path/to/client_certificate.pem
+      &amp;keyfile=/path/to/client_key.pem
       &amp;verify=verify_peer
       &amp;server_name_indication=myhost
     </pre>

--- a/site/web-mqtt.md
+++ b/site/web-mqtt.md
@@ -165,9 +165,9 @@ TLS configuration parameters are provided in the `web_mqtt.ssl` section:
 <pre class="lang-ini">
 web_mqtt.ssl.port       = 15673
 web_mqtt.ssl.backlog    = 1024
-web_mqtt.ssl.certfile   = /path/to/server/certificate.pem
-web_mqtt.ssl.keyfile    = /path/to/server/private_key.pem
-web_mqtt.ssl.cacertfile = /path/to/testca/ca_certificate_bundle.pem
+web_mqtt.ssl.cacertfile = /path/to/ca_certificate.pem
+web_mqtt.ssl.certfile   = /path/to/server_certificate.pem
+web_mqtt.ssl.keyfile    = /path/to/server_key.pem
 # needed when private key has a passphrase
 # web_mqtt.ssl.password   = changeme
 </pre>
@@ -180,9 +180,9 @@ section is `rabbitmq_web_mqtt.ssl_config`:
   {rabbitmq_web_mqtt,
       [{ssl_config, [{port,       15673},
                      {backlog,    1024},
-                     {certfile,   "/path/to/server/certificate.pem"},
-                     {keyfile,    "/path/to/server/private_key.pem"},
-                     {cacertfile, "/path/to/testca/ca_certificate_bundle.pem"}
+                     {cacertfile, "/path/to/ca_certificate.pem"}
+                     {certfile,   "/path/to/server_certificate.pem"},
+                     {keyfile,    "/path/to/server_key.pem"}
                      %% needed when private key has a passphrase
                      %% , {password,   "changeme"}
                     ]}]}
@@ -210,9 +210,9 @@ and a number of other [TLS options](/ssl.html) for the Web MQTT plugin:
 <pre class="lang-erlang">
 {rabbitmq_web_mqtt,
   [{ssl_config,
-    [{cacertfile,           "/path/to/testca/ca_certificate_bundle.pem"},
-     {certfile,             "/path/to/server/certificate.pem"},
-     {keyfile,              "/path/to/server/private_key.pem"},
+    [{cacertfile,           "/path/to/ca_certificate.pem"},
+     {certfile,             "/path/to/server_certificate.pem"},
+     {keyfile,              "/path/to/server_key.pem"},
      {verify,               verify_peer},
      {fail_if_no_peer_cert, true},
      {versions,             ['tlsv1.2']},

--- a/site/web-stomp.md
+++ b/site/web-stomp.md
@@ -153,9 +153,9 @@ TLS configuration parameters are provided in the `web_stomp.ssl` section:
 <pre class="lang-ini">
 web_stomp.ssl.port       = 15673
 web_stomp.ssl.backlog    = 1024
-web_stomp.ssl.certfile   = /path/to/server/certificate.pem
-web_stomp.ssl.keyfile    = /path/to/server/private_key.pem
-web_stomp.ssl.cacertfile = /path/to/testca/ca_certificate_bundle.pem
+web_stomp.ssl.cacertfile = /path/to/ca_certificate.pem
+web_stomp.ssl.certfile   = /path/to/server_certificate.pem
+web_stomp.ssl.keyfile    = /path/to/server_key.pem
 web_stomp.ssl.password   = changeme
 </pre>
 
@@ -167,9 +167,9 @@ section is `rabbitmq_web_stomp.ssl_config`:
   {rabbitmq_web_stomp,
       [{ssl_config, [{port,       15673},
                      {backlog,    1024},
-                     {certfile,   "/path/to/server/certificate.pem"},
-                     {keyfile,    "/path/to/server/private_key.pem"},
-                     {cacertfile, "/path/to/testca/ca_certificate_bundle.pem"},
+                     {cacertfile, "/path/to/ca_certificate.pem"},
+                     {certfile,   "/path/to/server_certificate.pem"},
+                     {keyfile,    "/path/to/server_key.pem"},
                      %% needed when private key has a passphrase
                      {password,   "changeme"}]}]}
 ].


### PR DESCRIPTION
Consistently use file names that would be generated by https://github.com/michaelklishin/tls-gen.git

[166742920]

See #785 too