### PR TITLE
Use stunnel3 wrapper in stunnel example.

### DIFF
--- a/site/troubleshooting-ssl.md
+++ b/site/troubleshooting-ssl.md
@@ -341,11 +341,25 @@ In the discussion that follows it is assumed that stunnel will only be used temp
 perform TLS termination but that is out of scope for this guide.
 
 In this example <code>stunnel</code> will connect to the unencrypted port of the broker (5672) and accept
-TLS connections from TLS-capable clients on port 5679:
+TLS connections from TLS-capable clients on port 5679.
+
+Parameters are passed via a config file named <code>stunnel.conf</code>. It has the following content:
+
+<pre  class="lang-bash">
+foreground = yes
+
+[rabbit-amqp]
+connect = localhost:5672
+accept = 5679
+cert = client/key-cert.pem
+debug = 7
+</pre>
+
+<code>stunnel</code> is started as follows:
 
 <pre  class="lang-bash">
 cat client_key.pem client_certificate.pem > client/key-cert.pem
-stunnel -r localhost:5672 -d 5679 -f -p client/key-cert.pem -D 7
+stunnel stunnel.conf
 </pre>
 
 <code>stunnel</code> requires a certificate and its corresponding private key. The certificate


### PR DESCRIPTION
The stunnel example does not work for stunnel versions >= 4, but there is a perl-script wrapper provided that allows for usage of older commandline options. I've created this pull request to reflect this in the docs.

BR,
Thomas
