### PR TITLE
RabbitMQ plugin for kubectl

### DIFF
--- a/site/ha.md
+++ b/site/ha.md
@@ -526,7 +526,7 @@ client need take any action or be informed of the failure.
 Note that mirror failures may not be detected immediately and
 the interruption of the per-connection flow control mechanism
 can delay message publication. The details are described
-[here](nettick.html).
+in the [Inter-node Communication Heartbeats](nettick.html) guide.
 
 If the master fails, then one of the mirrors will be promoted to
 master as follows:

--- a/site/kubernetes/operator/kubectl-plugin.md
+++ b/site/kubernetes/operator/kubectl-plugin.md
@@ -1,0 +1,211 @@
+# RabbitMQ Cluster Operator plugin for kubectl
+
+This guide covers the RabbitMQ Cluster Operator plugin for kubectl.
+This plugin makes it easy to install the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html).
+into any Kuberenetes instance and offers several commands for common workflows with RabbitMQ clusters.
+
+The only pre-requesites to using the plugin are a working installation of kubectl and krew.
+
+1. [Install the plugin](#install)
+2. [Using the plugin](#using)
+
+Each plugin command automates many interactions with the kuberenetes API and the RabbitMQ cluster operator.
+For a more detailed guide on using the operator and how to deploy Custom Resource objects it manages, see the
+[Using RabbitMQ Cluster Operator](/kubernetes/operator/using-operator.html) page.
+---
+## <a id='install' class='anchor' href='#install'>Install the plugin</a>
+
+### <a id='krew' class='anchor' href='#krew'>Setup Krew</a>
+
+[Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) is the plugin manager for kubectl command-line tool. 
+
+Get krew for your system [here](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).
+
+Verify your krew installation.
+
+<pre class="lang-bash">
+kubectl krew
+</pre>
+
+### <a id='install-plugin' class='anchor' href='#install-plugin'>Install kubectl RabbitMQ plugin</a>
+
+With krew setup we can go ahead and install the RabbitMQ Cluster Operator plugin.
+
+<pre class="lang-bash">
+kubectl krew install rabbitmq
+</pre>
+
+To verify the installation, get the list of available commands:
+
+<pre class="lang-bash">
+kubectl rabbitmq help
+# USAGE:
+#   Install RabbitMQ Cluster Operator (optionally provide image to use a relocated image or a specific version)
+#     kubectl rabbitmq install-cluster-operator [IMAGE]
+# [...]
+</pre>
+
+---
+## <a id='using' class='anchor' href='#using'>Using the Plugin</a>
+
+### <a id='create-rmq' class='anchor' href='#create-rmq'>Create a RabbitMQ cluster</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq create INSTANCE
+</pre>
+
+This will create RabbitMQ cluster with some basic configuration where only the cluster name is configured.
+
+### <a id='get-rmq' class='anchor' href='#get-rmq'>Get a RabbitMQ cluster</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq get INSTANCE
+</pre>
+
+Display all of the kubernetes resources associated with the named RabbitMQ cluster including
+pods, configmaps, statefulsets, services and secrets.
+
+<pre class="lang-bash">
+NAME                     READY   STATUS    RESTARTS   AGE
+pod/hello-rmq-server-0   0/1     Pending   0          5h31m
+
+NAME                               DATA   AGE
+configmap/hello-rmq-plugins-conf   1      5h31m
+configmap/hello-rmq-server-conf    2      5h31m
+
+NAME                                READY   AGE
+statefulset.apps/hello-rmq-server   0/1     5h31m
+
+NAME                      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)              AGE
+service/hello-rmq         ClusterIP   10.100.156.4   none        5672/TCP,15672/TCP   5h31m
+service/hello-rmq-nodes   ClusterIP   None           none        4369/TCP,25672/TCP   5h31m
+
+NAME                             TYPE     DATA   AGE
+secret/hello-rmq-default-user    Opaque   3      5h31m
+secret/hello-rmq-erlang-cookie   Opaque   1      5h31m
+</pre>
+
+### <a id='list-rmq' class='anchor' href='#list-rmq'>List all RabbitMQ clusters</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq list
+</pre>
+
+Displays all RabbitMQ clusters deployed by the RabbitMQ cluster operator on the target kuberentes instance.
+
+### <a id='delete-rmq' class='anchor' href='#delete-plugin'>Delete RabbitMQ cluster</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq delete INSTANCE
+</pre>
+
+Delete a RabbitMQ cluster, or multiple RabbitMQ clusters. When deleting multiple RabbitMQ clusters, provide a space
+seperated list.
+
+<pre class="lang-bash">
+kubectl rabbitmq delete rmq1 rmq2 rmq3
+</pre>
+
+### <a id='secrets' class='anchor' href='#secrets'>Print default user secrets</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq secrets INSTANCE
+</pre>
+
+Displays the default user secrets for the named RabbitMQ cluster
+
+### <a id='manage' class='anchor' href='#manage'>Open the Management UI</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq manage INSTANCE
+</pre>
+
+Opens the RabbitMQ Management dashboard in a browser.
+
+### <a id='debug' class='anchor' href='#debug'>Set Log Level to debug</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq debug INSTANCE
+</pre>
+
+Sets the log level on all nodes to debug. For a detailed breakdown on RabbitMQ logging
+see the [logging docs page](/logging.html).
+
+### <a id='tail' class='anchor' href='#tail'>Tail Logs</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq tail INSTANCE
+</pre>
+
+Attach to live log output from all RabbitMQ nodes.
+
+### <a id='observe' class='anchor' href='#observe'>Observe</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq observe INSTANCE INDEX
+</pre>
+
+Opens the rabbitmq-diagnostics observer interface for a given node. For more
+information on the rabbitmq-diagnostics see [here](rabbitmq-diagnostics.8.html).
+
+### <a id='feature-flags' class='anchor' href='#feature-flags'>Enable All Feature Flags</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq enable-all-feature-flags INSTANCE 
+</pre>
+
+This command wraps the `rabbitmqctl` CLI to enable all possible feature flags.
+For comprehensive documentation on all feature flags see [here](/feature-flags.html).
+
+### <a id='pause-reconciliation' class='anchor' href='#pause-reconciliation'>Pause Reconciliation</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq pause-reconciliation INSTANCE 
+</pre>
+
+This adds the label "rabbitmq.com/pauseReconciliation=true" to your RabbitMQ cluster, which prevents the operator from
+watching and updating the instance.
+
+### <a id='resume-reconciliation' class='anchor' href='#resume-reconciliation'>Resume Reconciliation</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq resume-reconciliation INSTANCE 
+</pre>
+
+Instructs the operator to resume reconciliation for a RabbitMQ cluster.
+
+### <a id='list-pause-reconciliation-instances' class='anchor' href='#list-pause-reconciliation-instances'>List Instances with Paused Reconciliation</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq resume-reconciliation INSTANCE 
+</pre>
+
+Lists all instances that are not being reconciled by the operator.
+
+
+### <a id='perf-test' class='anchor' href='#perf-test'>Perf Test</a>
+
+<pre class="lang-bash">
+kubectl rabbitmq perf-test INSTANCE --rate 100
+</pre>
+
+Runs perf-test against an instance. You can pass as many perf test parameters as you like here.
+For more information on perf-test and what parameters are available see [here](https://rabbitmq.github.io/rabbitmq-perf-test/stable/htmlsingle/).
+
+If you want to monitor perf-test, you can do so by creating the following ServiceMonitor:
+<pre class="lang-yaml">
+  apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: kubectl-perf-test
+  spec:
+    endpoints:
+    - interval: 15s
+      targetPort: 8080
+    selector:
+      matchLabels:
+        app: perf-test
+</pre>
+
+---
+Please submit feedback and feature requests for the RabbitMQ Cluster Operator plugin for kubectl [here](https://github.com/rabbitmq/cluster-operator).

--- a/site/kubernetes/operator/kubectl-plugin.md
+++ b/site/kubernetes/operator/kubectl-plugin.md
@@ -137,7 +137,8 @@ see the [logging docs page](/logging.html).
 kubectl rabbitmq tail INSTANCE
 </pre>
 
-Attach to live log output from all RabbitMQ nodes.
+Attach to live log output from all RabbitMQ nodes. This requires the `tail` plugin for kubectl.
+Install it with `kubectl krew install tail`.
 
 ### <a id='observe' class='anchor' href='#observe'>Observe</a>
 

--- a/site/kubernetes/operator/kubectl-plugin.md
+++ b/site/kubernetes/operator/kubectl-plugin.md
@@ -1,4 +1,4 @@
-# RabbitMQ Cluster Operator plugin for kubectl
+# RabbitMQ Cluster Operator Plugin for kubectl
 
 This guide covers the RabbitMQ Cluster Operator plugin for kubectl.
 This plugin makes it easy to install the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html).
@@ -19,9 +19,7 @@ For a more detailed guide on using the operator and how to deploy Custom Resourc
 
 [Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) is the plugin manager for kubectl command-line tool. 
 
-Get krew for your system [here](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).
-
-Verify your krew installation.
+After installing `krew`, verify the installation:
 
 <pre class="lang-bash">
 kubectl krew
@@ -99,7 +97,7 @@ Displays all RabbitMQ clusters deployed by the RabbitMQ cluster operator on the 
 kubectl rabbitmq delete INSTANCE
 </pre>
 
-Delete a RabbitMQ cluster, or multiple RabbitMQ clusters. When deleting multiple RabbitMQ clusters, provide a space
+Deletes a RabbitMQ cluster, or multiple RabbitMQ clusters. When deleting multiple RabbitMQ clusters, provide a space
 seperated list.
 
 <pre class="lang-bash">
@@ -129,7 +127,7 @@ kubectl rabbitmq debug INSTANCE
 </pre>
 
 Sets the log level on all nodes to debug. For a detailed breakdown on RabbitMQ logging
-see the [logging docs page](/logging.html).
+see the [Logging guide](/logging.html).
 
 ### <a id='tail' class='anchor' href='#tail'>Tail Logs</a>
 
@@ -137,8 +135,12 @@ see the [logging docs page](/logging.html).
 kubectl rabbitmq tail INSTANCE
 </pre>
 
-Attach to live log output from all RabbitMQ nodes. This requires the `tail` plugin for kubectl.
-Install it with `kubectl krew install tail`.
+Attach to live log output from all RabbitMQ nodes. This requires the `tail` plugin for `kubectl`.
+Install it with
+
+<pre class="lang-bash">
+kubectl krew install tail
+</pre>
 
 ### <a id='observe' class='anchor' href='#observe'>Observe</a>
 
@@ -146,7 +148,7 @@ Install it with `kubectl krew install tail`.
 kubectl rabbitmq observe INSTANCE INDEX
 </pre>
 
-Opens the [rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html) observer interface for a given node.
+Opens the [`rabbitmq-diagnostics`](/rabbitmq-diagnostics.8.html) observer interface for a given node.
 
 ### <a id='feature-flags' class='anchor' href='#feature-flags'>Enable All Feature Flags</a>
 
@@ -154,8 +156,7 @@ Opens the [rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html) observer interfac
 kubectl rabbitmq enable-all-feature-flags INSTANCE 
 </pre>
 
-This command wraps the `rabbitmqctl` CLI to enable all possible feature flags.
-For comprehensive documentation on all feature flags see [here](/feature-flags.html).
+This command uses [`rabbitmqctl`](/cli.html) to enable all possible [feature flags](/feature-flags.html).
 
 ### <a id='pause-reconciliation' class='anchor' href='#pause-reconciliation'>Pause Reconciliation</a>
 
@@ -163,8 +164,8 @@ For comprehensive documentation on all feature flags see [here](/feature-flags.h
 kubectl rabbitmq pause-reconciliation INSTANCE 
 </pre>
 
-This adds the label "rabbitmq.com/pauseReconciliation=true" to your RabbitMQ cluster, which prevents the operator from
-watching and updating the instance.
+This adds the label "rabbitmq.com/pauseReconciliation=true" to the target RabbitMQ cluster.
+The label prevents the Operator from watching and updating the instance.
 
 ### <a id='resume-reconciliation' class='anchor' href='#resume-reconciliation'>Resume Reconciliation</a>
 
@@ -207,4 +208,4 @@ To monitor PerfTest, add the following ServiceMonitor:
 </pre>
 
 ---
-Please submit feedback and feature requests for the RabbitMQ Cluster Operator plugin for kubectl [here](https://github.com/rabbitmq/cluster-operator).
+Please submit feedback and feature requests for the RabbitMQ Cluster Operator [on GitHub](https://github.com/rabbitmq/cluster-operator).

--- a/site/kubernetes/operator/kubectl-plugin.md
+++ b/site/kubernetes/operator/kubectl-plugin.md
@@ -120,7 +120,7 @@ Displays the default user secrets for the named RabbitMQ cluster
 kubectl rabbitmq manage INSTANCE
 </pre>
 
-Opens the RabbitMQ Management dashboard in a browser.
+Opens the RabbitMQ [Management UI](/management.html) in a browser.
 
 ### <a id='debug' class='anchor' href='#debug'>Set Log Level to debug</a>
 
@@ -146,8 +146,7 @@ Install it with `kubectl krew install tail`.
 kubectl rabbitmq observe INSTANCE INDEX
 </pre>
 
-Opens the rabbitmq-diagnostics observer interface for a given node. For more
-information on the rabbitmq-diagnostics see [here](rabbitmq-diagnostics.8.html).
+Opens the [rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html) observer interface for a given node.
 
 ### <a id='feature-flags' class='anchor' href='#feature-flags'>Enable All Feature Flags</a>
 
@@ -178,7 +177,7 @@ Instructs the operator to resume reconciliation for a RabbitMQ cluster.
 ### <a id='list-pause-reconciliation-instances' class='anchor' href='#list-pause-reconciliation-instances'>List Instances with Paused Reconciliation</a>
 
 <pre class="lang-bash">
-kubectl rabbitmq resume-reconciliation INSTANCE 
+kubectl rabbitmq [list pause reconciliation instances](list-pause-reconciliation-instances) INSTANCE
 </pre>
 
 Lists all instances that are not being reconciled by the operator.
@@ -190,10 +189,9 @@ Lists all instances that are not being reconciled by the operator.
 kubectl rabbitmq perf-test INSTANCE --rate 100
 </pre>
 
-Runs perf-test against an instance. You can pass as many perf test parameters as you like here.
-For more information on perf-test and what parameters are available see [here](https://rabbitmq.github.io/rabbitmq-perf-test/stable/htmlsingle/).
+Runs [perf-test](https://rabbitmq.github.io/rabbitmq-perf-test/stable/htmlsingle/) against an instance. You can pass as many perf test parameters as you like here.
 
-If you want to monitor perf-test, you can do so by creating the following ServiceMonitor:
+To monitor PerfTest, add the following ServiceMonitor:
 <pre class="lang-yaml">
   apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor

--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -19,6 +19,7 @@ Documentation of the Operator spans several guides:
 
  * [Quickstart RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/quickstart-operator.html)
  * [Installing RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html)
+ * [RabbitMQ Plugin for kubectl](/kubernetes/operator/kubectl-plugin.html)
  * [Using RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/using-operator.html)
  * [Monitoring RabbitMQ Clusters on Kubernetes](/kubernetes/operator/operator-monitoring.html)
  * [Troubleshooting RabbitMQ Clusters on Kubernetes](/kubernetes/operator/troubleshooting-operator.html)

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -22,7 +22,7 @@ This guide goes through the following steps:
 
 Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at its [installation instructions](/kubernetes/operator/install-operator.html).
 
-For extensive documentation on the plugin see [here](/kubernetes/operator/kubectl-plugin.html).
+For extensive documentation on the plugin see the [`kubectl` Plugin guide](/kubernetes/operator/kubectl-plugin.html).
 
 ## Install the RabbitMQ Cluster Operator
 

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -22,6 +22,8 @@ This guide goes through the following steps:
 
 Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at its [installation instructions](/kubernetes/operator/install-operator.html).
 
+For extensive documentation on the plugin see [here](/kubernetes/operator/kubectl-plugin.html).
+
 ## Install the RabbitMQ Cluster Operator
 
 Let's start by installing the latest version of the Cluster Operator. This can be done directly using `kubectl apply`:


### PR DESCRIPTION
This commit adds a dedicated page for installation and usage
of the rabbitmq kubectl plugin.