### PR TITLE
Typo fix. usused=>unused

### DIFF
--- a/site/tutorials/tutorial-five-go.md
+++ b/site/tutorials/tutorial-five-go.md
@@ -270,7 +270,7 @@ func main() {
         q, err := ch.QueueDeclare(
                 "",    // name
                 false, // durable
-                false, // delete when usused
+                false, // delete when unused
                 true,  // exclusive
                 false, // no-wait
                 nil,   // arguments

--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -245,7 +245,7 @@ we're interested in.
 q, err := ch.QueueDeclare(
   "",    // name
   false, // durable
-  false, // delete when usused
+  false, // delete when unused
   true,  // exclusive
   false, // no-wait
   nil,   // arguments
@@ -428,7 +428,7 @@ func main() {
         q, err := ch.QueueDeclare(
                 "",    // name
                 false, // durable
-                false, // delete when usused
+                false, // delete when unused
                 true,  // exclusive
                 false, // no-wait
                 nil,   // arguments

--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -198,7 +198,7 @@ defer ch.Close()
 q, err := ch.QueueDeclare(
   "hello", // name
   false,   // durable
-  false,   // delete when usused
+  false,   // delete when unused
   false,   // exclusive
   false,   // no-wait
   nil,     // arguments

--- a/site/tutorials/tutorial-six-go.md
+++ b/site/tutorials/tutorial-six-go.md
@@ -67,7 +67,7 @@ Let's try it:
 q, err := ch.QueueDeclare(
   "",    // name
   false, // durable
-  false, // delete when usused
+  false, // delete when unused
   true,  // exclusive
   false, // noWait
   nil,   // arguments
@@ -263,7 +263,7 @@ func main() {
         q, err := ch.QueueDeclare(
                 "rpc_queue", // name
                 false,       // durable
-                false,       // delete when usused
+                false,       // delete when unused
                 false,       // exclusive
                 false,       // no-wait
                 nil,         // arguments
@@ -376,7 +376,7 @@ func fibonacciRPC(n int) (res int, err error) {
         q, err := ch.QueueDeclare(
                 "",    // name
                 false, // durable
-                false, // delete when usused
+                false, // delete when unused
                 true,  // exclusive
                 false, // noWait
                 nil,   // arguments

--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -196,7 +196,7 @@ as an empty string, we create a non-durable queue with a generated name:
 q, err := ch.QueueDeclare(
   "",    // name
   false, // durable
-  false, // delete when usused
+  false, // delete when unused
   true,  // exclusive
   false, // no-wait
   nil,   // arguments
@@ -417,7 +417,7 @@ func main() {
         q, err := ch.QueueDeclare(
                 "",    // name
                 false, // durable
-                false, // delete when usused
+                false, // delete when unused
                 true,  // exclusive
                 false, // no-wait
                 nil,   // arguments


### PR DESCRIPTION
Fixed typos in golang code examples