### PR TITLE
Added code to tutorial to prevent non-existent queue error

### DIFF
--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -97,7 +97,7 @@ var queue = 'task_queue';
 
 //Make sure queue exists before attempting to consume messages from it 
 channel.assertQueue(queue, {
-    {durable: false
+    {durable: true
 });
 
 channel.consume(queue, function(msg) {

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -95,6 +95,11 @@ messages from the queue and perform the task, so let's call it `worker.js`:
 <pre class="lang-javascript">
 var queue = 'task_queue';
 
+//Make sure queue exists before attempting to consume messages from it 
+channel.assertQueue(queue, {
+    {durable: false
+});
+
 channel.consume(queue, function(msg) {
   var secs = msg.content.toString().split('.').length - 1;
 


### PR DESCRIPTION
I'm a novice in this area, but the example of worker.js in the 2nd part of the javascript tutorial failed for me as the queue didn't exist when the worker.js file was launched. I added the necessary "assertQueue" call to create prior to attempting to consume.