### PR TITLE
Add quickstart guide

### DIFF
--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -17,6 +17,7 @@ used by applications running on Kubernetes or outside of Kubernetes.
 
 Documentation of the Operator spans several guides:
 
+ * [Quickstart RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/quickstart-operator.html)
  * [Installing RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html)
  * [Using RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/using-operator.html)
  * [Monitoring RabbitMQ Clusters on Kubernetes](/kubernetes/operator/operator-monitoring.html)

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -170,9 +170,9 @@ kubectl rabbitmq tail hello-world
 Next, let's access the Management UI.
 
 ```shell
-username=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)
+username="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)"
 echo "username: $username"
-password=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)
+password="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)"
 echo "password: $password"
 
 kubectl port-forward "service/hello-world" 15672
@@ -197,10 +197,10 @@ Next step, would be to connect an application to the RabbitMQ Cluster in order t
 Here, we will be using the `hello-world` service to find the connection address, and the `hello-world-default-user` to find connection credentials.
 
 ```shell
-username=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)
-password=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)
-service=$(kubectl get service hello-world -o jsonpath='{.spec.clusterIP}')
-kubectl run perf-test --image=pivotalrabbitmq/perf-test -- --uri amqp://{username}:{password}@{service}
+username="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)"
+password="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)"
+service="$(kubectl get service hello-world -o jsonpath='{.spec.clusterIP}')"
+kubectl run perf-test --image=pivotalrabbitmq/perf-test -- --uri amqp://$username:$password@$service
 
 # pod/perf-test created
 ```

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -124,15 +124,6 @@ NAME          AGE    STATUS
 hello-world   4m10s
 ```
 
-Briefly breaking down what the `hello-world` RabbitMQ Cluster has created in terms of Kubernetes objects -
-
-- a `hello-world-server-0` pod. This pod runs a single container which is loaded with the RabbitMQ Image. By default, this is the [Community RabbitMQ image available on Dockerhub](https://hub.docker.com/_/rabbitmq).
-- a statefulset `hello-world-server`. The RabbitMQ server pods are wrapped with the stateful set abstraction of Kubernetes which ensures pod restarts on failure, ordered upgrades, etc. If you wish to understand why statefulsets are the chosen abstraction, you can read the [diy RabbitMQ on Kubernetes blog post](https://www.rabbitmq.com/blog/tag/diy/).
-- a service `hello-world` and a service `hello-world-nodes`. Here, the `hello-world` service opens ports `5672` and `15672` which are the `amqp` and the Management UI ports. It is the `hello-world` service that is used to interact and connect with the RabbitMQ server. Conversely, the `hello-world-nodes` service is used only for inter-node communication.
-
-There are other resources such as Secrets, ConfigMaps, etc, that are also created, but for the sake for brevity, we will move on in this quickstart.
-
-
 ## View RabbitMQ Logs
 
 In order to make sure RabbitMQ has started correctly, let's view the RabbitMQ log file. This can be done by viewing the RabbitMQ pod logs. In this case, it would be -
@@ -192,7 +183,7 @@ kubectl rabbitmq manage hello-world
 
 ## Connect An Application To The Cluster
 
-Next step, would be to connect an application to the RabbitMQ Cluster in order to use it's messaging capabilities. The [perf-test](https://github.com/rabbitmq/rabbitmq-perf-test) application is frequently used within the RabbitMQ community for load testing a RabbitMQ Cluster.
+The next step would be to connect an application to the RabbitMQ Cluster in order to use it's messaging capabilities. The [perf-test](https://github.com/rabbitmq/rabbitmq-perf-test) application is frequently used within the RabbitMQ community for load testing RabbitMQ Clusters.
 
 Here, we will be using the `hello-world` service to find the connection address, and the `hello-world-default-user` to find connection credentials.
 

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -87,7 +87,7 @@ metadata:
 ```
 Submit this using the following command -
 ```shell
-kubectl apply -f https//raw.githubusercontent.com/rabbitmq/cluster-operator/main/docs/examples/hello-world/rabbitmq.yaml
+kubectl apply -f https://raw.githubusercontent.com/rabbitmq/cluster-operator/main/docs/examples/hello-world/rabbitmq.yaml
 ```
 
 This will create  a RabbitMQ cluster called `hello-world` in the current namespace. You can see the RabbitMQ Cluster as it is being created:

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -1,0 +1,237 @@
+# Quickstart
+
+This is the fastest way to get up and running with a RabbitMQ cluster deployed by the Cluster Operator. More detailed resources are available for [installation](/kubernetes/operator/install-operator.html), [usage](/kubernetes/operator/using-operator.html) and [API reference](/kubernetes/operator/using-operator.html).
+
+## Prerequisites
+
+- Access to a Kubernetes cluster version 1.17 or above
+- `kubectl` configured to access the cluster
+
+## Quickstart Steps
+
+This guide is goes through the following steps -
+1. Install the RabbitMQ Cluster Operator
+2. Deploy a RabbitMQ Cluster using the Operator
+3. View RabbitMQ Logs
+4. Access the RabbitMQ Management UI
+5. Attach A Workload to the Cluster
+6. Next Steps
+
+## The `kubectl rabbitmq` Plugin
+
+Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at it's [installation instructions](/Kubernetes/operator/install-operator.html).
+
+## Install the RabbitMQ Cluster Operator
+
+Let's start by installing the latest version of the Cluster Operator. This can done directly using `kubectl apply` -
+
+```shell
+kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml"
+# namespace/rabbitmq-system created
+# customresourcedefinition.apiextensions.k8s.io/rabbitmqclusters.rabbitmq.com created
+# serviceaccount/rabbitmq-cluster-operator created
+# role.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-role created
+# clusterrole.rbac.authorization.k8s.io/rabbitmq-cluster-operator-role created
+# rolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-rolebinding created
+# clusterrolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-operator-rolebinding created
+# deployment.apps/rabbitmq-cluster-operator created
+```
+
+The Cluster Operator can also be installed using the `kubectl rabbitmq` plugin -
+
+```shell
+kubectl rabbitmq install-cluster-operator
+```
+
+Installing the Cluster Operator creates a bunch of Kubernetes resources. Breaking these down, we have:
+- a new namespace `rabbitmq-system`. The Cluster Operator deployment is created in this namespace.
+```shell
+kubectl get all -n rabbitmq-system
+
+NAME                                             READY   STATUS    RESTARTS   AGE
+pod/rabbitmq-cluster-operator-54f948d8b6-k79kd   1/1     Running   0          2m10s
+
+NAME                                        READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/rabbitmq-cluster-operator   1/1     1            1           2m10s
+
+NAME                                                   DESIRED   CURRENT   READY   AGE
+replicaset.apps/rabbitmq-cluster-operator-54f948d8b6   1         1         1       2m10s
+```
+- a new custom resource `rabbitmqclusters.rabbitmq.com`. The custom resource allows us to define an API for the creation of RabbitMQ Clusters.
+```shell
+kubectl get customresourcedefinitions.apiextensions.k8s.io
+
+NAME                                             CREATED AT
+...
+rabbitmqclusters.rabbitmq.com                    2021-01-14T11:12:26Z
+...
+```
+- and some rbac roles. These are required by the Operator to create, update and delete RabbitMQ Clusters.
+
+## Hello RabbitMQ!
+
+Now that we have the Operator deployed, let's create the simplest RabbitMQ Cluster.
+
+This example can be found in the [Cluster Operator GitHub repo](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/hello-world).  As mentioned on the page:
+> This is the simplest `RabbitmqCluster` definition. The only explicitly specified property is the name of the cluster. Everything else will be configured according to the Cluster Operator's defaults.
+
+The [examples folder](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) has many other references such as creating a RabbitMQ Cluster with TLS, mTLS, setting up a Cluster with production defaults, adding community plugins, etc.
+
+Continuing with our example, we will submit the following yaml to Kubernetes:
+
+```yaml
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+	name: hello-world
+```
+Submit this using the following command -
+```shell
+kubectl apply -f https//raw.githubusercontent.com/rabbitmq/cluster-operator/main/docs/examples/hello-world/rabbitmq.yaml
+```
+
+This will create  a RabbitMQ cluster called `hello-world` in the current namespace. You can see the RabbitMQ Cluster as it is being created:
+
+```shell
+watch kubectl get all
+
+NAME                       READY   STATUS    RESTARTS   AGE
+pod/hello-world-server-0   1/1     Running   0          2m
+
+NAME                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)              AGE
+service/hello-world         ClusterIP   10.75.242.149   <none>        5672/TCP,15672/TCP   2m
+service/hello-world-nodes   ClusterIP   None            <none>        4369/TCP,25672/TCP   2m
+service/kubernetes          ClusterIP   10.75.240.1     <none>        443/TCP              4h1m
+
+NAME                                  READY   AGE
+statefulset.apps/hello-world-server   1/1     2m
+```
+
+You will also be able to see an instance of the `rabbitmqclusters.rabbitmq.com` custom resource created.
+
+```shell
+kubectl get rabbitmqclusters.rabbitmq.com
+
+NAME          AGE    STATUS
+hello-world   4m1s
+```
+
+You may also use the kubectl rabbitmq plugin to list the RabbitMQ Clusters deployed -
+
+```shell
+kubectl rabbitmq list
+NAME          AGE    STATUS
+hello-world   4m10s
+```
+
+Briefly breaking down what the `hello-world` RabbitMQ Cluster has created in terms of Kubernetes objects -
+
+- a `hello-world-server-0` pod. This pod runs a single container which is loaded with the RabbitMQ Image. By default, this is the [Community RabbitMQ image available on Dockerhub](https://hub.docker.com/_/rabbitmq).
+- a statefulset `hello-world-server`. The RabbitMQ server pods are wrapped with the stateful set abstraction of Kubernetes which ensures pod restarts on failure, ordered upgrades, etc. If you wish to understand why statefulsets are the chosen abstraction, you can read the [diy RabbitMQ on Kubernetes blog post](https://www.rabbitmq.com/blog/tag/diy/).
+- a service `hello-world` and a service `hello-world-nodes`. Here, the `hello-world` service opens ports `5672` and `15672` which are the `amqp` and the Management UI ports. It is the `hello-world` service that is used to interact and connect with the RabbitMQ server. Conversely, the `hello-world-nodes` service is used only for inter-node communication.
+
+There are other resources such as Secrets, ConfigMaps, etc, that are also created, but for the sake for brevity, we will move on in this quickstart.
+
+
+## View RabbitMQ Logs
+
+In order to make sure RabbitMQ has started correctly, let's view the RabbitMQ log file. This can be done by viewing the RabbitMQ pod logs. In this case, it would be -
+
+```shell
+kubectl logs hello-world-server-0
+...
+
+ Starting RabbitMQ 3.8.9 on Erlang 23.2.1
+ Copyright (c) 2007-2020 VMware, Inc. or its affiliates.
+ Licensed under the MPL 2.0. Website: https://rabbitmq.com
+
+  ##  ##      RabbitMQ 3.8.9
+  ##  ##
+  ##########  Copyright (c) 2007-2020 VMware, Inc. or its affiliates.
+  ######  ##
+  ##########  Licensed under the MPL 2.0. Website: https://rabbitmq.com
+
+  Doc guides: https://rabbitmq.com/documentation.html
+  Support:    https://rabbitmq.com/contact.html
+  Tutorials:  https://rabbitmq.com/getstarted.html
+  Monitoring: https://rabbitmq.com/monitoring.html
+
+...
+```
+
+If you care only about viewing the logs, the detail of the component is hidden away in the kubectl rabbitmq plugin. Here, you may just run:
+
+```shell
+kubectl rabbitmq tail hello-world
+```
+
+## Access The Management UI
+
+Next, let's access the Management UI.
+
+```shell
+username=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)
+echo "username: $username"
+password=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)
+echo "password: $password"
+
+kubectl port-forward "service/hello-world" 15672
+```
+Now we can open localhost:15672 in the browser and see the Management UI. The credentials are as printed in the commands above. Alternatively, you can run a `curl` command to verify access -
+
+```shell
+curl -u$username:$password localhost:15672/api/overview
+{"management_version":"3.8.9","rates_mode":"basic", ...}
+```
+
+Using the `kubectl rabbitmq` plugin, the Management UI can be accessed using -
+
+```shell
+kubectl rabbitmq manage hello-world
+```
+
+## Connect An Application To The Cluster
+
+Next step, would be to connect an application to the RabbitMQ Cluster in order to use it's messaging capabilities. The [perf-test](https://github.com/rabbitmq/rabbitmq-perf-test) application is frequently used within the RabbitMQ community for load testing a RabbitMQ Cluster.
+
+Here, we will be using the `hello-world` service to find the connection address, and the `hello-world-default-user` to find connection credentials.
+
+```shell
+username=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)
+password=$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)
+service=$(kubectl get service hello-world -o jsonpath='{.spec.clusterIP}')
+kubectl run perf-test --image=pivotalrabbitmq/perf-test -- --uri amqp://{username}:{password}@{service}
+
+# pod/perf-test created
+```
+
+These steps are automated in the kubectl rabbitmq plugin which may simply be run as:
+
+```shell
+kubectl rabbitmq perf-test hello-world
+```
+
+We can now view the perf-test logs by running -
+
+```shell
+kubectl logs --follow perf-test
+...
+id: test-141948-895, time: 16.001s, sent: 25651 msg/s, received: 25733 msg/s, min/median/75th/95th/99th consumer latency: 1346110/1457130/1495463/1529703/1542172 µs
+id: test-141948-895, time: 17.001s, sent: 26933 msg/s, received: 26310 msg/s, min/median/75th/95th/99th consumer latency: 1333807/1411182/1442417/1467869/1483273 µs
+id: test-141948-895, time: 18.001s, sent: 26292 msg/s, received: 25505 msg/s, min/median/75th/95th/99th consumer latency: 1329488/1428657/1455482/1502191/1518218 µs
+id: test-141948-895, time: 19.001s, sent: 23727 msg/s, received: 26055 msg/s, min/median/75th/95th/99th consumer latency: 1355788/1450757/1480030/1514469/1531624 µs
+id: test-141948-895, time: 20.001s, sent: 25009 msg/s, received: 25202 msg/s, min/median/75th/95th/99th consumer latency: 1327462/1447157/1474394/1509857/1521303 µs
+id: test-141948-895, time: 21.001s, sent: 28487 msg/s, received: 25942 msg/s, min/median/75th/95th/99th consumer latency: 1350527/1454599/1490094/1519461/1531042 µs
+...
+```
+
+As can be seen, perf-test is able to produce and consume about 25,000 messages per second.
+
+## Next Steps
+
+Now that you are up and running with the basics, you can explore what the Cluster Operator can do for you!
+
+You can do so by:
+1. Looking at [more examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) such as [monitoring the deployed RabbitMQ Cluster using Prometheus](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/prometheus), [enabling TLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/tls), etc.
+2. Looking at the [API reference documentation](/kubernetes/operator/using-operator.html).
+3. Check out our [GitHub repository](https://github.com/rabbitmq/cluster-operator/) and contribute to this guide, other docs, and the codebase!

--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -5,8 +5,8 @@
 This guide covers how to deploy Custom Resource objects that will
 be managed by the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html).
 If RabbitMQ Cluster Kubernetes Operator is not installed,
-see the [installation guide](/kubernetes/operator/install-operator.html). This guide is structured
-in the following sections:
+see the [installation guide](/kubernetes/operator/install-operator.html). For instructions on getting started quickly, see the [quickstart guide](/kubernetes/operator/quickstart-operator.html)
+This guide is structured in the following sections:
 
 * [Confirm Service Availability](#service-availability).
 * [Apply Pod Security Policies](#psp).


### PR DESCRIPTION
Quickstart that covers - 
- installing the cluster operator
- deploying a simple rabbitmq cluster using the operator
- accessing management ui on the deployed cluster
- viewing rabbitmq logs on the deployed cluster
- links to next steps

It also 
- breaks down the kubernetes resources that get created as a result of both installing the operator and creating a rabbitmq cluster using the operator
- promotes the examples on the cluster operator github repo