### PR TITLE
Update installation guide of Cluster Operator

### DIFF
--- a/site/kubernetes/operator/install-operator.md
+++ b/site/kubernetes/operator/install-operator.md
@@ -3,33 +3,78 @@
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 This guide covers the installation of the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html) in a Kubernetes cluster.
+If you are installing in OpenShift, follow the instructions in [Installation on OpenShift](#openshift) section.
 
 ## <a id='compatibility' class='anchor' href='#compatibility'>Compatibility</a>
 
 The Operator requires
 
 * Kubernetes 1.16 or above
-* [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.8+
+* [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.4+
 
 -----
 
 ## <a id='installation' class='anchor' href='#installation'>Installation</a>
 
-To install the Operator you need to clone the [cluster-operator](https://github.com/rabbitmq/cluster-operator/) repository and then create the necessary resources in the Kubernetes cluster.
-
-The following steps should be sufficient for most environments:
+To install the Operator, run the following command:
 
 <pre class="lang-bash">
-git clone git@github.com:rabbitmq/cluster-operator.git
-cd cluster-operator
-kubectl create -f config/namespace/base/namespace.yaml
-kubectl create -f config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
-kubectl -n rabbitmq-system create --kustomize config/rbac/
-kubectl -n rabbitmq-system create --kustomize config/manager/
+kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml"
+# namespace/rabbitmq-system created
+# customresourcedefinition.apiextensions.k8s.io/rabbitmqclusters.rabbitmq.com created
+# serviceaccount/rabbitmq-cluster-operator created
+# role.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-role created
+# clusterrole.rbac.authorization.k8s.io/rabbitmq-cluster-operator-role created
+# rolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-rolebinding created
+# clusterrolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-operator-rolebinding created
+# deployment.apps/rabbitmq-cluster-operator created
 </pre>
 
 At this point, the RabbitMQ Cluster Kubernetes Operator is successfully installed.
 Once the RabbitMQ Cluster Kubernetes Operator pod is running, head over to [Using Kubernetes RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/using-operator.html) for instructions on how to deploy RabbitMQ using a Kubernetes Custom Resource.
+
+If you want to install a specific version of the Operator, you will have to obtain the manifest link from the
+[Operator Releases](https://github.com/rabbitmq/cluster-operator/releases). Please note that releases prior to 0.46.0
+do not have this manifest. We strongly recommend to install versions 0.46.0+
+
+### <a id='kubectl-plugin' class='anchor' href='#kubectl-plugin'>Installation using kubectl-rabbitmq plugin</a>
+
+The plugin can be installed by downloading the file and placing it in the system PATH. In most Linux systems, the
+location `/usr/local/bin` is part of the PATH. You can check your current PATH using `echo $PATH`. This plugin presents
+an alterantive to install the Cluster Operator. It also provides a shortcut to create and edit `RabbitmqCluster` resources.
+
+The following command downloads the plugin from the main branch:
+
+<pre class="lang-bash">
+curl -o kubectl-rabbitmq "https://raw.githubusercontent.com/rabbitmq/cluster-operator/main/bin/kubectl-rabbitmq"
+</pre>
+
+Make sure the file is executable and somewhere in the PATH:
+
+<pre class="lang-bash">
+chmod +x kubectl-rabbitmq
+mv kubectl-rabbitmq /usr/local/bin/kubectl-rabbitmq
+</pre>
+
+Test that the plugin installed correctly and install the Cluster Operator by running the commands below.
+If you get an error, open a new terminal session.
+
+<pre class="lang-bash">
+kubectl rabbitmq help
+# USAGE:
+#   Install RabbitMQ Cluster Operator (optionally provide image to use a relocated image or a specific version)
+#     kubectl rabbitmq install-cluster-operator [IMAGE]
+# [...]
+kubectl rabbitmq install-cluster-operator
+# namespace/rabbitmq-system created
+# customresourcedefinition.apiextensions.k8s.io/rabbitmqclusters.rabbitmq.com created
+# serviceaccount/rabbitmq-cluster-operator created
+# role.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-role created
+# clusterrole.rbac.authorization.k8s.io/rabbitmq-cluster-operator-role created
+# rolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-rolebinding created
+# clusterrolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-operator-rolebinding created
+# deployment.apps/rabbitmq-cluster-operator created
+</pre>
 
 -----
 
@@ -38,17 +83,29 @@ Once the RabbitMQ Cluster Kubernetes Operator pod is running, head over to [Usin
 If you can't pull images from Docker Hub directly to your Kubernetes cluster, you need to relocate the images to your private registry first. The exact steps depend on your environment but will likely look like this:
 
 <pre class="lang-bash">
-docker pull rabbitmqoperator/rabbitmq-cluster-kubernetes-operator-dev:latest
-docker tag rabbitmqoperator/rabbitmq-cluster-kubernetes-operator-dev:latest {someregistry}/rabbitmq-cluster-kubernetes-operator-dev:latest
-docker push {someregistry}/cluster-operator:latest
+docker pull rabbitmqoperator/cluster-operator:{some-version}
+docker tag rabbitmqoperator/cluster-operator:{some-version} {someregistry}/cluster-operator-dev:{some-version}
+docker push {someregistry}/cluster-operator:{some-version}
 </pre>
 
-The value of `{someregistry}` should be the address of an OCI compatible registry.
+The value of `{someregistry}` should be the address of an OCI compatible registry. The value of `{some-version}` is
+a version number of the Cluster Operator.
 
-You also need to update the deployment to use your private registry. Run the following command from the `cluster-operator/config/manager` folder **before** the last installation step:
+You also need to update the deployment to use your private registry. [Download the manifest](https://github.com/rabbitmq/cluster-operator/releases)
+from the release you are relocating and edit the section in Deployment image. You can locate this section by `grep`'ing
+the string `image:`
 
 <pre class="lang-bash">
-kustomize edit set image 'controller={someregistry}/rabbitmq-cluster-kubernetes-operator-dev:latest'
+grep -C3 image: releases/rabbitmq-cluster-operator.yaml
+# [...]
+# --
+#           valueFrom:
+#             fieldRef:
+#               fieldPath: metadata.namespace
+#         image: rabbitmqoperator/cluster-operator:0.46.0
+#         name: operator
+#         resources:
+#           limits:
 </pre>
 
 If you require authentication to pull images from your private image registry, you must [Configure Kubernetes Cluster Access to Private Images](#private-images).
@@ -94,24 +151,33 @@ The RabbitMQ cluster operator runs as user ID `1000` and RabbitMQ runs as user I
 By default OpenShift has security context constraints which disallow to create pods running with these user IDs.
 To install the RabbitMQ cluster operator on OpenShift, you need to perform the following steps:
 
-1. In above [installation steps](#installation), after creating the namespace via `kubectl create -f config/namespace/base/namespace.yaml` but before
-creating the manager via `kubectl -n rabbitmq-system create --kustomize config/manager/`, change the following fields:
+1. Download the installation manifest from the [release page in GitHub](https://github.com/rabbitmq/cluster-operator/releases).
 
-<pre class="lang-bash">
-oc edit namespace rabbitmq-system
-</pre>
+    Edit the `Namespace` object named `rabbitmq-system` to include the following annotations:
 
-<pre class="lang-yaml">
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-...
-    openshift.io/sa.scc.supplemental-groups: 1000/1
-    openshift.io/sa.scc.uid-range: 1000/1
-</pre>
+    <pre class="lang-yaml">
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      annotations:
+    ...
+	openshift.io/sa.scc.supplemental-groups: 1000/1
+	openshift.io/sa.scc.uid-range: 1000/1
+    </pre>
 
-2. For every namespace where the RabbitMQ cluster custom resources will be created (here we assume `default` namespace), change the following fields:
+2. Run the installation command.
+  <pre class="lang-yaml">
+  kubectl create -f cluster-operator.yml
+  # namespace/rabbitmq-system created
+  # customresourcedefinition.apiextensions.k8s.io/rabbitmqclusters.rabbitmq.com created
+  # serviceaccount/rabbitmq-cluster-operator created
+  # role.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-role created
+  # clusterrole.rbac.authorization.k8s.io/rabbitmq-cluster-operator-role created
+  # rolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-rolebinding created
+  # clusterrolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-operator-rolebinding created
+  # deployment.apps/rabbitmq-cluster-operator created</pre>
+
+3. For every namespace where the RabbitMQ cluster custom resources will be created (here we assume `default` namespace), change the following fields:
 
 <pre class="lang-bash">
 oc edit namespace default


### PR DESCRIPTION
We have a new 1-step installation method that simplifies the process of installing the Operator. We also added an alternative installation method levaraging the kubectl rabbitmq plugin.

The required RabbitMQ version is 3.8.4+ (it was 3.8.8) because 3.8.4 allows the configuration through `conf.d` style. There is no reason to require 3.8.8 as minimum version.