### PR TITLE
Add documentation on memory headroom for cluster operator

### DIFF
--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -382,6 +382,10 @@ spec:
       memory: 2Gi
 </pre>
 
+**Note:** It's possible for RabbitMQ and Erlang to temporarily exceed the total available memory, which could cause an immediate OOM kill.
+To prevent this from happening, the cluster operator sets memory headroom of 20% (with a max value of 2GB) by configuring `total_memory_available_override_value`.
+This means the actual memory limit set in RabbitMQ is 20% less than the specified resource requirement.
+
 For more information about concepts mentioned above, see:
 
 <table class="nice">


### PR DESCRIPTION
This feature was not documented, and has confused a user: rabbitmq/cluster-operator#670.

A followup from PR: #1171, the previous PR contains many typos.