### PR TITLE
Docs: Correct syntax to get a message with no requeue

### DIFF
--- a/site/management-cli.md
+++ b/site/management-cli.md
@@ -170,7 +170,7 @@ rabbitmqadmin publish exchange=amq.default routing_key=test payload="hello, worl
 ### And get it back
 
 <pre class="lang-bash">
-rabbitmqadmin get queue=test requeue=false
+rabbitmqadmin get queue=test ackmode=ack_requeue_false
 # => +-------------+----------+---------------+--------------+------------------+-------------+
 # => | routing_key | exchange | message_count |   payload    | payload_encoding | redelivered |
 # => +-------------+----------+---------------+--------------+------------------+-------------+


### PR DESCRIPTION
As mentioned in this discussion:

https://github.com/rabbitmq/rabbitmq-management/issues/521#issuecomment-504917401

By the way, are there any (separate) docs for the rabbitmqadmin python app? Have you considered releasing the app to pypi.org; and maintaining documentation on e.g read-the-docs?