### PR TITLE
Update amqp-concepts.md

### DIFF
--- a/site/tutorials/amqp-concepts.md
+++ b/site/tutorials/amqp-concepts.md
@@ -106,7 +106,7 @@ AMQP 0-9-1 brokers provide four exchange types:
 
 <table>
   <thead>
-    <th>Name</th>
+    <th>Exchange type</th>
     <th>Default pre-declared names</th>
   </thead>
   <tr>


### PR DESCRIPTION
When reading the text I was confused about the table having two columns both having Name in the header, so I renamed the first column of exchange types to 'Exchange type'. Might as well be Exchange type name.