### PR TITLE
Document default TLS verification depth

### DIFF
--- a/site/ssl.md
+++ b/site/ssl.md
@@ -511,6 +511,7 @@ The depth is the maximum number of non-self-issued intermediate certificates tha
 may follow the peer certificate in a valid certification path.
 So if depth is 0 the peer (e.g. client) certificate must be signed by the trusted CA directly,
 if 1 the path can be "peer, CA, trusted CA", if it is 2 "peer, CA, CA, trusted CA", and so on.
+The default depth is 1.
 
 The following example demonstrates how to configure certificate validation depth for
 RabbitMQ server:


### PR DESCRIPTION
I've seen in other SSL implementations that when no certificate verification depth is specified, it means "unlimited", and I was wrongly assuming this is a standard behaviour. Some long troubleshooting experience taught me that for Erlang, [the default maximum depth is 1](http://erlang.org/doc/man/ssl.html#type-allowed_cert_chain_length).

I suggest extending this paragraph of the documentation taken from Erlang to also include the default value, hoping it will save time for others.

Thanks!