### PR TITLE
remove deprecated stuff in php tutorial

### DIFF
--- a/site/tutorials/tutorial-five-php.md
+++ b/site/tutorials/tutorial-five-php.md
@@ -216,7 +216,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/site/tutorials/tutorial-four-php.md
+++ b/site/tutorials/tutorial-four-php.md
@@ -318,7 +318,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/site/tutorials/tutorial-one-php.md
+++ b/site/tutorials/tutorial-one-php.md
@@ -190,7 +190,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume('hello', '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 </pre>

--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -273,7 +273,7 @@ $callback = function ($req) {
 $channel->basic_qos(null, 1, null);
 $channel->basic_consume('rpc_queue', '', false, false, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/site/tutorials/tutorial-three-php.md
+++ b/site/tutorials/tutorial-three-php.md
@@ -314,7 +314,7 @@ $callback = function ($msg) {
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -427,7 +427,7 @@ $callback = function ($msg) {
 $channel->basic_qos(null, 1, null);
 $channel->basic_consume('task_queue', '', false, false, false, false, $callback);
 
-while (count($channel->callbacks)) {
+while ($channel->is_consuming()) {
     $channel->wait();
 }
 


### PR DESCRIPTION
AMQPChannel::$callbacks was marked as @Internal in php-amqplib/php-amqplib@f30adba and AMQPChannel::is_consuming() public API was introduced to replace it.
