### PR TITLE
Update the parameter name in the sample of dynamic shovel

### DIFF
--- a/site/shovel-dynamic.md
+++ b/site/shovel-dynamic.md
@@ -71,7 +71,7 @@ different:
 
 <pre class="lang-powershell">
 rabbitmqctl.bat set_parameter shovel my-shovel ^
-  "{""src-protocol"": ""amqp091"", ""src-uri"":""amqp://localhost"", ""source-queue"": ""source-queue"", ^ 
+  "{""src-protocol"": ""amqp091"", ""src-uri"":""amqp://localhost"", ""src-queue"": ""source-queue"", ^ 
    ""dest-protocol"": ""amqp091"", ""dest-uri"": ""amqp://remote.rabbitmq.local"", ^
    ""dest-queue"": ""target-queue""}"
 </pre>


### PR DESCRIPTION
A small issue I found while reading documentation about dynamic shovels. The parameter in the sample should be named `src-queue` instead of `source-queue`.