### PR TITLE
acknowledgements are actually turned _on_ by default

### DIFF
--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -207,7 +207,7 @@ There aren't any message timeouts; RabbitMQ will redeliver the message when
 the consumer dies. It's fine even if processing a message takes a very, very
 long time.
 
-Message acknowledgments are turned off by default.
+Message acknowledgments were previously turned off by ourselves.
 It's time to turn them on by setting the fourth parameter to `basic_consume` to `false`
 (true means _no ack_) and send a proper acknowledgment
 from the worker, once we're done with a task.


### PR DESCRIPTION
I'd rather prefer to use named parameters if it wasn't such a young feature in PHP (introduced just a month ago):
```php
$channel->basic_consume($queueName, no_ack: true, callback: $callback);
```
But since it's so young, maybe it's better to use an old syntax. But it's yet worth to fix the false statement that `no_ack` is turned off by default.

@pivotal-issuemaster This is an Obvious Fix