### PR TITLE
Fix Vhost kind in yaml example for topology operator documentation

### DIFF
--- a/site/kubernetes/operator/using-topology-operator.md
+++ b/site/kubernetes/operator/using-topology-operator.md
@@ -185,7 +185,7 @@ The following manifest will create a vhost named 'test' in a RabbitmqCluster nam
 
 <pre class="lang-bash">
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
+kind: Vhost
 metadata:
   name: test-vhost # name of this custom resource
   namespace: rabbitmq-system


### PR DESCRIPTION
In the documentation for using the topology operator, the Vhost example has a `kind: Queue` instead of a `kind: Vhost` in the yaml example. This PR fixes that, according to the example in https://github.com/rabbitmq/messaging-topology-operator/blob/main/docs/examples/vhosts/vhost.yaml