### PR TITLE
Heartbeats aren't min-negotiated like frame max

### DIFF
--- a/site/heartbeats.md
+++ b/site/heartbeats.md
@@ -44,11 +44,9 @@ and client libraries. This value is negotiated between the
 client and RabbitMQ server at the time of connection. The
 client must be configured to request heartbeats.
 
-The broker and client will attempt to negotiate
-heartbeats by default. When both values are greater than zero, the lower of the requested
-values will be used. A zero value disables heartbeats.
+The broker gives a suggested heartbeat timeout value when the client connects. The client can ignore this suggestion. Any heartbeat timeout value sent by the client is used for the duration of that connection. A client response of `0` disables heartbeats.
 
-The timeout is in seconds, and default value is `60`.
+The timeout is in seconds, and default broker suggestion is `60`.
 
 
 ## <a id="heartbeats-interval" class="anchor" href="#heartbeats-interval">Heartbeat Frames</a>


### PR DESCRIPTION
From testing I've found that the broker heartbeat setting is ignored by at least all AMQP 0.9.1 clients, which contradicts the existing documentation.

The following table shows the actual values, taken from the management UI, on RabbitMQ 3.8.3 & an AMQP 0.9.1 client.

| Server Config | Client Value  | Actual Value |
|---------------|--------------|--------------|
| 100               | 60                | 60                |
| 100               | 3600            | 3600            |
| 100               | 0                  | 0                  |
| 0                   | 3600            | 3600            |

I believe the relevant code to be https://github.com/rabbitmq/rabbitmq-server/blob/e61c608380e9bd3dba2c2fe5656c19c69e130525/src/rabbit_reader.erl#L1181-L1218 which appears to just use the value specified by the client.