### PR TITLE
Avoid using keyserver in shell snippet

### DIFF
--- a/site/install-debian.xml
+++ b/site/install-debian.xml
@@ -493,7 +493,7 @@ wget -O - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | sudo apt-k
 #!/bin/sh
 
 ## Install RabbitMQ signing key
-sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
+curl -fsSL https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc | sudo apt-key add -
 
 ## Install apt HTTPS transport
 sudo apt-get install apt-transport-https


### PR DESCRIPTION
Avoid using keyserver in shell snippet (as already done in https://github.com/rabbitmq/rabbitmq-website/commit/399453e29fa192fa6d2d3e545b55534db5ac3f3a).