### PR TITLE
Fix grammar, formatting, dead links, etc

### DIFF
--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -9,23 +9,24 @@ This is the fastest way to get up and running with a RabbitMQ cluster deployed b
 
 ## Quickstart Steps
 
-This guide is goes through the following steps -
+This guide goes through the following steps:
+
 1. Install the RabbitMQ Cluster Operator
 2. Deploy a RabbitMQ Cluster using the Operator
 3. View RabbitMQ Logs
 4. Access the RabbitMQ Management UI
-5. Attach A Workload to the Cluster
+5. Attach a Workload to the Cluster
 6. Next Steps
 
 ## The `kubectl rabbitmq` Plugin
 
-Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at it's [installation instructions](/Kubernetes/operator/install-operator.html).
+Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at its [installation instructions](/kubernetes/operator/install-operator.html).
 
 ## Install the RabbitMQ Cluster Operator
 
-Let's start by installing the latest version of the Cluster Operator. This can done directly using `kubectl apply` -
+Let's start by installing the latest version of the Cluster Operator. This can be done directly using `kubectl apply`:
 
-```shell
+<pre class="lang-bash">
 kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml"
 # namespace/rabbitmq-system created
 # customresourcedefinition.apiextensions.k8s.io/rabbitmqclusters.rabbitmq.com created
@@ -35,17 +36,18 @@ kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/latest/d
 # rolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-rolebinding created
 # clusterrolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-operator-rolebinding created
 # deployment.apps/rabbitmq-cluster-operator created
-```
+</pre>
 
-The Cluster Operator can also be installed using the `kubectl rabbitmq` plugin -
+The Cluster Operator can also be installed using the `kubectl rabbitmq` plugin:
 
-```shell
+<pre class="lang-bash">
 kubectl rabbitmq install-cluster-operator
-```
+</pre>
 
 Installing the Cluster Operator creates a bunch of Kubernetes resources. Breaking these down, we have:
+
 - a new namespace `rabbitmq-system`. The Cluster Operator deployment is created in this namespace.
-```shell
+<pre class="lang-bash">
 kubectl get all -n rabbitmq-system
 
 NAME                                             READY   STATUS    RESTARTS   AGE
@@ -56,43 +58,43 @@ deployment.apps/rabbitmq-cluster-operator   1/1     1            1           2m1
 
 NAME                                                   DESIRED   CURRENT   READY   AGE
 replicaset.apps/rabbitmq-cluster-operator-54f948d8b6   1         1         1       2m10s
-```
+</pre>
 - a new custom resource `rabbitmqclusters.rabbitmq.com`. The custom resource allows us to define an API for the creation of RabbitMQ Clusters.
-```shell
+<pre class="lang-bash">
 kubectl get customresourcedefinitions.apiextensions.k8s.io
 
 NAME                                             CREATED AT
 ...
 rabbitmqclusters.rabbitmq.com                    2021-01-14T11:12:26Z
 ...
-```
+</pre>
 - and some rbac roles. These are required by the Operator to create, update and delete RabbitMQ Clusters.
 
 ## Hello RabbitMQ!
 
 Now that we have the Operator deployed, let's create the simplest RabbitMQ Cluster.
 
-This example can be found in the [Cluster Operator GitHub repo](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/hello-world).  As mentioned on the page:
+This example can be found in the [Cluster Operator GitHub repo](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/hello-world). As mentioned on the page:
 > This is the simplest `RabbitmqCluster` definition. The only explicitly specified property is the name of the cluster. Everything else will be configured according to the Cluster Operator's defaults.
 
 The [examples folder](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) has many other references such as creating a RabbitMQ Cluster with TLS, mTLS, setting up a Cluster with production defaults, adding community plugins, etc.
 
 Continuing with our example, we will submit the following yaml to Kubernetes:
 
-```yaml
+<pre class="lang-yaml">
 apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
 	name: hello-world
-```
-Submit this using the following command -
-```shell
+</pre>
+Submit this using the following command:
+<pre class="lang-bash">
 kubectl apply -f https://raw.githubusercontent.com/rabbitmq/cluster-operator/main/docs/examples/hello-world/rabbitmq.yaml
-```
+</pre>
 
-This will create  a RabbitMQ cluster called `hello-world` in the current namespace. You can see the RabbitMQ Cluster as it is being created:
+This will create a RabbitMQ cluster called `hello-world` in the current namespace. You can see the RabbitMQ Cluster as it is being created:
 
-```shell
+<pre class="lang-bash">
 watch kubectl get all
 
 NAME                       READY   STATUS    RESTARTS   AGE
@@ -105,30 +107,30 @@ service/kubernetes          ClusterIP   10.75.240.1     &lt;none&gt;  443/TCP   
 
 NAME                                  READY   AGE
 statefulset.apps/hello-world-server   1/1     2m
-```
+</pre>
 
 You will also be able to see an instance of the `rabbitmqclusters.rabbitmq.com` custom resource created.
 
-```shell
+<pre class="lang-bash">
 kubectl get rabbitmqclusters.rabbitmq.com
 
 NAME          AGE    STATUS
 hello-world   4m1s
-```
+</pre>
 
-You may also use the kubectl rabbitmq plugin to list the RabbitMQ Clusters deployed -
+You may also use the kubectl rabbitmq plugin to list the RabbitMQ Clusters deployed:
 
-```shell
+<pre class="lang-bash">
 kubectl rabbitmq list
 NAME          AGE    STATUS
 hello-world   4m10s
-```
+</pre>
 
 ## View RabbitMQ Logs
 
-In order to make sure RabbitMQ has started correctly, let's view the RabbitMQ log file. This can be done by viewing the RabbitMQ pod logs. In this case, it would be -
+In order to make sure RabbitMQ has started correctly, let's view the RabbitMQ log file. This can be done by viewing the RabbitMQ pod logs. In this case, it would be:
 
-```shell
+<pre class="lang-bash">
 kubectl logs hello-world-server-0
 ...
 
@@ -148,63 +150,63 @@ kubectl logs hello-world-server-0
   Monitoring: https://rabbitmq.com/monitoring.html
 
 ...
-```
+</pre>
 
 If you care only about viewing the logs, the detail of the component is hidden away in the kubectl rabbitmq plugin. Here, you may just run:
 
-```shell
+<pre class="lang-bash">
 kubectl rabbitmq tail hello-world
-```
+</pre>
 
 ## Access The Management UI
 
 Next, let's access the Management UI.
 
-```shell
+<pre class="lang-bash">
 username="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)"
 echo "username: $username"
 password="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)"
 echo "password: $password"
 
 kubectl port-forward "service/hello-world" 15672
-```
-Now we can open localhost:15672 in the browser and see the Management UI. The credentials are as printed in the commands above. Alternatively, you can run a `curl` command to verify access -
+</pre>
+Now we can open localhost:15672 in the browser and see the Management UI. The credentials are as printed in the commands above. Alternatively, you can run a `curl` command to verify access:
 
-```shell
+<pre class="lang-bash">
 curl -u$username:$password localhost:15672/api/overview
 {"management_version":"3.8.9","rates_mode":"basic", ...}
-```
+</pre>
 
-Using the `kubectl rabbitmq` plugin, the Management UI can be accessed using -
+Using the `kubectl rabbitmq` plugin, the Management UI can be accessed using:
 
-```shell
+<pre class="lang-bash">
 kubectl rabbitmq manage hello-world
-```
+</pre>
 
 ## Connect An Application To The Cluster
 
-The next step would be to connect an application to the RabbitMQ Cluster in order to use it's messaging capabilities. The [perf-test](https://github.com/rabbitmq/rabbitmq-perf-test) application is frequently used within the RabbitMQ community for load testing RabbitMQ Clusters.
+The next step would be to connect an application to the RabbitMQ Cluster in order to use its messaging capabilities. The [perf-test](https://github.com/rabbitmq/rabbitmq-perf-test) application is frequently used within the RabbitMQ community for load testing RabbitMQ Clusters.
 
 Here, we will be using the `hello-world` service to find the connection address, and the `hello-world-default-user` to find connection credentials.
 
-```shell
+<pre class="lang-bash">
 username="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.username}' | base64 --decode)"
 password="$(kubectl get secret hello-world-default-user -o jsonpath='{.data.password}' | base64 --decode)"
 service="$(kubectl get service hello-world -o jsonpath='{.spec.clusterIP}')"
 kubectl run perf-test --image=pivotalrabbitmq/perf-test -- --uri amqp://$username:$password@$service
 
 # pod/perf-test created
-```
+</pre>
 
 These steps are automated in the kubectl rabbitmq plugin which may simply be run as:
 
-```shell
+<pre class="lang-bash">
 kubectl rabbitmq perf-test hello-world
-```
+</pre>
 
-We can now view the perf-test logs by running -
+We can now view the perf-test logs by running:
 
-```shell
+<pre class="lang-bash">
 kubectl logs --follow perf-test
 ...
 id: test-141948-895, time: 16.001s, sent: 25651 msg/s, received: 25733 msg/s, min/median/75th/95th/99th consumer latency: 1346110/1457130/1495463/1529703/1542172 µs
@@ -214,7 +216,7 @@ id: test-141948-895, time: 19.001s, sent: 23727 msg/s, received: 26055 msg/s, mi
 id: test-141948-895, time: 20.001s, sent: 25009 msg/s, received: 25202 msg/s, min/median/75th/95th/99th consumer latency: 1327462/1447157/1474394/1509857/1521303 µs
 id: test-141948-895, time: 21.001s, sent: 28487 msg/s, received: 25942 msg/s, min/median/75th/95th/99th consumer latency: 1350527/1454599/1490094/1519461/1531042 µs
 ...
-```
+</pre>
 
 As can be seen, perf-test is able to produce and consume about 25,000 messages per second.
 
@@ -223,6 +225,7 @@ As can be seen, perf-test is able to produce and consume about 25,000 messages p
 Now that you are up and running with the basics, you can explore what the Cluster Operator can do for you!
 
 You can do so by:
+
 1. Looking at [more examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) such as [monitoring the deployed RabbitMQ Cluster using Prometheus](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/prometheus), [enabling TLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/tls), etc.
 2. Looking at the [API reference documentation](/kubernetes/operator/using-operator.html).
-3. Check out our [GitHub repository](https://github.com/rabbitmq/cluster-operator/) and contribute to this guide, other docs, and the codebase!
+3. Checking out our [GitHub repository](https://github.com/rabbitmq/cluster-operator/) and contributing to this guide, other docs, and the codebase!

--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -5,7 +5,7 @@
 This guide covers how to deploy Custom Resource objects that will
 be managed by the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html).
 If RabbitMQ Cluster Kubernetes Operator is not installed,
-see the [installation guide](/kubernetes/operator/install-operator.html). For instructions on getting started quickly, see the [quickstart guide](/kubernetes/operator/quickstart-operator.html)
+see the [installation guide](/kubernetes/operator/install-operator.html). For instructions on getting started quickly, see the [quickstart guide](/kubernetes/operator/quickstart-operator.html).
 This guide is structured in the following sections:
 
 * [Confirm Service Availability](#service-availability).

--- a/site/troubleshooting-networking.md
+++ b/site/troubleshooting-networking.md
@@ -315,7 +315,7 @@ using [Prometheus and Grafana](/prometheus.html).
 High connection churn (lots of connections opened and closed after a brief
 period of time) [can lead to resource exhaustion](/networking.html#dealing-with-high-connection-churn).
 It is therefore important to be able to identify such scenarios. `netstat` and `ss`
-are most popular options for [inspecting TCP connections](troubleshooting-inspecting-connections).
+are most popular options for [inspecting TCP connections](#inspecting-connections).
 A lot of connections in the `TIME_WAIT` state is a likely symptom of high connection churn.
 Lots of connections in states other than `ESTABLISHED` also might be a symptom worth investigating.
 

--- a/site/uri-query-parameters.md
+++ b/site/uri-query-parameters.md
@@ -94,7 +94,7 @@ against the hostname `myhost`.
       certificate. <b>Note:</b> It is highly recommended to use
       both values. See the <a href="ssl.html">TLS guide</a> to
       learn more about TLS support in RabbitMQ in general and specifically the
-      <a href="ssl.html#configure-erlang">Erlang client</a>
+      <a href="ssl.html#erlang-client">Erlang client</a>
       section.
     </td>
   </tr>


### PR DESCRIPTION
- Lots of fixes on grammar, formatting, punctuation, capitalization, and dead links.
- In particular, corrected the code formatting in [the kubernetes/operator/quickstart-operator.html page](https://www.rabbitmq.com/kubernetes/operator/quickstart-operator.html).