### PR TITLE
fix typos in prometheus.md

### DIFF
--- a/site/prometheus.md
+++ b/site/prometheus.md
@@ -39,7 +39,7 @@ As of 3.8.0, RabbitMQ ships with built-in Prometheus & Grafana support.
 Support for Prometheus metric collector ships in the `rabbitmq_prometheus` plugin.
 The plugin exposes all RabbitMQ metrics on a dedicated TCP port, in Prometheus text format.
 
-These metrics provide a deep insights into the state of RabbitMQ nodes and [the runtime](/runtime.html).
+These metrics provide deep insights into the state of RabbitMQ nodes and [the runtime](/runtime.html).
 They make reasoning about the behaviour of RabbitMQ, applications that use it and various infrastructure
 elements a lot more informed.
 
@@ -58,7 +58,7 @@ There is a number of dashboards available:
 and others. Each is meant to provide an insight into a specific
 part of the system. When used together, they are able to explain RabbitMQ and application behaviour in detail.
 
-Note that the Grafana dashboards are opinionated and uses a number of conventions, for example, to
+Note that the Grafana dashboards are opinionated and use a number of conventions, for example, to
 [spot system health issues quicker](#health-indicators) or make [cross-graph referencing](#graph-colour-labelling) possible.
 Like all Grafana dashboards, they are also highly customizable. The conventions they assume are considered to be
 good practices and are thus recommended.
@@ -283,7 +283,7 @@ It is a lot more and efficient to have RabbitMQ [push messages to the consumer](
 
 ### <a id="example-workloads" class="anchor" href="#example-workloads">Example Workloads</a>
 
-The [Prometheus plugin repository](https://github.com/rabbitmq/rabbitmq-prometheus/tree/master/docker) contains example workloads that us [PerfTest](https://rabbitmq.github.io/rabbitmq-perf-test/stable/htmlsingle/)
+The [Prometheus plugin repository](https://github.com/rabbitmq/rabbitmq-prometheus/tree/master/docker) contains example workloads that use [PerfTest](https://rabbitmq.github.io/rabbitmq-perf-test/stable/htmlsingle/)
 to simulate different workloads.
 Their goal is to exercise all metrics in the RabbitMQ Overview dashboard. These examples are meant to be
 edited and extended as developers and operators see fit when exploring various metrics, their thresholds and behaviour.
@@ -437,7 +437,7 @@ below:
 
 The scraping HTTP endpoint can produce metrics as aggregated rows or individual rows.
 
-The the latter case, there will be an output row for each object-metric pair.
+In the latter case, there will be an output row for each object-metric pair.
 With a large number of stats-emitting entities, e.g. a lot of connections and queues,
 this can result in very large payloads and a lot of CPU resources spent serialising
 data to output. This mode therefore is only suitable for development environments


### PR DESCRIPTION
I have fixed four typos in the prometheus.md docs at lines 42, 61, 286 and 440