### PR TITLE
Fix typos, use https links

### DIFF
--- a/site/documentation.md
+++ b/site/documentation.md
@@ -244,7 +244,7 @@ many popular programming languages are also available, as is an [AMQP 0-9-1 Over
 ## References
 
  * [Java](https://rabbitmq.github.io/rabbitmq-java-client/api/current/)
- * [.NET](http://rabbitmq.github.io/rabbitmq-dotnet-client/index.html)
+ * [.NET](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html)
  * [AMQP 0-9-1 URI Specification](/uri-spec.html)
  * [URI Query Parameters](/uri-query-parameters.html)
   

--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -37,7 +37,7 @@ Key sections of the guide are:
 * [Concurrency Considerations and Safety](#concurrency)
 * [Automatic Recovery From Network Failures](#recovery)
 
-An [API reference](http://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.html) is available separately.
+An [API reference](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.html) is available separately.
 
 
 ## <a id="dotnet-versions" class="anchor" href="#dotnet-versions">.NET Version Requirements</a>
@@ -269,7 +269,7 @@ within an application. The name is optional; however, developers are strongly en
 as it would significantly simplify certain operational tasks.
 
 RabbitMQ .NET client provides a connection factory property,
-[`ConnectionFactory.ClientProvidedName`](http://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.ConnectionFactory.html#RabbitMQ_Client_ConnectionFactory_ClientProvidedName),
+[`ConnectionFactory.ClientProvidedName`](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.ConnectionFactory.html#RabbitMQ_Client_ConnectionFactory_ClientProvidedName),
 which, if set, controls the client-provided connection name for all new connections opened
 by this factory.
 

--- a/site/dotnet.md
+++ b/site/dotnet.md
@@ -100,7 +100,7 @@ Release notes can be found [on GitHub](https://github.com/rabbitmq/rabbitmq-dotn
 
 Please refer to the [RabbitMQ tutorials](/getstarted.html) and [.NET client user guide](/dotnet-api-guide.html).
 
-There's also [an online API reference](http://rabbitmq.github.io/rabbitmq-dotnet-client/index.html).
+There's also [an online API reference](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html).
 
 
 ## <a id="changelog" class="anchor" href="#changelog">Change log</a>

--- a/site/erlang-distribution-compression.md
+++ b/site/erlang-distribution-compression.md
@@ -9,7 +9,7 @@ This is based on TCP/IP connections and the exchanged data can be plain or
 ciphered if [SSL is configured](clustering-ssl.html).
 
 As the name suggests, Erlang distribution compression adds a third transport
-solution: compression. It allows inter-node communication to be reduce by up to
+solution: compression. It allows inter-node communication to be reduced by up to
 96%, depending on the nature of the data being compressed.
 
 <p class="box-info">
@@ -58,7 +58,7 @@ following things:
    remote node and specifies the list of algorithms it supports.
 
 4. The remote node compares the received list of algorithms to its own list.
-   The remode node's list is ordered by preference. The selected algorithm is
+   The remote node's list is ordered by preference. The selected algorithm is
    the first one in the remote node's list which is also supported by the
    initiating node. If there is no algorithm in common, the connection remains
    uncompressed and following steps are skipped.
@@ -66,7 +66,7 @@ following things:
 5. Once an algorithm is selected, the remote node **sends a message back to the
    initiating node to inform it of its decision**.
 
-6. The two nodes synhronize to **start compression** on the existing TCP
+6. The two nodes synchronize to **start compression** on the existing TCP
    connection.
 
 ## <a id="limitations" class="anchor" href="#limitations">Limitations</a>
@@ -79,7 +79,7 @@ following things:
     Erlang application to deal with the algorithm negotiation. The distribution
     module is a replacement to the default module (`inet_tcp_dist`) or the
     SSL-based one (`inet_tls_dist`). It is impossible to use two modules
-    simulatenously.
+    simultaneously.
 
 *   In VMware Tanzu RabbitMQ, the compression code relies on native libraries.
     **Only Linux/amd64 is supported** in the existing packaging. We might

--- a/site/rabbit.ent
+++ b/site/rabbit.ent
@@ -27,7 +27,7 @@ limitations under the License.
 <!ENTITY dir-server "rabbitmq-server/v&version-server;">
 
 <!ENTITY dir-dotnet-client "releases/rabbitmq-dotnet-client">
-<!ENTITY url-dotnet-apidoc-root "http://rabbitmq.github.io/rabbitmq-dotnet-client">
+<!ENTITY url-dotnet-apidoc-root "https://rabbitmq.github.io/rabbitmq-dotnet-client">
 <!ENTITY url-dotnet-apidoc "&url-dotnet-apidoc-root;/api">
 
 <!ENTITY dir-java-client "rabbitmq-java-client/v&version-java-client;">

--- a/site/ssl.md
+++ b/site/ssl.md
@@ -266,7 +266,7 @@ ssl_options.fail_if_no_peer_cert = true
 </pre>
 
 This configuration will also perform [peer certificate chain verification](#peer-verification)
-so clients clients without any certificates will be rejected.
+so clients without any certificates will be rejected.
 
 It is possible to completely disable regular (non-TLS) listeners. Only TLS-enabled
 clients would be able to connect to such a node, and only if they use the correct port:


### PR DESCRIPTION
- Fix a few typos
- Turn rabbitmq.github.io links into https