### PR TITLE
Man pages: rabbitmq-queues, rabbitmq-upgrade and diagnostics updates

### DIFF
--- a/site/cli.md
+++ b/site/cli.md
@@ -22,6 +22,9 @@ RabbitMQ comes with multiple command line tools:
  * [`rabbitmqctl`](/rabbitmqctl.8.html) for service management and general operator tasks
  * [`rabbitmq-diagnostics`](/rabbitmq-diagnostics.8.html) for diagnostics and [health checking](/monitoring.html)
  * [`rabbitmq-plugins`](/rabbitmq-plugins.8.html) for [plugin management](/plugins.html)
+ * [`rabbitmq-queues`](/rabbitmq-queues.8.html) for maintenance tasks on [queues](/queues.html),
+   in particular [quorum queues](/quorum-queues.html)
+ * [`rabbitmq-upgrade`](/rabbitmq-upgrade.8.html) for maintenance tasks related to upgrades
  * [`rabbitmqadmin`](/management-cli.html) for operator tasks over [HTTP API](/management.html)
 
 Different tools cover different usage scenarios. For example, `rabbitmqctl` is usually

--- a/site/man/rabbitmq-diagnostics.8.html
+++ b/site/man/rabbitmq-diagnostics.8.html
@@ -340,6 +340,23 @@ Most commands provided by <code class="Nm">rabbitmq-diagnostics</code> inspect
     <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmq-diagnostics
       check_port_listener 5672</code></div>
   </dd>
+  <dt><a class="permalink" href="#consume_event_stream"><code class="Cm" id="consume_event_stream">consume_event_stream</code></a></dt>
+  <dd>
+    <p class="Pp">Streams internal events from a running node. Output is
+        jq-compatible.</p>
+    <p class="Pp">Example:</p>
+    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmq-diagnostics
+      consume_event_stream -n rabbit@hostname --duration 20 --pattern
+      queue_.*</code></div>
+  </dd>
+  <dt><a class="permalink" href="#command_line_arguments"><code class="Cm" id="command_line_arguments">command_line_arguments</code></a></dt>
+  <dd>
+    <p class="Pp">Displays target node's command-line arguments and flags as
+        reported by the runtime.</p>
+    <p class="Pp">Example:</p>
+    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmq-diagnostics
+      command_line_arguments -n rabbit@hostname</code></div>
+  </dd>
   <dt><a class="permalink" href="#status"><code class="Cm" id="status">status</code></a></dt>
   <dd>See <code class="Cm">status</code> in
       <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></dd>

--- a/site/man/rabbitmq-env.conf.5.html
+++ b/site/man/rabbitmq-env.conf.5.html
@@ -62,6 +62,8 @@ Below is an example of a minimalistic <code class="Nm">rabbitmq-env.conf</code>
   <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>,
   <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>,
   <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>,
+  <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>,
+  <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>,
   <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>
 </section>
 <section class="Sh">

--- a/site/man/rabbitmq-queues.8.html
+++ b/site/man/rabbitmq-queues.8.html
@@ -1,0 +1,127 @@
+<div class="manual-text">
+<section class="Sh">
+<h2 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h2>
+<code class="Nm">rabbitmq-queues</code> &#x2014;
+<div class="Nd">RabbitMQ queue management tools</div>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h2>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">rabbitmq-queues</code></td>
+    <td>[<code class="Fl">-q</code>] [<code class="Fl">-s</code>]
+      [<code class="Fl">-l</code>] [<code class="Fl">-n</code>
+      <var class="Ar">node</var>] [<code class="Fl">-t</code>
+      <var class="Ar">timeout</var>] <var class="Ar">command</var>
+      [<var class="Ar">command_options</var>]</td>
+  </tr>
+</table>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h2>
+<code class="Nm">rabbitmq-queues</code> is a command line tool that provides
+  commands used to manage queues, mainly member handling for quorum queues. See
+  the <a class="Lk" href="https://www.rabbitmq.com/quorum-queues.html">RabbitMQ
+  quorum queue guide</a> and
+  <a class="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ highly
+  available (mirrored) queues guide</a> to learn more about queue types in
+  RabbitMQ.
+</section>
+<section class="Sh">
+<h2 class="Sh" id="OPTIONS"><a class="permalink" href="#OPTIONS">OPTIONS</a></h2>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#n"><code class="Fl" id="n">-n</code></a>
+    <var class="Ar">node</var></dt>
+  <dd>Default node is
+      &quot;rabbit@<var class="Ar">target-hostname</var>&quot;, where
+      <var class="Ar">target-hostname</var> is the local host. On a host named
+      &quot;myserver.example.com&quot;, the node name will usually be
+      &quot;rabbit@myserver&quot; (unless
+      <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output
+      of &quot;hostname -s&quot; is usually the correct suffix to use after
+      the &quot;@&quot; sign. See
+      <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for
+      details of configuring a RabbitMQ node.</dd>
+  <dt><a class="permalink" href="#q"><code class="Fl" id="q">-q</code></a>,
+    <code class="Fl">--quiet</code></dt>
+  <dd>Quiet output mode is selected. Informational messages are reduced when
+      quiet mode is in effect.</dd>
+  <dt><a class="permalink" href="#s"><code class="Fl" id="s">-s</code></a>,
+    <code class="Fl">--silent</code></dt>
+  <dd>Silent output mode is selected. Informational messages are reduced and
+      table headers are suppressed when silent mode is in effect.</dd>
+  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a>
+    <var class="Ar">timeout</var>, <code class="Fl">--timeout</code>
+    <var class="Ar">timeout</var></dt>
+  <dd>Operation timeout in seconds. Not all commands support timeouts. Default
+      is <code class="Cm">infinity</code>.</dd>
+  <dt><a class="permalink" href="#l"><code class="Fl" id="l">-l</code></a>,
+    <code class="Fl">--longnames</code></dt>
+  <dd>Must be specified when the cluster is configured to use long (FQDN) node
+      names. To learn more, see the
+      <a class="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
+      Clustering guide</a></dd>
+  <dt><a class="permalink" href="#-erlang-cookie"><code class="Fl" id="-erlang-cookie">--erlang-cookie</code></a>
+    <var class="Ar">cookie</var></dt>
+  <dd>Shared secret to use to authenticate to the target node. Prefer using a
+      local file or the <code class="Ev">RABBITMQ_ERLANG_COOKIE</code>
+      environment variable instead of specifying this option on the command
+      line. To learn more, see the
+      <a class="Lk" href="https://www.rabbitmq.com/cli.html">RabbitMQ CLI Tools
+      guide</a></dd>
+</dl>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="COMMANDS"><a class="permalink" href="#COMMANDS">COMMANDS</a></h2>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#help"><code class="Cm" id="help">help</code></a></dt>
+  <dd>
+    <p class="Pp">Displays general help and commands supported by
+        <code class="Nm">rabbitmq-queues</code>.</p>
+  </dd>
+</dl>
+<section class="Ss">
+<h3 class="Ss" id="Cluster"><a class="permalink" href="#Cluster">Cluster</a></h3>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#grow"><code class="Cm" id="grow">grow</code></a></dt>
+  <dd>
+    <p class="Pp">Grows quorum queue clusters by adding a member (replica) to
+        all or half of matching quorum queues on the given node.</p>
+  </dd>
+  <dt><a class="permalink" href="#rebalance"><code class="Cm" id="rebalance">rebalance</code></a></dt>
+  <dd>
+    <p class="Pp">Rebalances queues.</p>
+  </dd>
+  <dt><a class="permalink" href="#shrink"><code class="Cm" id="shrink">shrink</code></a></dt>
+  <dd>
+    <p class="Pp">Shrinks quorum queue clusters by removing any members
+        (replicas) on the given node.</p>
+  </dd>
+</dl>
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Replication"><a class="permalink" href="#Replication">Replication</a></h3>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#add_member"><code class="Cm" id="add_member">add_member</code></a></dt>
+  <dd>
+    <p class="Pp">Adds a quorum queue member (replica) for a queue on the given
+        node.</p>
+  </dd>
+  <dt><a class="permalink" href="#delete_member"><code class="Cm" id="delete_member">delete_member</code></a></dt>
+  <dd>
+    <p class="Pp">Removes a quorum queue member (replica) for a queue on the
+        given node.</p>
+  </dd>
+</dl>
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Queues"><a class="permalink" href="#Queues">Queues</a></h3>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#quorum_status"><code class="Cm" id="quorum_status">quorum_status</code></a></dt>
+  <dd>
+    <p class="Pp">Displays quorum status of a quorum queue.</p>
+  </dd>
+</dl>
+</section>
+</section>
+</div>

--- a/site/man/rabbitmq-server.8.html
+++ b/site/man/rabbitmq-server.8.html
@@ -79,6 +79,8 @@ RabbitMQ is an open source multi-protocol messaging broker.
   <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>,
   <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>,
   <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>,
+  <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>,
+  <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>,
   <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>,
   <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>
 </section>

--- a/site/man/rabbitmq-service.8.html
+++ b/site/man/rabbitmq-service.8.html
@@ -112,6 +112,8 @@ RabbitMQ is an open source multi-protocol messaging broker.
   <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>,
   <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>,
   <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>,
+  <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>,
+  <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>,
   <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>,
   <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>
 </section>

--- a/site/man/rabbitmq-upgrade.8.html
+++ b/site/man/rabbitmq-upgrade.8.html
@@ -1,0 +1,87 @@
+<div class="manual-text">
+<section class="Sh">
+<h2 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h2>
+<code class="Nm">rabbitmq-upgrade</code> &#x2014;
+<div class="Nd">RabbitMQ installation upgrade tools</div>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h2>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">rabbitmq-upgrade</code></td>
+    <td>[<code class="Fl">-q</code>] [<code class="Fl">-s</code>]
+      [<code class="Fl">-l</code>] [<code class="Fl">-n</code>
+      <var class="Ar">node</var>] [<code class="Fl">-t</code>
+      <var class="Ar">timeout</var>] <var class="Ar">command</var>
+      [<var class="Ar">command_options</var>]</td>
+  </tr>
+</table>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h2>
+<code class="Nm">rabbitmq-upgrade</code> is a command line tool that provides
+  commands used during the upgrade of RabbitMQ nodes. See the
+  <a class="Lk" href="https://www.rabbitmq.com/upgrade.html">RabbitMQ upgrade
+  guide</a> to learn more about RabbitMQ installation upgrades.
+</section>
+<section class="Sh">
+<h2 class="Sh" id="OPTIONS"><a class="permalink" href="#OPTIONS">OPTIONS</a></h2>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#n"><code class="Fl" id="n">-n</code></a>
+    <var class="Ar">node</var></dt>
+  <dd>Default node is
+      &quot;rabbit@<var class="Ar">target-hostname</var>&quot;, where
+      <var class="Ar">target-hostname</var> is the local host. On a host named
+      &quot;myserver.example.com&quot;, the node name will usually be
+      &quot;rabbit@myserver&quot; (unless
+      <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output
+      of &quot;hostname -s&quot; is usually the correct suffix to use after
+      the &quot;@&quot; sign. See
+      <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for
+      details of configuring a RabbitMQ node.</dd>
+  <dt><a class="permalink" href="#q"><code class="Fl" id="q">-q</code></a>,
+    <code class="Fl">--quiet</code></dt>
+  <dd>Quiet output mode is selected. Informational messages are reduced when
+      quiet mode is in effect.</dd>
+  <dt><a class="permalink" href="#s"><code class="Fl" id="s">-s</code></a>,
+    <code class="Fl">--silent</code></dt>
+  <dd>Silent output mode is selected. Informational messages are reduced and
+      table headers are suppressed when silent mode is in effect.</dd>
+  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a>
+    <var class="Ar">timeout</var>, <code class="Fl">--timeout</code>
+    <var class="Ar">timeout</var></dt>
+  <dd>Operation timeout in seconds. Not all commands support timeouts. Default
+      is <code class="Cm">infinity</code>.</dd>
+  <dt><a class="permalink" href="#l"><code class="Fl" id="l">-l</code></a>,
+    <code class="Fl">--longnames</code></dt>
+  <dd>Must be specified when the cluster is configured to use long (FQDN) node
+      names. To learn more, see the
+      <a class="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
+      Clustering guide</a></dd>
+  <dt><a class="permalink" href="#-erlang-cookie"><code class="Fl" id="-erlang-cookie">--erlang-cookie</code></a>
+    <var class="Ar">cookie</var></dt>
+  <dd>Shared secret to use to authenticate to the target node. Prefer using a
+      local file or the <code class="Ev">RABBITMQ_ERLANG_COOKIE</code>
+      environment variable instead of specifying this option on the command
+      line. To learn more, see the
+      <a class="Lk" href="https://www.rabbitmq.com/cli.html">RabbitMQ CLI Tools
+      guide</a></dd>
+</dl>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="COMMANDS"><a class="permalink" href="#COMMANDS">COMMANDS</a></h2>
+<dl class="Bl-tag">
+  <dt><a class="permalink" href="#help"><code class="Cm" id="help">help</code></a></dt>
+  <dd>
+    <p class="Pp">Displays general help and commands supported by
+        <code class="Nm">rabbitmq-upgrade</code>.</p>
+  </dd>
+  <dt><a class="permalink" href="#post_upgrade"><code class="Cm" id="post_upgrade">post_upgrade</code></a></dt>
+  <dd>
+    <p class="Pp">Runs post-upgrade tasks. In the current version, it performs
+        the rebalance of mirrored and quorum queues across all nodes in the
+        cluster..</p>
+  </dd>
+</dl>
+</section>
+</div>

--- a/site/man/rabbitmqctl.8.html
+++ b/site/man/rabbitmqctl.8.html
@@ -2117,6 +2117,8 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
   <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>,
   <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>,
   <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>,
+  <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>,
+  <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>,
   <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>,
   <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>
 </section>

--- a/site/manpages.md
+++ b/site/manpages.md
@@ -33,3 +33,6 @@ This page lists the available manual pages taken from the [latest stable release
  * [rabbitmq-server](rabbitmq-server.8.html): starts a RabbitMQ server node
  * [rabbitmq-service](rabbitmq-service.8.html): Windows service management
  * [rabbitmq-echopid](rabbitmq-echopid.8.html): a Windows-specific utility tool
+ * [rabbitmq-upgrade](rabbitmq-upgrade.8.html): upgrade commands
+ * [rabbitmq-queues](rabbitmq-queues.8.html): queue management commands
+

--- a/site/manpages.md
+++ b/site/manpages.md
@@ -30,9 +30,8 @@ This page lists the available manual pages taken from the [latest stable release
  * [rabbitmq-diagnostics](rabbitmq-diagnostics.8.html): commands useful for diagnostics, [health checking](/monitoring.html),
    and observing system state
  * [rabbitmq-plugins](rabbitmq-plugins.8.html): [plugin management](/plugins.html)
+ * [rabbitmq-upgrade](rabbitmq-upgrade.8.html): operational tasks related to upgrades
+ * [rabbitmq-queues](rabbitmq-queues.8.html): operational tasks for queues
  * [rabbitmq-server](rabbitmq-server.8.html): starts a RabbitMQ server node
  * [rabbitmq-service](rabbitmq-service.8.html): Windows service management
  * [rabbitmq-echopid](rabbitmq-echopid.8.html): a Windows-specific utility tool
- * [rabbitmq-upgrade](rabbitmq-upgrade.8.html): upgrade commands
- * [rabbitmq-queues](rabbitmq-queues.8.html): queue management commands
-

--- a/site/pages.xml.dat
+++ b/site/pages.xml.dat
@@ -133,6 +133,8 @@ limitations under the License.
          <x:page url="/rabbitmqctl.8.html" text="rabbitmqctl"/>
          <x:page url="/rabbitmq-diagnostics.8.html" text="rabbitmq-diagnostics"/>
          <x:page url="/rabbitmq-plugins.8.html" text="rabbitmq-plugins"/>
+         <x:page url="/rabbitmq-upgrade.8.html" text="rabbitmq-upgrade"/>
+         <x:page url="/rabbitmq-queues.8.html" text="rabbitmq-queues"/>
          <x:page url="/rabbitmq-server.8.html" text="rabbitmq-server"/>
          <x:page url="/rabbitmq-service.8.html" text="rabbitmq-service"/>
          <x:page url="/rabbitmq-echopid.8.html" text="rabbitmq-echopid"/>

--- a/site/rabbitmq-queues.8.xml
+++ b/site/rabbitmq-queues.8.xml
@@ -1,0 +1,34 @@
+<?xml-stylesheet type="text/xml" href="page.xsl"?>
+<!DOCTYPE html [
+<!ENTITY % entities SYSTEM "rabbit.ent" >
+%entities;
+]>
+<!--
+Copyright (c) 2007-2019 Pivotal Software, Inc.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
+      xmlns:xi="http://www.w3.org/2003/XInclude">
+  <head>
+    <title>rabbitmq-queues(8)</title>
+  </head>
+  <body>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-queues.8.html"/>
+    </doc:section>
+  </body>
+</html>

--- a/site/rabbitmq-upgrade.8.xml
+++ b/site/rabbitmq-upgrade.8.xml
@@ -1,0 +1,34 @@
+<?xml-stylesheet type="text/xml" href="page.xsl"?>
+<!DOCTYPE html [
+<!ENTITY % entities SYSTEM "rabbit.ent" >
+%entities;
+]>
+<!--
+Copyright (c) 2007-2019 Pivotal Software, Inc.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:doc="http://www.rabbitmq.com/namespaces/ad-hoc/doc"
+      xmlns:xi="http://www.w3.org/2003/XInclude">
+  <head>
+    <title>rabbitmq-upgrade(8)</title>
+  </head>
+  <body>
+    <doc:section name="manpage">
+      <xi:include href="man/rabbitmq-upgrade.8.html"/>
+    </doc:section>
+  </body>
+</html>

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -327,6 +327,8 @@ The script has certain assumptions (e.g. the default node name) and can fail to 
 some installations. The script should be considered
 experimental. Run it in a non-production environment first.
 
+A [queue master rebalance command](https://www.rabbitmq.com/rabbitmq-queues.8.html) is available. It rebalances queue masters for all queues, or those that match the given name pattern. Queue masters for mirrored queues and leaders for quorum queues are also rebalanced in the [post-upgrade command](https://www.rabbitmq.com/rabbitmq-upgrade.8.html).
+
 There is also a [third-party plugin](https://github.com/Ayanda-D/rabbitmq-queue-master-balancer)
 that rebalances queue masters. The plugin has some additional configuration and reporting tools,
 but is not supported or verified by the RabbitMQ team. Use at your own risk.


### PR DESCRIPTION
Document new cli commands and man pages for `rabbitmq-queues`, `rabbitmq-update`
Add diagnostics commands: `consume_event_stream`, `command_line_arguments`

Man pages in https://github.com/rabbitmq/rabbitmq-server/pull/2121