### PR TITLE
Connection Blocked updates for .NET Client example

### DIFF
--- a/site/connection-blocked.md
+++ b/site/connection-blocked.md
@@ -86,12 +86,12 @@ delegate. `IConnection` provides
 `IConnection.ConnectionUnblocked` events:
 
 <pre class="lang-csharp">
-  public void HandleBlocked(IConnection sender, ConnectionBlockedEventArgs args)
+  public void HandleBlocked(object sender, ConnectionBlockedEventArgs args)
   {
       // Connection is now blocked
   }
 
-  public void HandleUnblocked(IConnection sender)
+  public void HandleUnblocked(object sender, EventArgs args)
   {
       // Connection is now unblocked
   }


### PR DESCRIPTION
In the Connection Blocked documentation, the .NET example seems to have an incorrect signature for `HandleBlocked` and `HandleUnblocked`. I'm not sure whether this was intentional so raising this PR in case it was not.

In the case of `HandleBlocked` it was:
```csharp
public void HandleBlocked(IConnection sender, ConnectionBlockedEventArgs args)
```
instead of 
```csharp
public void HandleBlocked(object sender, ConnectionBlockedEventArgs args)
```

Similariy it for `HandleUnblocked` the signature was:
```csharp
public void HandleUnblocked(IConnection sender)
```
instead of
```csharp
public void HandleUnblocked(object sender, EventArgs args)
```
