### PR TITLE
Typo in tutorial-one-java: Replaced DefaultConsumer to DeliverCallback

### DIFF
--- a/site/tutorials/tutorial-one-java.md
+++ b/site/tutorials/tutorial-one-java.md
@@ -161,8 +161,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DeliverCallback;
 </pre>
 
-The extra `DefaultConsumer` is a class implementing the `Consumer`
-interface we'll use to buffer the messages pushed to us by the server.
+The extra `DeliverCallback` interface we'll use to buffer the messages pushed to us by the server.
 
 Setting up is the same as the publisher; we open a connection and a
 channel, and declare the queue from which we're going to consume.


### PR DESCRIPTION
This section describes how imports of `Recv.java` differ from imports of `Send.java`. 
> The extra `DefaultConsumer` is a class implementing the `Consumer` interface we'll use to buffer the messages pushed to us by the server.

Imports don't include `DefaultConsumer`, but they include `DeliverCallback`. So there is a typo.