### PR TITLE
Ensure to always use pip as a module of a given version of python

### DIFF
--- a/site/tutorials/tutorial-one-python.md
+++ b/site/tutorials/tutorial-one-python.md
@@ -56,7 +56,7 @@ messages from that queue.
 > [`pip`](https://pip.pypa.io/en/stable/quickstart/) package management tool:
 >
 > <pre class="lang-bash">
-> pip install pika --upgrade
+> python -m pip install pika --upgrade
 > </pre>
 
 Now we have Pika installed, we can write some


### PR DESCRIPTION
Prefer to use pip as a module, it's avoid error and mistakes during
package installation. With this approach we are always sure to
to install dependencies in the right python environment.