### PR TITLE
Document cluster operator feature flag limitations

### DIFF
--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -52,6 +52,11 @@ not be deployed to the RabbitMQ cluster. For example, if the `Secret` with admin
 a new `Secret` will be created with new username and password, but those will not be reflected in the RabbitMQ cluster.
 It works the same way for any `Secret` value, e.g. the value of the [shared inter-node authentication secret](/clustering.html#erlang-cookie)
 known as the Erlang cookie.
+
+#### RabbitMQ Cluster Feature Flags
+
+Cluster Operator does not support disabling any [RabbitMQ feature flags](https://www.rabbitmq.com/feature-flags.html#how-to-disable-feature-flags).
+The Operator lists all available feature flags and enables all of them at cluster start.
  
 ## <a id='topology-operator' class='anchor' href='#topology-operator'>RabbitMQ Messaging Topology Operator</a>
 

--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -12,7 +12,7 @@ In this and other Operator related guides, we use "Operator" (with a capital O) 
 pattern implementation and "operator" (with a lowercase o) to refer to a technical operations
 engineer (administrator).
 
-## RabbitMQ Cluster Kubernetes Operator
+## <a id='cluster-operator' class='anchor' href='#cluster-operator'>RabbitMQ Cluster Kubernetes Operator</a>
 
 RabbitMQ Cluster Kubernetes Operator provides a consistent and easy way to deploy RabbitMQ clusters to Kubernetes and
 run them, including "day two" (continuous) operations. RabbitMQ clusters deployed using the operator can be
@@ -53,7 +53,7 @@ a new `Secret` will be created with new username and password, but those will no
 It works the same way for any `Secret` value, e.g. the value of the [shared inter-node authentication secret](/clustering.html#erlang-cookie)
 known as the Erlang cookie.
  
-## RabbitMQ Messaging Topology Operator
+## <a id='topology-operator' class='anchor' href='#topology-operator'>RabbitMQ Messaging Topology Operator</a>
 
 RabbitMQ Messaging Topology Operator supports managing RabbitMQ messaging topologies objects through kubernetes declarative API.
 


### PR DESCRIPTION
- document the fact that cluster operator always enables all available feature flags in a cluster (a user has reported this: https://github.com/rabbitmq/cluster-operator/issues/688)
- add reference links to operator titles