### PR TITLE
Include detail about "mirroring_sync_batch_size"

### DIFF
--- a/site/ha.md
+++ b/site/ha.md
@@ -821,9 +821,10 @@ starting mirrors again.
 
 Classic queue leaders perform synchronisation in
 batches. Batch can be configured via the
-`ha-sync-batch-size` queue argument.  Earlier
-versions will synchronise `1` message at a
-time by default.  By synchronising messages in batches,
+`ha-sync-batch-size` queue argument. If no value is set `mirroring_sync_batch_size` 
+is used as the default value. Earlier
+versions (prior to 3.6.0) will synchronise `1` message at a
+time by default. By synchronising messages in batches,
 the synchronisation process can be sped up considerably.
 
 To choose the right value for


### PR DESCRIPTION
I never remember what the default value is, I use a search engine and can't find it on this page. This should fix that :)

I considered fully removing the "Earlier versions"-sentence as 3.5.x is now a relatively rare sighting.