### PR TITLE
Fix override example manifest

### DIFF
--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -450,6 +450,7 @@ kind: RabbitmqCluster
 metadata:
   name: additional-port
 spec:
+  replicas: 1
   override:
     clientService:
       spec:


### PR DESCRIPTION
The example manifest is missing a required field `spec.replicas`.