### PR TITLE
Rename all 'AuthoriSation' words to 'AuthoriZation'

### DIFF
--- a/site/access-control.md
+++ b/site/access-control.md
@@ -15,17 +15,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Authentication, Authorisation, Access Control
+# Authentication, Authorization, Access Control
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This document describes [authentication](#authentication) and [authorisation](#authorisation) features
+This document describes [authentication](#authentication) and [authorization](#authorization) features
 in RabbitMQ. Together they allow the operator to control access to the system.
 Different users can be granted access only to specific [virtual hosts](/vhosts.html). Their
 permissions in each virtual hosts also can be limited.
 
 RabbitMQ supports two major [authentication mechanisms](#mechanisms)
-as well as several [authentication and authorisation backends](#backends).
+as well as several [authentication and authorization backends](#backends).
 
 [Password-based](/passwords.html) authentication has a companion guide.
 A closely related topic of [TLS support](/ssl.html) is also covered in a dedicated guide.
@@ -34,16 +34,16 @@ Other topics discussed in this guide include:
 
  * [Default virtual host and user](#default-state)
  * [Connectivity limitations](#loopback-users) imposed on the default user
- * Troubleshooting of [authentication](#troubleshooting-authn) and [authorisation failures](#troubleshooting-authz)
+ * Troubleshooting of [authentication](#troubleshooting-authn) and [authorization failures](#troubleshooting-authz)
 
 
 ## <a id="terminology-and-definitions" class="anchor" href="#terminology-and-definitions">Terminology and Definitions</a>
 
-Authentication and authorisation are often confused or used
+Authentication and authorization are often confused or used
 interchangeably. That's wrong and in RabbitMQ, the two are
 separated. For the sake of simplicity, we'll define
 authentication as "identifying who the user is" and
-authorisation as "determining what the user is and isn't
+authorization as "determining what the user is and isn't
 allowed to do."
 
 
@@ -65,7 +65,7 @@ to reasonably secure generated value that won't be known to the public.
 
 After an application connects to RabbitMQ and before it can perform operations, it must
 authenticate, that is, present and prove its identity. With that identity, RabbitMQ nodes can
-look up its permissions and [authorize](#authorisation) access to resources
+look up its permissions and [authorize](#authorization) access to resources
 such as [virtual hosts](/vhosts.html), queues, exchanges, and so on.
 
 Two primary ways of authenticating a client are [username/password pairs](/passwords.html)
@@ -125,7 +125,7 @@ Or, in the [classic config file format](/configure.html#erlang-term-config-file)
 </pre>
 
 
-## <a id="authorisation" class="anchor" href="#authorisation">Authorisation: How Permissions Work</a>
+## <a id="authorization" class="anchor" href="#authorization">Authorization: How Permissions Work</a>
 
 When a RabbitMQ client establishes a connection to a
 server and [authenticates](#authentication), it specifies a virtual host within which it intends
@@ -252,25 +252,25 @@ Please refer to the [management plugin guide](/management.html#permissions) to l
 more about what tags are supported and how they limit management UI access.
 
 
-## <a id="topic-authorisation" class="anchor" href="#topic-authorisation">Topic Authorisation</a>
+## <a id="topic-authorization" class="anchor" href="#topic-authorization">Topic Authorization</a>
 
-As of version 3.7.0, RabbitMQ supports topic authorisation for topic exchanges. The routing key of a message
+As of version 3.7.0, RabbitMQ supports topic authorization for topic exchanges. The routing key of a message
 published to a topic exchange is taken into account when
-publishing authorisation is enforced (e.g. in RabbitMQ default authorisation backend,
+publishing authorization is enforced (e.g. in RabbitMQ default authorization backend,
 the routing key is matched against a regular expression to decide whether the message can be
 routed downstream or not).
-Topic authorisation targets protocols like STOMP and MQTT, which are structured
+Topic authorization targets protocols like STOMP and MQTT, which are structured
 around topics and use topic exchanges under the hood.
 
-Topic authorisation is an additional layer on top of
+Topic authorization is an additional layer on top of
 existing checks for publishers. Publishing a
 message to a topic-typed exchange will go through both the
 <code>basic.publish</code> and the routing key checks.
 The latter is never called if the former refuses access.
 
-Topic authorisation can also be enforced for topic consumers.
+Topic authorization can also be enforced for topic consumers.
 Note that it works different for different protocols. The concept
-of topic authorisation only really makes sense for the topic-oriented protocols such as MQTT
+of topic authorization only really makes sense for the topic-oriented protocols such as MQTT
 and STOMP. In AMQP 0-9-1, for example, consumers consume from queues
 and thus the standard resource permissions apply. In addition for AMQP 0-9-1,
 binding routing keys between an AMQP 0-9-1 topic exchange and
@@ -279,17 +279,17 @@ For more information about how RabbitMQ handles authorization for topics, please
 the [STOMP](/stomp.html) and [MQTT](/mqtt.html)
 documentation guides.
 
-When default authorisation backend is used, publishing to a
+When default authorization backend is used, publishing to a
 topic exchange or consuming from a topic is always authorised
 if no topic permissions
 are defined (which is the case on a fresh RabbitMQ
-installation). With this authorisation backend, topic
-authorisation as optional: you don't need to whitelist any
-exchanges. To use topic authorisation therefore you need to opt in
+installation). With this authorization backend, topic
+authorization as optional: you don't need to whitelist any
+exchanges. To use topic authorization therefore you need to opt in
 and define topic permissions for one or more exchanges. For details please see
 the [rabbitmqctl man page](/rabbitmqctl.8.html).
 
-Internal (default) authorisation backend supports variable expansion
+Internal (default) authorization backend supports variable expansion
 in permission patterns.
 Three variables are supported: <code>username</code>, <code>vhost</code>,
 and `client_id`. Note that `client_id` only
@@ -297,24 +297,24 @@ applies to MQTT. For example, if `tonyg` is the
 connected user, the permission `^{username}-.*` is expanded to
 `^tonyg-.*`
 
-If a different authorisation backend (e.g. [LDAP](ldap.html),
+If a different authorization backend (e.g. [LDAP](ldap.html),
 [HTTP](https://github.com/rabbitmq/rabbitmq-auth-backend-http),
 [AMQP](https://github.com/rabbitmq/rabbitmq-auth-backend-amqp)) is used, please refer
 to the documentation of those backends.
 
-If a custom authorisation backend is used, topic
-authorisation is enforced by implementing the
+If a custom authorization backend is used, topic
+authorization is enforced by implementing the
 <code>check_topic_access</code> callback of the
 <code>rabbit_authz_backend</code> behavior.
 
 
-## <a id="backends" class="anchor" href="#backends">Alternative Authentication and Authorisation Backends</a>
+## <a id="backends" class="anchor" href="#backends">Alternative Authentication and Authorization Backends</a>
 
-Authentication and authorisation are pluggable. Plugins can provide implementations
+Authentication and authorization are pluggable. Plugins can provide implementations
 of
 
  * authentication ("authn") backends
- * authorisation ("authz") backends
+ * authorization ("authz") backends
 
 It is possible for a plugin to provide both.
 For example the internal, [LDAP](/ldap.html)
@@ -323,7 +323,7 @@ backends do so.
 
 Some plugins, for example, the <a
 href="https://github.com/gotthardp/rabbitmq-auth-backend-ip-range">Source
-IP range one</a>, only provide an authorisation backend. Authentication
+IP range one</a>, only provide an authorization backend. Authentication
 is supposed to be handled by the internal database, LDAP, etc.
 
 ### <a id="combined-backends" class="anchor" href="#combined-backends">Combining Backends</a>
@@ -335,7 +335,7 @@ several authentication backends are used then the first
 positive result returned by a backend in the chain is
 considered to be final. This should not be confused with
 mixed backends (for example, using LDAP for authentication and internal
-backend for authorisation).
+backend for authorization).
 
 The following example configures RabbitMQ to use the internal backend
 only (and is the default):
@@ -372,7 +372,7 @@ The following aliases are available:
 When using third party plugins, providing a full module name is necessary.
 
 The following example configures RabbitMQ to use the [LDAP backend](/ldap.html)
-for both authentication and authorisation. Internal database will not be consulted:
+for both authentication and authorization. Internal database will not be consulted:
 
 <pre class="lang-ini">
 auth_backends.1 = ldap
@@ -437,7 +437,7 @@ Or, in the [classic config format](/configure.html#erlang-term-config-file):
 </pre>
 
 The following example configures RabbitMQ to use the internal
-database for authentication and the [source IP range backend](https://github.com/gotthardp/rabbitmq-auth-backend-ip-range) for authorisation:
+database for authentication and the [source IP range backend](https://github.com/gotthardp/rabbitmq-auth-backend-ip-range) for authorization:
 
 <pre class="lang-ini">
 # rabbitmq.conf
@@ -457,7 +457,7 @@ Or, in the [classic config format](/configure.html#erlang-term-config-file):
 </pre>
 
 The following example configures RabbitMQ to use the [LDAP backend](/ldap.html)
-for authentication and the internal backend for authorisation:
+for authentication and the internal backend for authorization:
 
 <pre class="lang-ini">
 # rabbitmq.conf
@@ -476,7 +476,7 @@ Or, in the [classic config format](/configure.html#erlang-term-config-file):
 
 The example below is fairly advanced. It will check LDAP
 first. If the user is found in LDAP then the password will be
-checked against LDAP and subsequent authorisation checks will
+checked against LDAP and subsequent authorization checks will
 be performed against the internal database (therefore users in
 LDAP must exist in the internal database as well, but do not
 need a password there). If the user is not found in LDAP then
@@ -650,7 +650,7 @@ authentication failures will result in a visible returned error, exception or ot
 a problem used in a particular programming language or environment.
 
 
-## <a id="troubleshooting-authz" class="anchor" href="#troubleshooting-authz">Troubleshooting Authorisation</a>
+## <a id="troubleshooting-authz" class="anchor" href="#troubleshooting-authz">Troubleshooting Authorization</a>
 
 [rabbitmqctl list_permissions](/cli.html) can be used to inspect a user's
 permission in a given virtual host:

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -268,7 +268,7 @@ published separately.
         <li>Simpler, ini-style <a href="configure.html">configuration format</a></li>
         <li><a href="vhosts.html">Per-vhost limits</a></li>
         <li><a href="parameters.html">Operator policies</a></li>
-        <li><a href="access-control.html">Topic-based authorisation</a></li>
+        <li><a href="access-control.html">Topic-based authorization</a></li>
         <li>Cross-protocol <a href="shovel.html">Shovel</a> (currently supports AMQP 0.9.1 and AMQP 1.0)</li>
         <li><a href="cli.html">Command-line tools</a> are extensible via plugins</li>
         <li><a href="https://github.com/rabbitmq/rabbitmq-server/issues/567">Message store multi-tenancy</a></li>

--- a/site/community-plugins.xml
+++ b/site/community-plugins.xml
@@ -139,7 +139,7 @@ limitations under the License.
       </doc:section>
 
       <doc:section name="auth">
-        <doc:heading>Authentication / Authorisation</doc:heading>
+        <doc:heading>Authentication / Authorization</doc:heading>
 
         <table class="plugins">
           <r:plugin name="rabbitmq_auth_backend_http">
@@ -149,7 +149,7 @@ limitations under the License.
             </i>
             Provides the ability for your RabbitMQ server to perform
             authentication (determining who can log in) and
-            authorisation (determining what permissions they have)
+            authorization (determining what permissions they have)
             by making requests to an HTTP server.
             <ul>
               <li>Download for <a href="https://dl.bintray.com/rabbitmq/community-plugins/3.6.x/rabbitmq_auth_backend_http">3.6.x</a></li>
@@ -160,7 +160,7 @@ limitations under the License.
 
           <r:plugin name="rabbitmq_auth_backend_amqp">
             Provides the ability for your RabbitMQ server to perform
-            authentication and authorisation over AMQP itself.
+            authentication and authorization over AMQP itself.
             <ul>
               <li>Download for <a href="https://dl.bintray.com/rabbitmq/community-plugins/3.7.x/rabbitmq_auth_backend_amqp">3.7.x</a></li>
               <li>Download for <a href="https://dl.bintray.com/rabbitmq/community-plugins/3.6.x/rabbitmq_auth_backend_amqp">3.6.x</a></li>
@@ -174,7 +174,7 @@ limitations under the License.
 	      This plugin is not ported to RabbitMQ 3.7.x+ yet.
             </i>
             Provides the ability for your RabbitMQ server to perform
-            authorisation based on the client IP address.
+            authorization based on the client IP address.
             <ul>
               <li>Download for <a href="https://dl.bintray.com/rabbitmq/community-plugins/3.7.x/rabbitmq_auth_backend_ip_range">3.7.x</a></li>
               <li>Download for <a href="https://dl.bintray.com/rabbitmq/community-plugins/3.6.x/rabbitmq_auth_backend_ip_range">3.6.x</a></li>

--- a/site/configure.md
+++ b/site/configure.md
@@ -822,7 +822,7 @@ auth_mechanisms.2 = AMQPLAIN
     <td><code>auth_backends</code></td>
     <td>
       <p>
-        List of <a href="/access-control.html">authentication and authorisation backends</a> to
+        List of <a href="/access-control.html">authentication and authorization backends</a> to
         use. See the <a href="/access-control.html">access control guide</a> for details and examples.
       </p>
       <p>

--- a/site/ldap.xml
+++ b/site/ldap.xml
@@ -33,11 +33,11 @@ limitations under the License.
       <p>
         RabbitMQ can use LDAP to perform <a
         href="/access-control.html">authentication and
-        authorisation</a> by deferring to an external LDAP
+        authorization</a> by deferring to an external LDAP
         server. This functionality is provided by a
         plugin that ships with RabbitMQ but <a href="#enabling-the-plugin">has to be enabled</a>.
-        Authentication and authorisation operations are
-        translated into <a href="#authorisation">LDAP queries</a> configured
+        Authentication and authorization operations are
+        translated into <a href="#authorization">LDAP queries</a> configured
         by the user.
       </p>
 
@@ -60,7 +60,7 @@ limitations under the License.
 
       <p>
         This guide covers the <a href="#ldap-operation-flow">LDAP operation flow</a> used by RabbitMQ, how the LDAP model
-        <a href="#authorisation">maps to the RabbitMQ permission model</a> and what tools are available
+        <a href="#authorization">maps to the RabbitMQ permission model</a> and what tools are available
         for <a href="#troubleshooting">troubleshooting</a>.
       </p>
     </doc:section>
@@ -102,7 +102,7 @@ sudo apt-get install -y erlang-eldap
         After enabling the plugin it is necessary to configure the node to use it.
         To do so, add <code>rabbit_auth_backend_ldap</code> to the list of <code>auth_backends</code>.
         See the <a href="/access-control.html">Access Control</a> guide for an overview of authentication
-        and authorisation backends and how they are used.
+        and authorization backends and how they are used.
       </p>
 
       <p>
@@ -143,7 +143,7 @@ auth_backends.2 = internal
 
       <p>
         In example, LDAP will be used for authentication first. If the user is found in LDAP then the
-        password will be checked against LDAP and subsequent authorisation
+        password will be checked against LDAP and subsequent authorization
         checks will be performed against the internal database (therefore
         users in LDAP must exist in the internal database as well, but do not
         need a password there). If the user is not found in LDAP then a second
@@ -170,7 +170,7 @@ auth_backends.2 = internal
       <p>
         Once the plugin is enabled and its backends are wired in, a number of LDAP-specific
         settings must be configured. They include LDAP server list, authentication and
-        authorisation settings and more.
+        authorization settings and more.
       </p>
 
       <p>
@@ -392,7 +392,7 @@ auth_ldap.use_ssl   = true
                 compare attributes of and so on). An LDAP database
                 must have some entries (typically users, groups) in
                 order to be practically useful for RabbitMQ
-                authentication and authorisation.
+                authentication and authorization.
               </td>
             </tr>
           </table>
@@ -420,7 +420,7 @@ auth_ldap.use_ssl   = true
         <p>
           At this point the connection can be considered successfully negotiated and established.
           It should be possible to open a channel on it, for example. All further operations
-          performed on the connection will execute one of the authorisation queries. For example,
+          performed on the connection will execute one of the authorization queries. For example,
           declaring a queue will execute a resource access query (covered below). Publishing a
           message to a topic exchange will additionally execute a topic access query. Please refer
           to the <a href="/access-control.html">Access Control guide</a> to learn more.
@@ -567,12 +567,12 @@ auth_ldap.log = network
 
 
       <doc:subsection name="other-bind">
-        <doc:heading>Binding for Authorisation Queries</doc:heading>
+        <doc:heading>Binding for Authorization Queries</doc:heading>
 
         <p>
           For authentication this plugin binds to the LDAP server as the
           user it is trying to authenticate. The <code>other_bind</code> setting controls how to
-          bind for authorisation queries, and to retrieve the details of a
+          bind for authorization queries, and to retrieve the details of a
           user who is logging in without presenting a password (e.g. using the
           <a href="/authentication.html">EXTERNAL authentication mechanism</a>).
         </p>
@@ -637,10 +637,10 @@ auth_ldap.other_bind.password = a-password</pre>
     </doc:section>
 
 
-    <doc:section name="authorisation">
-      <doc:heading>Configuring Authorisation</doc:heading>
+    <doc:section name="authorization">
+      <doc:heading>Configuring Authorization</doc:heading>
 
-      <doc:subsection name="authorisation-overview">
+      <doc:subsection name="authorization-overview">
         <doc:heading>How RabbitMQ Permission Model Maps to LDAP</doc:heading>
 
         <p>
@@ -648,8 +648,8 @@ auth_ldap.other_bind.password = a-password</pre>
           is different from that of LDAP. In addition, the way LDAP
           schemas are used will vary from company to
           company. Therefore a mechanism that defines what LDAP
-          requests are used by the RabbitMQ authorisation functions is
-          needed. Authorisation is controlled by four configurable queries:
+          requests are used by the RabbitMQ authorization functions is
+          needed. Authorization is controlled by four configurable queries:
 
           <ul>
             <li><code>rabbitmq_auth_backend_ldap.vhost_access_query</code></li>
@@ -679,7 +679,7 @@ auth_ldap.other_bind.password = a-password</pre>
         <doc:heading>Queries and Their Types</doc:heading>
 
         <p>
-          Each query mentioned above is used at a different authorisation stage and must
+          Each query mentioned above is used at a different authorization stage and must
           evaluate to either <code>true</code> or false. Specific query types (expressions,
           e.g. value comparison or group membership check) are covered later
           in this guide.
@@ -794,7 +794,7 @@ auth_ldap.other_bind.password = a-password</pre>
           The terms configure, write and read for resource access have the
           same meanings that they do for the built-in RabbitMQ permissions
           system, see http://www.rabbitmq.com/access-control.html. See
-          also <a href="/access-control.html#topic-authorisation">topic authorisation</a>
+          also <a href="/access-control.html#topic-authorization">topic authorization</a>
           for <code>topic_access_query</code>.
         </p>
 
@@ -809,7 +809,7 @@ auth_ldap.other_bind.password = a-password</pre>
       </doc:subsection>
 
 
-      <doc:subsection name="authorisation-vhost-access">
+      <doc:subsection name="authorization-vhost-access">
         <doc:heading>Virtual Host Access</doc:heading>
 
         <p>
@@ -828,7 +828,7 @@ auth_ldap.other_bind.password = a-password</pre>
       </doc:subsection>
 
 
-      <doc:subsection name="authorisation-tag-query">
+      <doc:subsection name="authorization-tag-query">
         <doc:heading>User Tags</doc:heading>
 
         <p>
@@ -843,7 +843,7 @@ auth_ldap.other_bind.password = a-password</pre>
 
 
     <doc:section name="query-reference">
-      <doc:heading>Authorisation Query Reference</doc:heading>
+      <doc:heading>Authorization Query Reference</doc:heading>
 
       <doc:subsection>
         <doc:heading>Constant Query</doc:heading>
@@ -1103,7 +1103,7 @@ auth_ldap.other_bind.password = a-password</pre>
         exchanges and declare from queues. Publishing to topic-typed
         exchanges is restricted to messages with a routing key
         beginning with "a" and consuming from topics isn't restricted
-        (topic authorisation).
+        (topic authorization).
       </p>
 
       The <a href="/configure.html#config-file">standard config</a>
@@ -1189,20 +1189,20 @@ auth_ldap.log        = false
       <doc:heading>Troubleshooting</doc:heading>
 
       <p>
-        Using LDAP for authentication and/or authorisation introduces another moving
+        Using LDAP for authentication and/or authorization introduces another moving
         part into the system. Since LDAP servers are accessed over the network,
         some topics covered in the <a href="/troubleshooting-networking.html">Network Troubleshooting</a>
         and <a href="/troubleshooting-ssl.html">TLS Troubleshooting</a> guides apply to LDAP.
       </p>
 
       <p>
-        In order to troubleshoot LDAP operations performed during the authentication and authorisation
+        In order to troubleshoot LDAP operations performed during the authentication and authorization
         stages, <a href="#logging">enabling LDAP traffic logging</a> is highly recommended.
       </p>
 
       <p>
         <a href="http://bit.ly/2GPyTmq">ldapsearch</a> is a command line tool that ships with LDAP and makes it possible to execute arbitrary
-        LDAP queries against an OpenLDAP installation. This can be useful when troubleshooting complex authorisation
+        LDAP queries against an OpenLDAP installation. This can be useful when troubleshooting complex authorization
         queries. <a href="https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc772839(v=ws.10)">ldp.exe</a> is the Active Directory counterpart.
       </p>
     </doc:section>

--- a/site/man/rabbitmqctl.8.html
+++ b/site/man/rabbitmqctl.8.html
@@ -690,7 +690,7 @@ Note that all user management commands
   Control</a></h3>
 Note that <code class="Nm" title="Nm">rabbitmqctl</code> manages the RabbitMQ
   internal user database. Permissions for users from any alternative
-  authorisation backend will not be visible to
+  authorization backend will not be visible to
   <code class="Nm" title="Nm">rabbitmqctl</code>.
 <dl class="Bl-tag">
   <dt><a class="permalink" href="#add_vhost"><code class="Cm" title="Cm" id="add_vhost">add_vhost</code></a>
@@ -871,7 +871,7 @@ Note that <code class="Nm" title="Nm">rabbitmqctl</code> manages the RabbitMQ
       <dd>The name of the user the permissions apply to in the target virtual
           host.</dd>
       <dt><var class="Ar" title="Ar">exchange</var></dt>
-      <dd>The name of the topic exchange the authorisation check will be applied
+      <dd>The name of the topic exchange the authorization check will be applied
           to.</dd>
       <dt><var class="Ar" title="Ar">write</var></dt>
       <dd>A regular expression matching the routing key of the published

--- a/site/management.md
+++ b/site/management.md
@@ -132,7 +132,7 @@ This is covered in the [following section](#permissions).
 
 ## <a id="permissions" class="anchor" href="#permissions">Access and Permissions</a>
 
-The management UI requires [authentication and authorisation](access-control.html), much like RabbitMQ requires
+The management UI requires [authentication and authorization](access-control.html), much like RabbitMQ requires
 it from connecting clients. In addition to successful authentication, management UI access is controlled by user tags.
 The tags are managed using [rabbitmqctl](/rabbitmqctl.8.html#set_user_tags).
 Newly created users do not have any tags set on them by default.

--- a/site/mqtt.md
+++ b/site/mqtt.md
@@ -443,7 +443,7 @@ to your configuration.
 
 Note that:
 
-* The authenticated user must exist in the configured authentication / authorisation backend(s).
+* The authenticated user must exist in the configured authentication / authorization backend(s).
 * Clients **must not** supply username and password.
 
 You can optionally specify a virtual host for a client certificate by using the `mqtt_default_vhosts`

--- a/site/news.xml
+++ b/site/news.xml
@@ -3700,7 +3700,7 @@ j8ZGl+/bUPvV/SuMHp61DbfBXjbeBmnP3mycMwo6LMr+ZBqwbVJq
           <p>
             This release fixes a number of bugs and introduces some enhancements,
             including streaming publish confirmations, new plugin mechanisms for
-            authentication and authorisation, and a great deal more.
+            authentication and authorization, and a great deal more.
             For details see the <a
             href="http://lists.rabbitmq.com/pipermail/rabbitmq-discuss/2011-February/011019.html">
             release notes</a>.

--- a/site/pages.xml.dat
+++ b/site/pages.xml.dat
@@ -122,7 +122,7 @@ limitations under the License.
        </x:page>
        <x:page url="/vhosts.html" text="Virtual Hosts"/>
        <x:page url="/pacemaker.html" text="High Availability (pacemaker)"/>
-       <x:page url="/access-control.html" text="Access Control (Authorisation)"/>
+       <x:page url="/access-control.html" text="Access Control (Authorization)"/>
        <x:page url="/authentication.html" text="Authentication Mechanisms"/>
        <x:page url="/ldap.html" text="LDAP"/>
        <x:page url="/lazy-queues.html" text="Lazy Queues"/>

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -320,7 +320,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
     <tr>
       <th>rabbitmq_auth_backend_ldap</th>
       <td>
-        Authentication and authorisation plugin using an external
+        Authentication and authorization plugin using an external
         LDAP server.
         <ul>
           <li><a href="ldap.html">Documentation for the LDAP
@@ -332,7 +332,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
     <tr>
       <th>rabbitmq_auth_backend_http</th>
       <td>
-        Authentication and authorisation plugin that uses an external HTTP API.
+        Authentication and authorization plugin that uses an external HTTP API.
 
         <ul>
           <li>

--- a/site/release-notes/3.6.1.md
+++ b/site/release-notes/3.6.1.md
@@ -170,7 +170,7 @@ a vulnerability in RabbitMQ management plugin.
    and could be used to exhaust server resources.
 
    The attacker needs to have access to HTTP API (authenticate successfully and have sufficient
-   tags to pass authorisation) in order to carry out the attack.
+   tags to pass authorization) in order to carry out the attack.
 
    There is no workaround for earlier releases.
 

--- a/site/release-notes/3.6.2.md
+++ b/site/release-notes/3.6.2.md
@@ -289,7 +289,7 @@ installing using `dpkg`, this dependency won't be automatically installed. To in
    GitHub issue: [rabbitmq-erlang-client#42](https://github.com/rabbitmq/rabbitmq-erlang-client/issues/42)
 
 
-### LDAP Authentication/Authorisation Backend
+### LDAP Authentication/Authorization Backend
 
 #### Bug Fixes
 
@@ -297,7 +297,7 @@ installing using `dpkg`, this dependency won't be automatically installed. To in
  
    GitHub issue: [rabbitmq-auth-backend-ldap#41](https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/41)
 
- * Non-existent group in `tag_queries` shouldn't terminate authorisation
+ * Non-existent group in `tag_queries` shouldn't terminate authorization
 
    GitHub issue: [rabbitmq-auth-backend-ldap#15](https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/15)
 
@@ -316,7 +316,7 @@ installing using `dpkg`, this dependency won't be automatically installed. To in
    GitHub issue: [rabbitmq-auth-backend-ldap#35](https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/35)
 
 
-### HTTP Authentication/Authorisation Backend
+### HTTP Authentication/Authorization Backend
 
 #### Enhancements
 

--- a/site/release-notes/README-2.3.0.txt
+++ b/site/release-notes/README-2.3.0.txt
@@ -41,7 +41,7 @@ enhancements
   http://www.rabbitmq.com/extensions.html#validated-user-id
 - pluggable SASL authentication mechanisms, and a new plugin
   to authenticate using SSL (see below)
-- pluggable authentication / authorisation backends, and a new plugin
+- pluggable authentication / authorization backends, and a new plugin
   to authenticate and authorise using LDAP (see below)
 - internal exchanges (cannot be published to directly,
   typically used with exchange-to-exchange bindings)
@@ -140,7 +140,7 @@ required.
 
 ldap authentication backend plugin
 ----------------------------------
-Experimental plugin allowing the authentication / authorisation
+Experimental plugin allowing the authentication / authorization
 database to be hosted in an LDAP server.
 
 

--- a/site/release-notes/README-3.3.0.txt
+++ b/site/release-notes/README-3.3.0.txt
@@ -50,7 +50,7 @@ enhancements
       are being held back by low prefetch counts
 26039 ensure rabbitmqctl's formatting of process IDs is more shell-script
       friendly
-25654 allow use of separate modules for authentication and authorisation
+25654 allow use of separate modules for authentication and authorization
 25722 explicitly set Erlang distribution port in all circumstances
 25910 add process identification information to process dictionary to aid in
       debugging

--- a/site/release-notes/README-3.4.4.txt
+++ b/site/release-notes/README-3.4.4.txt
@@ -65,7 +65,7 @@ bug fixes
 STOMP plugin
 ------------
 bug fixes
-26553 Unexpected authorisation errors may result in client connections staying open
+26553 Unexpected authorization errors may result in client connections staying open
 26282 Improve error messages for STOMP connection failures
       (TLS issues, abrupt TCP connection closures) (since 3.3.3)
 26559 STOMP reader should handle system messages (since 1.4.0)

--- a/site/stomp.md
+++ b/site/stomp.md
@@ -231,7 +231,7 @@ to your configuration.
 
 Note that:
 
-* The authenticated user must exist in the configured authentication / authorisation backend(s).
+* The authenticated user must exist in the configured authentication / authorization backend(s).
 * Clients must **not** supply `login` and `passcode` headers.
 
 ### <a id="cta.ic" class="anchor" href="#cta.ic">Implicit Connect</a>

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -81,10 +81,10 @@ cookie file is, and most common reasons why CLI tools fail to perform operations
 [Troubleshooting Networking](/troubleshooting-networking.html) is a dedicated guide on the topic of networking and connectivity.
 
 
-## <a id="authentication" class="anchor" href="#authentication">Authentication and Authorisation</a>
+## <a id="authentication" class="anchor" href="#authentication">Authentication and Authorization</a>
 
 [Access Control guide](/access-control.html) contains sections on [troubleshooting client authentication](/access-control.html#troubleshooting-authn)
-and [troubleshooting authorisation](/access-control.html#troubleshooting-authz).
+and [troubleshooting authorization](/access-control.html#troubleshooting-authz).
 
 
 ## <a id="connections" class="anchor" href="#connections">Connections</a>


### PR DESCRIPTION
These docs lack a standard of how to write the word 'authorization'.
It can be found written in both ways.

"While many people in the UK prefer the 's' (and some will make a fuss about it being "American"), both forms are recognised in the UK, and the Oxford Dictionaries (which are widely taken as authorities) prefer 'z'. On the other side, I have encountered Americans who were not even aware that 's' was a possibility, and regarded it as simply a mistake."
https://english.stackexchange.com/questions/282621/authorization-vs-authorisation-im-in-some-real-dilemma