### PR TITLE
Fix regex escaping

### DIFF
--- a/site/access-control.md
+++ b/site/access-control.md
@@ -429,7 +429,7 @@ Built-in AMQP 0-9-1 resource names are prefixed with
 <code>amq.</code> and server generated names are prefixed
 with <code>amq.gen</code>.
 
-For example, <code>'^(amq\.gen.*|amq\.default)$'</code> gives a user access to
+For example, <code>'^(amq\\.gen.*|amq\\.default)$'</code> gives a user access to
 server-generated names and the default exchange.  The empty
 string, <code>''</code> is a synonym for <code>'^$'</code>
 and restricts permissions in the exact same way.

--- a/site/parameters.md
+++ b/site/parameters.md
@@ -340,7 +340,7 @@ PUT /api/policies/%2f/ha-fed
   </tr>
 </table>
 
-By doing that all the queues matched by the pattern "^hf\." will have the `"federation-upstream-set"`
+By doing that all the queues matched by the pattern "^hf\\." will have the `"federation-upstream-set"`
 and the policy definitions applied to them.
 
 ## <a id="operator-policies" class="anchor" href="#operator-policies">Operator Policies</a>


### PR DESCRIPTION
There were some regexes that weren't being displayed correctly. More specifically, the escaped `.`s were being shown unescaped:

![image](https://user-images.githubusercontent.com/20007613/105088894-2ef1ae00-5a7b-11eb-98de-62d71d6df1d2.png)
(I find that specific case rather dangerous, as the regex works, but also gives more permissions that intended)

I changed it so it displays the dots correctly escaped:

![image](https://user-images.githubusercontent.com/20007613/105089035-62343d00-5a7b-11eb-9fc7-12e451e97d2a.png)

---

Although I did search the repo for similar cases of unescaped `.`s, I did not look for other possibly unescaped characters. So it is possible that more cases exist.