### PR TITLE
Add SSL password option to Management Plugin docs page

### DIFF
--- a/site/management.md
+++ b/site/management.md
@@ -421,6 +421,7 @@ management.ssl.port       = 15671
 management.ssl.cacertfile = /path/to/ca_certificate.pem
 management.ssl.certfile   = /path/to/server_certificate.pem
 management.ssl.keyfile    = /path/to/server_key.pem
+management.ssl.password   = bunnies
 </pre>
 
 More [TLS options](/ssl.html) can be configured for the HTTPS listener.
@@ -430,6 +431,7 @@ management.ssl.port       = 15671
 management.ssl.cacertfile = /path/to/ca_certificate.pem
 management.ssl.certfile   = /path/to/server_certificate.pem
 management.ssl.keyfile    = /path/to/server_key.pem
+management.ssl.password   = bunnies
 
 # For RabbitMQ 3.7.10 and later versions
 management.ssl.honor_cipher_order   = true


### PR DESCRIPTION
Hi.

I'm tried to connect Management UI with HTTPS, finally I realized my `rabbitmq.conf` lacks `management.ssl.password = bunnies` and  worked fine by adding it to my `rabbitmq.conf`. ([Thanks Michał!](https://groups.google.com/g/rabbitmq-users/c/7hbvKq_Xdc4))

Then, I added it also to document for RabbitMQ beginners like me. And created this PR.

Thanks.

* note: Similarly, I should also add `management.ssl.verify = verify_peer` and `management.ssl.fail_if_no_peer_cert = true` to the Management Plugin docs page?