### PR TITLE
Typo fix in 2nd python tutorial

### DIFF
--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -341,7 +341,7 @@ to the n-th consumer.
   </div>
 </div>
 
-In order to defeat that we can use the `basic.qos` method with the
+In order to defeat that we can use the `basic_qos` method with the
 `prefetch_count=1` setting. This tells RabbitMQ not to give more than
 one message to a worker at a time. Or, in other words, don't dispatch
 a new message to a worker until it has processed and acknowledged the


### PR DESCRIPTION
Update the second tutorial on python. The correct name of the method is `basic_qos`