### PR TITLE
Link RabbitMQ Cluster Operator overview in docs landing page

### DIFF
--- a/site/documentation.md
+++ b/site/documentation.md
@@ -52,6 +52,7 @@ for the original RabbitMQ protocol.
 
 #### Operating Systems and Platforms
 
+ * [Kubernetes](/kubernetes/operator/operator-overview.html)
  * [Debian and Ubuntu](/install-debian.html)
  * [Red Hat Enterprise Linux, CentOS, Fedora](/install-rpm.html)
  * [Windows Installer](/install-windows.html), [Windows-specific Issues](/windows-quirks.html)

--- a/site/download.md
+++ b/site/download.md
@@ -39,7 +39,7 @@ docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-manag
 
 ## Kubernetes
 
- * Open source [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
+ * Open source [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
  * A [peer discovery](/cluster-formation.html) mechanism [for Kubernetes](/cluster-formation.html#peer-discovery-k8s)
  * GKE-, Minikube-, or Kind-based [examples](https://github.com/rabbitmq/diy-kubernetes-examples) that demonstrate a [DIY RabbitMQ on Kubernetes deployment](https://www.rabbitmq.com/blog/2020/08/10/deploying-rabbitmq-to-kubernetes-whats-involved/)
 
@@ -73,7 +73,7 @@ docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-manag
 ## Cloud
 
  * [Tanzu™ RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
- * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
+ * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
  * [CloudAMQP](https://www.cloudamqp.com): RabbitMQ-as-a-Service available in multiple clouds
  * [Amazon EC2](/ec2.html)
 

--- a/site/kubernetes/operator/install-operator.md
+++ b/site/kubernetes/operator/install-operator.md
@@ -9,8 +9,8 @@ If you are installing in OpenShift, follow the instructions in [Installation on 
 
 The Operator requires
 
-* Kubernetes 1.16 or above
-* [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.4+
+* Kubernetes 1.17 or above
+* [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.8+
 
 -----
 
@@ -39,25 +39,14 @@ do not have this manifest. We strongly recommend to install versions 0.46.0+
 
 ### <a id='kubectl-plugin' class='anchor' href='#kubectl-plugin'>Installation using kubectl-rabbitmq plugin</a>
 
-The plugin can be installed by downloading the file and placing it in the system PATH. In most Linux systems, the
-location `/usr/local/bin` is part of the PATH. You can check your current PATH using `echo $PATH`. This plugin presents
-an alternative to install the Cluster Operator. It also provides a shortcut to create and edit `RabbitmqCluster` resources.
-
-The following command downloads the plugin from the main branch:
+The `kubectl rabbitmq` plugin provides commands for managing RabbitMQ clusters.
+The plugin can be installed using [krew](https://github.com/kubernetes-sigs/krew):
 
 <pre class="lang-bash">
-curl -o kubectl-rabbitmq "https://raw.githubusercontent.com/rabbitmq/cluster-operator/main/bin/kubectl-rabbitmq"
+kubectl krew install rabbitmq
 </pre>
 
-Make sure the file is executable and somewhere in the PATH:
-
-<pre class="lang-bash">
-chmod +x kubectl-rabbitmq
-mv kubectl-rabbitmq /usr/local/bin/kubectl-rabbitmq
-</pre>
-
-Test that the plugin installed correctly and install the Cluster Operator by running the commands below.
-If you get an error, open a new terminal session.
+To get the list of available commands, use:
 
 <pre class="lang-bash">
 kubectl rabbitmq help
@@ -102,7 +91,7 @@ grep -C3 image: releases/rabbitmq-cluster-operator.yaml
 #           valueFrom:
 #             fieldRef:
 #               fieldPath: metadata.namespace
-#         image: rabbitmqoperator/cluster-operator:0.46.0
+#         image: rabbitmqoperator/cluster-operator:0.49.0
 #         name: operator
 #         resources:
 #           limits:

--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -49,7 +49,7 @@ versions.
 
 The Operator requires
 
- * Kubernetes 1.16 or above
+ * Kubernetes 1.17 or above
  * [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.8+
 
 
@@ -69,17 +69,3 @@ a new `Secret` will be created with new username and password, but those will no
 It works the same way for any `Secret` value, e.g. the value of the [shared inter-node authentication secret](/clustering.html#erlang-cookie)
 known as the Erlang cookie.
 
-## <a id='plugin' class='anchor' href='#plugin'>kubectl plugin</a>
-
-The `kubectl rabbitmq` plugin provides commands for managing RabbitMQ clusters.
-The plugin can be installed using [krew](https://github.com/kubernetes-sigs/krew):
-
-<pre class="lang-bash">
-kubectl krew install rabbitmq
-</pre>
-
-To get the list of available commands, use:
-
-<pre class="lang-bash">
-kubectl rabbitmq help
-</pre>


### PR DESCRIPTION
In the documentation landing page, there is now a link to the overview of Cluster Operator. This should make Cluster Operator docs more accessible and easier to find.

An alternative path is "Docs" -> "Installation and provisioning" -> "Kubernetes". This path takes the user to the installation guide.

Related to https://github.com/rabbitmq/cluster-operator/issues/456