### PR TITLE
Fix links, spelling, punctuation, wording, example code

### DIFF
--- a/site/clients.md
+++ b/site/clients.md
@@ -37,7 +37,7 @@ limitations under the License.
 
  * [Downloads and Installation](erlang-client.html)
  * [API Guide](erlang-client-user-guide.html)
- * [API Reference](https://hexdocs.pm/amqp_client/" target="_blank)
+ * <a href="https://hexdocs.pm/amqp_client/" target="_blank">API Reference</a>
 
 ## Other Resources
 

--- a/site/connection-blocked.md
+++ b/site/connection-blocked.md
@@ -31,7 +31,7 @@ To receive these notifications, the client must present a
 `capabilities` table in its `client-properties` in which there is a key
 `connection.blocked` and a boolean value `true`.
 
-See the [capabilities](#capabilities) section for further
+See the [capabilities](/consumer-cancel.html#capabilities) section for further
 details on this. Our supported clients indicate this capability
 by default and provide a way to register handlers for the
 `connection.blocked` and `connection.unblocked` methods.

--- a/site/definitions-standby.md
+++ b/site/definitions-standby.md
@@ -63,7 +63,7 @@ The plugin has two sides on a schema replication link (connection):
 
 Downstreams connect to their upstream and periodically initiate sync operations. These
 operations synchronise the schema on the downstream side with that of the upstream,
-with some safety mechanisms (covered laster in this guide).
+with some safety mechanisms (covered later in this guide).
 
  A node running in the downstream mode (a follower) can be **converted to an upstream** (leader)
  on the fly. This will make it disconnect from its original source, therefore stopping all
@@ -123,7 +123,7 @@ A node participating in schema definition syncing must be provided with two piec
  * What mode it operates in, `upstream` (leader) or `downstream` (passive follower)
  * Upstream connection endpoints
 
-This is true for both upstreams and downtreams.
+This is true for both upstreams and downstreams.
 
 The mode must be provided in the config file. Supported values are `upstream`
 and `downstream`, respectively:

--- a/site/erlang-distribution-compression.md
+++ b/site/erlang-distribution-compression.md
@@ -72,7 +72,7 @@ following things:
 ## <a id="limitations" class="anchor" href="#limitations">Limitations</a>
 
 *   Erlang distribution **compression and SSL can't be used at the same time**:
-    the user must choose between both.
+    the user must choose between them.
 
     The reason is that the Erlang node is configured with a specific
     distribution module provided with VMware Tanzu RabbitMQ, plus a small

--- a/site/federated-exchanges.md
+++ b/site/federated-exchanges.md
@@ -170,7 +170,7 @@ to be upstream from it. More complex multiply-connected arrangements are allowed
 Such complex topologies will be increasingly difficult to reason about and troubleshoot, however.
 
 To prevent messages being continually copied and re-routed (in a never-ending cycle) there is a limit placed
-on the number of times a message can be copied over a link [`max-hops`](#upstream-sets) below).
+on the number of times a message can be copied over a link ([`max-hops`](#upstream-sets) below).
 
 It is recommended that all the exchanges linked by federation are of the
 same type. Mixing types can and likely will lead to confusing routing behaviours.

--- a/site/federated-queues.md
+++ b/site/federated-queues.md
@@ -41,7 +41,7 @@ to one or more downstreams, federated queues move data where the consumers are,
 always preferring local consumers to remote ones. Federated queues are considered
 to be equal peers, there is no "leader/follower" relationship between them like with federated exchanges.
 
-A federated queue links to other its federated peers (called _upstream_ queues).
+A federated queue links to other of its federated peers (called _upstream_ queues).
 It will retrieve messages from upstream queues in order to satisfy demand for
 messages from local consumers. The upstream queues do not
 need to be reconfigured. They are assumed to be located on a separate node or in a separate

--- a/site/install-windows.md
+++ b/site/install-windows.md
@@ -311,4 +311,4 @@ In the event that the Erlang VM terminates when RabbitMQ is running
 as a service, rather than writing the crash dump to the current
 directory (which doesn't make sense for a service) it is written
 to an `erl_crash.dump` file in the [base directory](/relocate.html) of
-the RabbitMQ server, defaulting to `%APPDATA%\%RABBITMQ_SERVICENAME%` - typically `%APPDATA%\RabbitMQ` otherwise).
+the RabbitMQ server, defaulting to `%APPDATA%\%RABBITMQ_SERVICENAME%` - typically `%APPDATA%\RabbitMQ` otherwise.

--- a/site/kubernetes/operator/troubleshooting-operator.md
+++ b/site/kubernetes/operator/troubleshooting-operator.md
@@ -54,9 +54,9 @@ Potential solution is to create the PodSecurityPolicy and RBAC resources by foll
 ### <a id="pods-stuck-in-terminating-state" class="anchor" href="#pods-stuck-in-terminating-state">Pods Are Stuck in the Terminating State</a>
 
 symptom: "After deleting a RabbitmqCluster instance, some Pods
-are stuck in the terminating state. RabbitMQ is still running in the affected Pods.
+are stuck in the terminating state. RabbitMQ is still running in the affected Pods."
 
-cause: "The likely cause is a leftover quorum queue in RabbitMQ.",
+cause: "The likely cause is a leftover quorum queue in RabbitMQ."
 
 Potential solution to resolve this issue:
 

--- a/site/management.md
+++ b/site/management.md
@@ -392,7 +392,7 @@ management.tcp.port = 15672
 </pre>
 
 It is possible to configure what interface the API endpoint will use, similarly
-to [messaging protoco listeners](/networking.html#interfaces), using
+to [messaging protocol listeners](/networking.html#interfaces), using
 the `management.tcp.ip` key:
 
 <pre class="lang-ini">

--- a/site/management.md
+++ b/site/management.md
@@ -675,10 +675,10 @@ management.enable_queue_totals = true
 ### <a id="csp" class="anchor" href="#csp">Content Security Policy (CSP)</a>
 
 It is possible to configure what [CSP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) value
-is used by HTTP API responses. The default value is `script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'"`:
+is used by HTTP API responses. The default value is `script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'`:
 
 <pre class="lang-ini">
-management.csp.policy = script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'"
+management.csp.policy = script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'
 </pre>
 
 The value can be any valid CSP header string:

--- a/site/memory-use.md
+++ b/site/memory-use.md
@@ -545,8 +545,8 @@ and increase the percentage of efficiently used memory. The right set of setting
 the workload and message payload size distribution.
 
 Runtime's memory allocator behavior can be tuned, please refer to
-[erl](http://erlang.org/doc/man/erl.html" target="_blank) and
-[erts_alloc](http://erlang.org/doc/man/erts_alloc.html" target="_blank)
+<a href="http://erlang.org/doc/man/erl.html" target="_blank">erl</a> and
+<a href="http://erlang.org/doc/man/erts_alloc.html" target="_blank">erts_alloc</a>
 documentation.
 
 

--- a/site/memory-use.md
+++ b/site/memory-use.md
@@ -576,10 +576,10 @@ Some messages can be stored on disk, but still have their metadata kept in memor
 
 ### <a id="queue-memory-usage" class="anchor" href="#queue-memory-usage">How much memory does a queue use?</a>
 
-A message has multiple parts that use up memory. Every queue is backed an Erlang process.
+A message has multiple parts that use up memory. Every queue is backed by an Erlang process.
 If a queue is mirrored, each mirror is a separate Erlang process.
 
-Since a queues master is a single Erlang process, message ordering can be guaranteed.
+Since a queue's master is a single Erlang process, message ordering can be guaranteed.
 Multiple queues means multiple Erlang processes which get an even amount of CPU time.
 This ensures that no queue can block other queues.
 
@@ -598,7 +598,7 @@ curl -s -u guest:guest http://127.0.0.1:15672/api/queues/%2f/queue-name |
 }
 </pre>
 
- * `memory`: memory used by the queue process, accounts message metadata (at least 720 bytes per message), does not account for message payloads over 64 bytes
+ * `memory`: memory used by the queue process, accounts for message metadata (at least 720 bytes per message), does not account for message payloads over 64 bytes
  * `message_bytes_ram`: memory used by the message payloads, regardless of the size
 
 If messages are small, message metadata can use more memory than the message payload.
@@ -613,7 +613,7 @@ Erlang uses [generational garbage collection](https://www.erlang-solutions.com/b
 Garbage collection is done per queue, independently of all other Erlang processes.
 
 When garbage collection runs, it will copy used process memory before deallocating unused memory.
-This can can lead to the queue process using up to twice as much memory during garbage collection, as shown here (queue contains a lot of messages):
+This can lead to the queue process using up to twice as much memory during garbage collection, as shown here (queue contains a lot of messages):
 
 <img class="screenshot" src="img/memory/queue-memory-usage-spikes.png" alt="Queue under load memory usage" title="Queue under load memory usage" />
 

--- a/site/memory-use.md
+++ b/site/memory-use.md
@@ -392,7 +392,7 @@ curl -s -u guest:guest http://127.0.0.1:15672/api/nodes/rabbit@mercurio/memory/r
 
 ### <a id="breakdown-connections" class="anchor" href="#breakdown-connections">Connections</a>
 
-This includes memory used by client connections (including [Shovels](/shovel.html) and [Federation links](/federation.html)
+This includes memory used by client connections (including [Shovels](/shovel.html) and [Federation links](/federation.html))
 and channels, and outgoing ones (Shovels and Federation upstream links). Most of the memory
 is usually used by TCP buffers, which on Linux autotune to about 100 kB in size by default.
 TCP buffer size can be reduced at the cost of a proportional decrease in connection throughput.

--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -118,7 +118,7 @@ Collect the following metrics on all hosts that run RabbitMQ nodes or applicatio
  * Free disk space on the mount used for the [node data directory](/relocate.html)
  * File descriptors used by `beam.smp` vs. [max system limit](/networking.html#open-file-handle-limit)
  * TCP connections by state (`ESTABLISHED`, `CLOSE_WAIT`, `TIME_WAIT`)
- * Network throughput (bytes received, bytes sent) & maximum network throughput)
+ * Network throughput (bytes received, bytes sent) & maximum network throughput
  * Network latency (between all RabbitMQ nodes in a cluster as well as to/from clients)
 
 There is no shortage of existing tools (such as Prometheus or Datadog) that collect infrastructure
@@ -427,8 +427,8 @@ immediately obvious which component is misbehaving. Every single part of the sys
 applications, should be monitored and investigated.
 
 Some infrastructure-level and RabbitMQ metrics can show
-presence of an unusual system behaviour or issue but can't pin
-point the root cause. For example, it is easy to tell that a
+presence of an unusual system behaviour or issue but can't
+pinpoint the root cause. For example, it is easy to tell that a
 node is running out of disk space but not always easy to tell why.
 This is where application metrics come in: they can help identify
 a run-away publisher, a repeatedly failing consumer, a consumer that cannot

--- a/site/prometheus.md
+++ b/site/prometheus.md
@@ -399,7 +399,7 @@ default.
 Once RabbitMQ is configured to expose metrics to Prometheus, Prometheus should be made
 aware of where it should scrape RabbitMQ metrics from. There are a number of ways of doing this.
 Please refer to the official <a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/"
-target="_blank">Prometheus configuration documentation</a> .
+target="_blank">Prometheus configuration documentation</a>.
 There's also a <a href="https://prometheus.io/docs/introduction/first_steps/" target="_blank">first steps with Prometheus</a> guide
 for beginners.
 
@@ -446,7 +446,7 @@ prometheus.tcp.port = 15692
 </pre>
 
 It is possible to configure what interface the Prometheus plugin API endpoint will use, similarly
-to [messaging protoco listeners](/networking.html#interfaces), using
+to [messaging protocol listeners](/networking.html#interfaces), using
 the `prometheus.tcp.ip` key:
 
 <pre class="lang-ini">

--- a/site/troubleshooting-networking.md
+++ b/site/troubleshooting-networking.md
@@ -32,7 +32,7 @@ that help narrow most common issues down efficiently.
 
 Networking protocols are [layered](https://en.wikipedia.org/wiki/OSI_model#Comparison_with_TCP.2FIP_model).
 So are problems with them. An effective troubleshooting
-strategy typically uses the process of elimination to pin point the issue (or multiple issues),
+strategy typically uses the process of elimination to pinpoint the issue (or multiple issues),
 starting at higher levels. Specifically for messaging technologies, the following steps
 are often effective and sufficient:
 
@@ -85,7 +85,7 @@ In modern versions either tool can be used to run those commands but
 [rabbitmq-diagnostics][2] is what most documentation guides
 will typically recommend.
 
-The listeners sections will look something like this:
+The listeners section will look something like this:
 
 <pre class="lang-ini">
 Interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication

--- a/site/troubleshooting-ssl.md
+++ b/site/troubleshooting-ssl.md
@@ -58,7 +58,7 @@ This step checks that the broker is listening on the [expected port(s)](/network
 To verify that TLS has been enabled on the node, use <code>[rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html) listeners</code>
 or the <code>listeners</code> section in <code>[rabbitmqctl](/rabbitmqctl.8.html) status</code>.
 
-The listeners sections will look something like this:
+The listeners section will look something like this:
 
 <pre class="lang-ini">
 Interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication

--- a/site/tutorials/tutorial-five-dotnet.md
+++ b/site/tutorials/tutorial-five-dotnet.md
@@ -291,4 +291,4 @@ with more than two routing key parameters.
 (Full source code for [EmitLogTopic.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/EmitLogTopic/EmitLogTopic.cs)
 and [ReceiveLogsTopic.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/ReceiveLogsTopic/ReceiveLogsTopic.cs))
 
-Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-dotnet.html)
+Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-dotnet.html).

--- a/site/tutorials/tutorial-four-javascript.md
+++ b/site/tutorials/tutorial-four-javascript.md
@@ -370,7 +370,7 @@ And, for example, to emit an `error` log message just type:
 
 
 (Full source code for [(emit_log_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/emit_log_direct.js)
-and [(receive_logs_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive_logs_direct.js)
+and [(receive_logs_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive_logs_direct.js))
 
 Move on to [tutorial 5](tutorial-five-javascript.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-six-dotnet.md
+++ b/site/tutorials/tutorial-six-dotnet.md
@@ -98,7 +98,7 @@ channel.BasicPublish(exchange: "",
 > a message. Most of the properties are rarely used, with the exception of
 > the following:
 >
-> * `Persistent`: : Marks a message as persistent (with a value of `2`)
+> * `Persistent`: Marks a message as persistent (with a value of `true`)
 >    or transient (any other value). Take a look at [the second tutorial](tutorial-two-dotnet.html).
 > * `DeliveryMode`: those familiar with the protocol may choose to use this
 >    property instead of `Persistent`. They control the same thing.

--- a/site/tutorials/tutorial-six-spring-amqp.md
+++ b/site/tutorials/tutorial-six-spring-amqp.md
@@ -38,7 +38,7 @@ service that returns Fibonacci numbers.
 ### Client interface
 
 To illustrate how an RPC service could be used we're going to
-change the names of our profiles from "Sender" and "Receiver
+change the names of our profiles from "Sender" and "Receiver"
 to "Client" and "Server". When we call the server we will get
 back the fibonacci of the argument we call with. 
 

--- a/site/tutorials/tutorial-six-spring-amqp.md
+++ b/site/tutorials/tutorial-six-spring-amqp.md
@@ -278,7 +278,7 @@ from the queue to the exchange with the `rpc` routing-key.
 The server code is rather straightforward:
 
   * As usual we start annotating our receiver method with a `@RabbitListener`
-    and defining the queue its listening on. 
+    and defining the queue it's listening on.
   * Our Fibonacci method calls fib() with the payload parameter and returns
     the result
   
@@ -319,7 +319,7 @@ is as easy as the server:
     exchange name, routing key and message.
   * We print the result
 
-Making the client request is simply:
+Making the client request is simple:
 
 <pre class="lang-java">
 import org.springframework.amqp.core.DirectExchange;

--- a/site/tutorials/tutorial-two-spring-amqp.md
+++ b/site/tutorials/tutorial-two-spring-amqp.md
@@ -122,7 +122,7 @@ public class Tut2Config {
 ### Sender
 
 We will modify the sender to provide a means for identifying
-whether its a longer running task by appending a dot to the
+whether it's a longer running task by appending a dot to the
 message in a very contrived fashion using the same method
 on the `RabbitTemplate` to publish the message, `convertAndSend`.
 The documentation defines this as, "Convert a Java object to

--- a/site/uri-query-parameters.md
+++ b/site/uri-query-parameters.md
@@ -39,7 +39,7 @@ when they are.
 Example (non-encrypted):
 
 <pre class="lang-ini">
-amqp://myhost?heartbeat=10&amp;connection_timeout=10000
+amqp://myhost?heartbeat=5&amp;connection_timeout=10000
 </pre>
 
 This specifies a (non-encrypted) network connection to the host

--- a/site/windows-quirks.md
+++ b/site/windows-quirks.md
@@ -38,7 +38,7 @@ set DIST_PORT=44556
 
  * Install the RabbitMQ Windows service using `.\rabbitmq-service.bat install`
  * Start the RabbitMQ Windows service using `.\rabbitmq-service.bat start`
- * Verify what port being used for inter-node and CLI tool communication:
+ * Verify what port is being used for inter-node and CLI tool communication:
 
 <pre class="lang-bash">
 epmd -names


### PR DESCRIPTION
- Fix invalid links
- Correct spelling
- Fix punctuation
- Improve wording
- Fix incorrect example code