### PR TITLE
Add note about multiple Erlang versions on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 target/
 site/img/.DS_Store
 .DS_Store
+*env*/

--- a/site/install-windows-manual.md
+++ b/site/install-windows-manual.md
@@ -32,6 +32,9 @@ and <code>\erl<var>x.x.x</var>\bin\erl.exe</code> will be in
 `&dir-win32-apps;` or `&dir-win-apps;`, depending on
 your platform and whether you chose a 32bit or 64bit version of Erlang.
 
+**Important:** your system should only have one version of Erlang installed.
+Please consult the [Windows-specific Issues](windows-quirks.html) page.
+
 ### <a id="set-erlang-home-variable" class="anchor" href="#set-erlang-home-variable">Make Sure ERLANG_HOME is Set</a>
 
 In case there's an existing RabbitMQ installation with the broker running as a service and

--- a/site/install-windows.md
+++ b/site/install-windows.md
@@ -57,6 +57,9 @@ provide binary 64-bit builds of Erlang as well.
 otherwise a registry key expected by the RabbitMQ installer will not be
 present.
 
+**Important:** your system should only have one version of Erlang installed.
+Please consult the [Windows-specific Issues](windows-quirks.html) page.
+
 Once a supported version of Erlang is installed, download the RabbitMQ installer (<code><span class="path">rabbitmq-server-&version-server;.exe</span></code>) and run it.
 It installs RabbitMQ as a Windows service and starts it using the default configuration.
 

--- a/site/windows-quirks.md
+++ b/site/windows-quirks.md
@@ -22,6 +22,23 @@ Windows. However, sometimes there are circumstances beyond our
 control that can introduce quirky behaviour. This page documents
 them.
 
+## Multiple versions of Erlang may cause installation issues
+
+Due to how the Windows `.exe` installer detects an installed version of Erlang, RabbitMQ may end up not using the latest version of Erlang installed. Please ensure that only one version of Erlang is installed - the version you wish RabbitMQ to use. If you must upgrade Erlang, use this procedure:
+
+<ul>
+  <li>Stop the RabbitMQ windows service</li>
+  <li>Un-install Erlang</li>
+  <li>Install the new version of Erlang</li>
+  <li>Open the "RabbitMQ Command Prompt (sbin dir)" start menu item and run these commands:
+    <pre class="lang-text">
+    .\rabbitmq-service.bat remove
+    .\rabbitmq-service.bat install
+    .\rabbitmq-service.bat start
+    </pre>
+  </li>
+</ul>
+
 ## Cannot install to a path with non-ASCII characters
 
 RabbitMQ will fail to start with the error that reads
@@ -76,9 +93,7 @@ country-specific encoding.
   </li>
 </ul>
 
-## Installing as a non-administrator user leaves <a href="/clustering.html#erlang-cookie">.erlang.cookie</a>
-in the wrong place
-
+## Installing as a non-administrator user leaves `.erlang.cookie` in the wrong place
 
 This makes it impossible to use [CLI tools](/cli.html) and cluster nodes.
 
@@ -95,6 +110,8 @@ This makes it impossible to use [CLI tools](/cli.html) and cluster nodes.
     to <code>%HOMEDRIVE%%HOMEPATH%</code>.
   </li>
 </ul>
+
+Please also refer to the `.erlang.cookie` [documentation](/clustering.html#erlang-cookie).
 
 ## <a id="computername-vs-hostname" class="anchor" href="#computername-vs-hostname">COMPUTERNAME is different from HOSTNAME</a>
 


### PR DESCRIPTION
This addresses the uncommon scenario where a user has multiple versions of Erlang installed, and the sort order of the version causes an old version to be used.

https://github.com/rabbitmq/rabbitmq-server-release/issues/117

https://github.com/rabbitmq/rabbitmq-server/issues/1969#issuecomment-583469093

It is not possible to change the behavior in NSIS.

[171866390]