### PR TITLE
Correct Go variable casing

### DIFF
--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -126,8 +126,8 @@ forever := make(chan bool)
 go func() {
   for d := range msgs {
     log.Printf("Received a message: %s", d.Body)
-    dot_count := bytes.Count(d.Body, []byte("."))
-    t := time.Duration(dot_count)
+    dotCount := bytes.Count(d.Body, []byte("."))
+    t := time.Duration(dotCount)
     time.Sleep(t * time.Second)
     log.Printf("Done")
   }
@@ -264,8 +264,8 @@ forever := make(chan bool)
 go func() {
   for d := range msgs {
     log.Printf("Received a message: %s", d.Body)
-    dot_count := bytes.Count(d.Body, []byte("."))
-    t := time.Duration(dot_count)
+    dotCount := bytes.Count(d.Body, []byte("."))
+    t := time.Duration(dotCount)
     time.Sleep(t * time.Second)
     log.Printf("Done")
     d.Ack(false)
@@ -572,8 +572,8 @@ func main() {
         go func() {
                 for d := range msgs {
                         log.Printf("Received a message: %s", d.Body)
-                        dot_count := bytes.Count(d.Body, []byte("."))
-                        t := time.Duration(dot_count)
+                        dotCount := bytes.Count(d.Body, []byte("."))
+                        t := time.Duration(dotCount)
                         time.Sleep(t * time.Second)
                         log.Printf("Done")
                         d.Ack(false)


### PR DESCRIPTION
According to [Effective Go](https://golang.org/doc/effective_go.html#mixed-caps), the convention is to use MixedCaps or mixedCaps rather than underscores to write multiword names. 

In this PR I corrected an instance where a variable was defined using snake case.