### PR TITLE
Remove  bad link on service page to Open Source Architect

### DIFF
--- a/site/services.md
+++ b/site/services.md
@@ -46,9 +46,8 @@ based on the [RabbitMQ Operator for Kubernetes](https://www.rabbitmq.com/kuberne
 
 The following companies provide free, virtual, or instructor-led courses for RabbitMQ:
 [VMware](https://academy.pivotal.io/store-catalog),
-[Erlang Solutions](https://www.erlang-solutions.com/products/rabbitmq.html),
-[LearnQuest](http://www.learnquest.com/course-detail.aspx?cnum=rabbitmq-e1xc) and
-[Open Source Architect](https://opensource.io/product/rabbitmq-training/).
+[Erlang Solutions](https://www.erlang-solutions.com/products/rabbitmq.html) and
+[LearnQuest](http://www.learnquest.com/course-detail.aspx?cnum=rabbitmq-e1xc).
 These <strong>training courses</strong> cover learning messaging with RabbitMQ, use cases, patterns,
 best practice design and architecture.
 


### PR DESCRIPTION
Remove bad link.

See  https://github.com/rabbitmq/rabbitmq-website/issues/1103