### PR TITLE
Replace deprecated php-amqplib API

### DIFF
--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -265,9 +265,7 @@ $callback = function ($req) {
         '',
         $req->get('reply_to')
     );
-    $req->delivery_info['channel']->basic_ack(
-        $req->delivery_info['delivery_tag']
-    );
+    $req->ack();
 };
 
 $channel->basic_qos(null, 1, null);

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -217,7 +217,7 @@ $callback = function ($msg) {
   echo ' [x] Received ', $msg->body, "\n";
   sleep(substr_count($msg->body, '.'));
   echo " [x] Done\n";
-  $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+  $msg->ack();
 };
 
 $channel->basic_consume('task_queue', '', false, false, false, false, $callback);
@@ -421,7 +421,7 @@ $callback = function ($msg) {
     echo ' [x] Received ', $msg->body, "\n";
     sleep(substr_count($msg->body, '.'));
     echo " [x] Done\n";
-    $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+    $msg->ack();
 };
 
 $channel->basic_qos(null, 1, null);


### PR DESCRIPTION
As of php-amqplib version 2.12.0 (see PR: https://github.com/php-amqplib/php-amqplib/pull/799) we should use method `ack()` on the message directly.
