### PR TITLE
Minor fix to layout in the section Port Access

### DIFF
--- a/site/clustering.md
+++ b/site/clustering.md
@@ -125,7 +125,8 @@ CLI tools, client libraries and RabbitMQ nodes also open connections (client TCP
 Firewalls can prevent nodes and CLI tools from communicating with each other.
 Make sure the following ports are accessible:
 
- * 4369: [epmd](http://erlang.org/doc/man/epmd.html), a peer discovery service used by RabbitMQ nodes and CLI tools * 5672, 5671: used by AMQP 0-9-1 and 1.0 clients without and with TLS
+ * 4369: [epmd](http://erlang.org/doc/man/epmd.html), a peer discovery service used by RabbitMQ nodes and CLI tools 
+ * 5672, 5671: used by AMQP 0-9-1 and 1.0 clients without and with TLS
  * 25672: used for inter-node and CLI tools communication (Erlang distribution server port)
    and is allocated from a dynamic range (limited to a single port by default,
    computed as AMQP port + 20000). Unless external connections on these ports are really necessary (e.g.


### PR DESCRIPTION
The ports '5672, 5671' were not visible in a line of their own. This may cause users skimming over the content to miss it.