### PR TITLE
added .tut1 to package in rabbitmq springboot tutorial

### DIFF
--- a/site/tutorials/tutorial-one-spring-amqp.md
+++ b/site/tutorials/tutorial-one-spring-amqp.md
@@ -176,7 +176,7 @@ public class RabbitAmqpTutorialsApplication {
 and add the `RabbitAmqpTutorialsRunner` class as follows:
 
 <pre class="lang-java">
-package org.springframework.amqp.tutorials;
+package org.springframework.amqp.tutorials.tut1;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
While following the first tutorial for hello-world in spring boot, I noticed that a package name was missing 'tut1' at the end.