### PR TITLE
Update Monitoring RabbitMQ in Kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 $(PIPENV): $(PYTHON)
 ifeq ($(PLATFORM),Darwin)
   ifeq ($(wildcard $(PIPENV_BIN)),)
-	@brew install pipenv
+	@brew list pipenv || brew install pipenv
   endif
 endif
 

--- a/site/kubernetes/operator/install-operator.md
+++ b/site/kubernetes/operator/install-operator.md
@@ -9,7 +9,7 @@ If you are installing in OpenShift, follow the instructions in [Installation on 
 
 The Operator requires
 
-* Kubernetes 1.17 or above
+* Kubernetes 1.18 or above
 * [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) 3.8.8+
 
 -----

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -4,7 +4,7 @@ This is the fastest way to get up and running with a RabbitMQ cluster deployed b
 
 ## Prerequisites
 
-- Access to a Kubernetes cluster version 1.17 or above
+- Access to a Kubernetes cluster version 1.18 or above
 - `kubectl` configured to access the cluster
 
 ## Quickstart Steps


### PR DESCRIPTION
This PR adds docs on how to integrate RabbitMQ scrape targets,
alerting rules, and Grafana dashboards with an existing Prometheus.

We describe the integration for a Prometheus installed by Prometheus
Operator (i.e. CRDs ServiceMonitor, PodMonitor, PrometheusRule are available)
and for a Prometheus not installed by Prometheus Operator.

Remove the section to scrape RabbitMQ by annotations since that approach
is not recommended anymore.

This PR tries to remove duplicate YAML definitions from the docs
and instead links to the YAML definitions already present in the
cluster-operator repo.

Relates to https://github.com/rabbitmq/cluster-operator/pull/667 and https://github.com/rabbitmq/cluster-operator/pull/676.