### PR TITLE
Fix schema in WebSocket connection string

### DIFF
--- a/site/web-stomp.md
+++ b/site/web-stomp.md
@@ -56,7 +56,7 @@ is included as part of [RabbitMQ Web STOMP examples](https://github.com/rabbitmq
 The WebSocket endpoint is available on the `/ws` path:
 
 <pre class="lang-plaintext">
-http://127.0.0.1:15674/ws
+ws://127.0.0.1:15674/ws
 </pre>
 
 This endpoint will only work with Websocket capable clients. Note that


### PR DESCRIPTION
Fixes the schema of a WebSocket URL to use `ws` instead of `http`.