### PR TITLE
Ensure to always use pip as a module of a given version of python

### DIFF
--- a/site/connections.md
+++ b/site/connections.md
@@ -285,7 +285,7 @@ the TCP socket.
 Applications that experience flow control regularly may consider to use separate connections
 to publish and consume to avoid flow control effects on non-publishing operations (e.g. queue management).
 
-## <a id="errors" class="anchor" href="#errors">Error Handling and Protocol Exceptions</a>
+## <a id="errors" class="anchor" href="#error-handling">Error Handling and Protocol Exceptions</a>
 
 A connection can fail or be unable to satisfy a client operation. Such scenarios are called errors
 or protocol exceptions. They can indicate a transient condition (e.g. a resource is locked),

--- a/site/tutorials/tutorial-one-python.md
+++ b/site/tutorials/tutorial-one-python.md
@@ -56,7 +56,7 @@ messages from that queue.
 > [`pip`](https://pip.pypa.io/en/stable/quickstart/) package management tool:
 >
 > <pre class="lang-bash">
-> pip install pika --upgrade
+> python -m pip install pika --upgrade
 > </pre>
 
 Now we have Pika installed, we can write some


### PR DESCRIPTION
Prefer to use pip as a module, it's avoid error and mistakes during
package installation. With this approach we are always sure to
to install dependencies in the right python environment.