### PR TITLE
fixed broken link

### DIFF
--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -252,6 +252,6 @@ Now that you are up and running with the basics, you can explore what the Cluste
 
 You can do so by:
 
-1. Looking at [more examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) such as [monitoring the deployed RabbitMQ Cluster using Prometheus](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/prometheus), [enabling TLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/tls), etc.
+1. Looking at [more examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) such as [monitoring the deployed RabbitMQ Cluster using Prometheus](https://www.rabbitmq.com/prometheus.html), [enabling TLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/tls), etc.
 2. Looking at the [API reference documentation](/kubernetes/operator/using-operator.html).
 3. Checking out our [GitHub repository](https://github.com/rabbitmq/cluster-operator/) and contributing to this guide, other docs, and the codebase!


### PR DESCRIPTION
I noticed that link was broken.
There didn't seem to be any documentation in the cluster-operator repo regarding Prometheus monitoring.
The substitute [link](https://www.rabbitmq.com/prometheus.html) seems like the next best thing.

Signed-off-by: Mathis Van Eetvelde <mathis.vaneetvelde@protonmail.com>