### PR TITLE
Use callback arg for acks in worker

### DIFF
--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -255,7 +255,7 @@ consumer.Received += (model, ea) =>
 
     Console.WriteLine(" [x] Done");
 
-    channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
+    model.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
 };
 channel.BasicConsume(queue: "task_queue", autoAck: false, consumer: consumer);
 </pre>
@@ -495,7 +495,7 @@ class Worker
 
                 Console.WriteLine(" [x] Done");
 
-                channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
+                model.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
             };
             channel.BasicConsume(queue: "task_queue",
                                  autoAck: false,


### PR DESCRIPTION
When sending the ack, we should use the channel provided to us by the callback mechanism, not capture it from the outer scope. This lets use e.g. to extract the callback to a separate method.