### PR TITLE
Add Foo-Foo-MQ to devtools for node

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -105,6 +105,8 @@ Miscellaneous projects:
  * [amqp-stats](https://github.com/timisbusy/node-amqp-stats): a node.js interface for RabbitMQ management statistics
  * [Rascal](https://github.com/guidesmiths/rascal): a config driven wrapper for [amqp.node](https://github.com/squaremo/amqp.node) supporting multi-host connections,
    automatic error recovery, redelivery flood protection, transparent encryption and channel pooling.
+ * [foo-foo-mq](https://github.com/foo-foo-mq/foo-foo-mq): an opinionated abstraction over [amqp.node](https://github.com/squaremo/amqp.node)
+   that uses reasonable assumptions and defaults to simplify the implementation messaging patterns on RabbitMQ.
 
 
 ## <a id="objc-swift-dev" class="anchor" href="#objc-swift-dev">Objective-C and Swift</a>


### PR DESCRIPTION
@zlintz and I have recently taken over the decently popular node library [Rabbot](https://github.com/arobson/rabbot) (with the support of its owners).

We have re-branded the library as [foo-foo-mq](https://github.com/foo-foo-mq/foo-foo-mq) and maintain it and some related dependencies under the organization [Foo-Foo-MQ](https://github.com/Foo-Foo-MQ/).

We recently released version 5.0.0 with support for node 14 and amqplib 6 and are averaging between one and two thousand downloads a week at this point.

We would love it if we could be added to the list on this page. Thank you!