### PR TITLE
Remove topic header that is not included anymore

### DIFF
--- a/site/runtime.md
+++ b/site/runtime.md
@@ -41,7 +41,6 @@ Topics covered include:
  * [Memory allocator](#allocators) settings
  * [Open file handle limit](#open-file-handle-limit)
  * [Inter-node communication buffer](#distribution-buffer) size
- * [Asynchronous I/O thread pool](#io-threads) size
  * [Erlang process limit](#erlang-process-limit)
 
 ## <a id="vm-settings" class="anchor" href="#vm-settings">VM Settings</a>


### PR DESCRIPTION
The anchor link doesn't go anywhere since the section has been removed.