### PR TITLE
docs(memory): Remove extra backtick from memory docs

### DIFF
--- a/site/memory.md
+++ b/site/memory.md
@@ -164,7 +164,7 @@ immediately and thus eventually blocks all publishing connections. This may be
 useful if you wish to disable publishing globally:
 
 <pre class="lang-bash">
-rabbitmqctl set_vm_memory_high_watermark 0`
+rabbitmqctl set_vm_memory_high_watermark 0
 </pre>
 
 ## <a id="address-space" class="anchor" href="#address-space">Limited Address Space</a>


### PR DESCRIPTION
There is an extra backtick in this line:
![image](https://user-images.githubusercontent.com/6242296/69905840-acde8b80-1387-11ea-8b87-b04aad3b2d4e.png)
in this page: https://www.rabbitmq.com/memory.html
