### PR TITLE
Remove broken links from the website

### DIFF
--- a/site/how.xml
+++ b/site/how.xml
@@ -166,7 +166,7 @@ limitations under the License.
           <a href="/resources/SkillsMatterCloudAndGridExchange2010RabbitMQCloudMessagingUseCases.pdf">PDF of the slides</a>, 3.2MB).
     </li>
     <li>
-    <a href="http://helenaedelson.com/?p=685">Why RabbitMQ for Cloud?</a><br/>
+    <a href="https://web.archive.org/web/20170115215106/http://helenaedelson.com/?p=685">Why RabbitMQ for Cloud?</a><br/>
     Holly Edelson explains why RabbitMQ is ideal for implementing a cloud messaging solution.
   </li>
   <li>

--- a/site/how.xml
+++ b/site/how.xml
@@ -227,11 +227,6 @@ limitations under the License.
           <a href="https://forge.puppet.com/puppet/rabbitmq">Puppet Module</a><br />
           A module for managing RabbitMQ with Puppet.
         </li>
-        <li>
-          <a href="http://del.icio.us/alexisrichardson/rabbitmq+management">RabbitMQ Management</a> and
-          <a href="http://del.icio.us/alexisrichardson/rabbitmq+monitoring">RabbitMQ Monitoring</a> on del.icio.us<br />
-          More links to what others are doing to manage and monitor RabbitMQ.
-        </li>
       </ul>
     </doc:section>
     <doc:section name="messaging-patterns">


### PR DESCRIPTION
Hi,

I found at least 2 broken links in the how to section.

I switch one to the archived version of the article and removed the second as it was never archived.

![Capture d’écran de 2021-01-12 14-24-19](https://user-images.githubusercontent.com/1225931/104320400-912e3a00-54e2-11eb-8399-2db1342bfde9.png)
![Capture d’écran de 2021-01-12 14-22-23](https://user-images.githubusercontent.com/1225931/104320403-91c6d080-54e2-11eb-984c-88112e2c1419.png)
