### PR TITLE
Remove RABBITMQ_GENERATED_CONFIG_DIR

### DIFF
--- a/site/relocate.md
+++ b/site/relocate.md
@@ -87,14 +87,6 @@ file and directories have sufficient permissions
     </td>
   </tr>
   <tr>
-    <td>RABBITMQ_GENERATED_CONFIG_DIR</td>
-    <td>
-      The directory where RabbitMQ writes its generated configuration
-      files.
-    </td>
-  </tr>
-
-  <tr>
     <td>RABBITMQ_MNESIA_BASE</td>
     <td>
       This base directory contains sub-directories for the RabbitMQ


### PR DESCRIPTION
No longer applies after merge of rabbitmq/rabbitmq-server#2180

See https://github.com/rabbitmq/rabbitmq-common/pull/345