### PR TITLE
Add PHP tutorial seven to tutorials menu; fix grammar

### DIFF
--- a/site/tutorials/tutorial-seven-java.md
+++ b/site/tutorials/tutorial-seven-java.md
@@ -72,7 +72,7 @@ confirmation with the `Channel#waitForConfirmsOrDie(long)` method.
 The method returns as soon as the message has been confirmed. If the
 message is not confirmed within the timeout or if it is nack-ed (meaning
 the broker could not take care of it for some reason), the method will
-throw an exception. The handling of the exception will usually consists
+throw an exception. The handling of the exception usually consists
 in logging an error message and/or retrying to send the message.
 
 Different client libraries have different ways to synchronously deal with publisher confirms,

--- a/site/tutorials/tutorial-seven-php.md
+++ b/site/tutorials/tutorial-seven-php.md
@@ -72,7 +72,7 @@ confirmation with the `$channel::wait_for_pending_acks(int|float)` method.
 The method returns as soon as the message has been confirmed. If the
 message is not confirmed within the timeout or if it is nack-ed (meaning
 the broker could not take care of it for some reason), the method will
-throw an exception. The handling of the exception will usually consists
+throw an exception. The handling of the exception usually consists
 in logging an error message and/or retrying to send the message.
 
 Different client libraries have different ways to synchronously deal with publisher confirms,

--- a/site/tutorials/tutorials-menu.xml.inc
+++ b/site/tutorials/tutorials-menu.xml.inc
@@ -152,6 +152,7 @@ limitations under the License.
     <ul>
       <li><a href="/tutorials/tutorial-seven-java.html">Java</a></li>
       <li><a href="/tutorials/tutorial-seven-dotnet.html">C#</a></li>
+      <li><a href="/tutorials/tutorial-seven-php.html">PHP</a></li>
     </ul>
   </td>
   <td class="tutorial-empty"></td>


### PR DESCRIPTION
- Add PHP tutorial seven to the tutorials menu.
- Minor grammar fixes.