### PR TITLE
Add operator documentation for mTLS configuration

### DIFF
--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -422,6 +422,10 @@ spec:
 already exist in the same Namespace as the `RabbitmqCluster` object. It is expected that the Secret contains `tls.key`
 and `tls.crt` for the private key and public certificate respectively.
 
+Optionally, configure RabbitMQ to connect using mTLS by providing a CA Certificate to verify peer certificates against.
+This certificate must be stored under a key of name `spec.tls.caCertName`, in a Secret of name `spec.tls.caSecretName`, in
+the same Namespace as the `RabbitmqCluster` object. Note that this can be the same Secret as `spec.tls.secretName`.
+
 **Default Value:** N/A
 
 **Example:**
@@ -434,6 +438,8 @@ metadata:
 spec:
   tls:
     secretName: rabbitmq-server-certs
+    caSecretName: rabbitmq-ca-cert
+    caCertName: ca.crt
 </pre>
 
 ### <a name='override' class='anchor' href='#override'>Override Resource Properties</a>


### PR DESCRIPTION
Follow on PR from https://github.com/rabbitmq/cluster-operator/pull/232

This PR adds in the missing documentation for mTLS configuration in the Kubernetes operator.