### PR TITLE
Update support k8s versions for cluster operator

### DIFF
--- a/site/kubernetes/operator/install-operator.md
+++ b/site/kubernetes/operator/install-operator.md
@@ -8,10 +8,8 @@ This guide covers the installation of the [RabbitMQ Cluster Kubernetes Operator]
 
 The Operator requires
 
-* Kubernetes 1.16 or 1.17
+* Kubernetes 1.16 or above
 * [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.5+
-
-There is a [known issue when deploying to Kubernetes 1.18](https://github.com/rabbitmq/cluster-operator/issues/230).
 
 -----
 

--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -49,10 +49,8 @@ versions.
 
 The Operator requires
 
- * Kubernetes 1.16 or 1.17
+ * Kubernetes 1.16 or above
  * [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.5+
-
-There is a [known issue when deploying to Kubernetes 1.18](https://github.com/rabbitmq/cluster-operator/issues/230).
 
 ## <a id='installation' class='anchor' href='#installation'>Installation</a>
 


### PR DESCRIPTION
k8s `1.18` is currently supported.