### PR TITLE
Add installation documentation for Tanzu RabbitMQ for K8s

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -36,12 +36,31 @@ docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-manag
  * MacOS: [Homebrew](install-homebrew.html) | [Generic binary build](install-generic-unix.html)
  * [Erlang/OTP for RabbitMQ](/which-erlang.html)
 
+## VMware Tanzu™ RabbitMQ® (Commercial Edition)
+
+ * [Tanzu™ RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
+ * [Tanzu™ RabbitMQ® on Kubernetes](kubernetes/tanzu/installation.html)
+
 ## Kubernetes
 
- * Open source [RabbitMQ Cluster Kubernetes Operator](kubernetes/operator/operator-overview.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
- * Kubernetes Operator [quickstart guide](kubernetes/operator/quickstart-operator.html)
- * Kubernetes Operator [usage guide](kubernetes/operator/using-operator.html)
- * Kubernetes Operator [examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples)
+### RabbitMQ Cluster Kubernetes Operator
+
+Open source [RabbitMQ Cluster Kubernetes Operator](kubernetes/operator/operator-overview.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator)):
+
+ * [quickstart guide](kubernetes/operator/quickstart-operator.html)
+ * [usage guide](kubernetes/operator/using-operator.html)
+ * [examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples)
+
+### RabbitMQ Topology Kubernetes Operator
+
+Open source [RabbitMQ Topology Kubernetes Operator](kubernetes/operator/using-topology-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/messaging-topology-operator)):
+
+ * [installation guide](kubernetes/operator/install-topology-operator.html)
+ * [usage guide](kubernetes/operator/using-topology-operator.html)
+
+
+Other guides related to Kubernetes:
+
  * A [peer discovery](/cluster-formation.html) mechanism [for Kubernetes](/cluster-formation.html#peer-discovery-k8s)
 
 
@@ -49,6 +68,14 @@ docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-manag
 
  * Docker community-maintained [RabbitMQ Docker image](https://registry.hub.docker.com/_/rabbitmq/) ([on GitHub](https://github.com/docker-library/rabbitmq/))
 
+
+## Cloud
+
+ * [Tanzu™ RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
+ * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
+ * [Tanzu™ RabbitMQ® on Kubernetes](kubernetes/tanzu/installation.html)
+ * [CloudAMQP](https://www.cloudamqp.com): RabbitMQ-as-a-Service available in multiple clouds
+ * [Amazon EC2](ec2.html)
 
 ## Downloads [on GitHub](https://github.com/rabbitmq/rabbitmq-server/releases)
 
@@ -65,15 +92,7 @@ docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-manag
 ## Debian (Apt) and RPM (Yum) Repositories
 
  * [Package Cloud](https://packagecloud.io/rabbitmq/)
-
-
-## Cloud
-
- * [Tanzu™ RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
- * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
- * [CloudAMQP](https://www.cloudamqp.com): RabbitMQ-as-a-Service available in multiple clouds
- * [Amazon EC2](/ec2.html)
-
+ * [Cloudsmith.io](https://cloudsmith.io/~rabbitmq/repos/)
 
 ## Provisioning Tools (Chef, Puppet, etc)
 

--- a/site/kubernetes/operator/install-operator.md
+++ b/site/kubernetes/operator/install-operator.md
@@ -1,4 +1,21 @@
-# Installing RabbitMQ Cluster Operator in a Kubernetes cluster
+<!--
+Copyright (c) 2020-2021 VMware, Inc. or its affiliates.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Installing RabbitMQ Cluster Operator in a Kubernetes Cluster
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 

--- a/site/kubernetes/tanzu/installation.md
+++ b/site/kubernetes/tanzu/installation.md
@@ -13,7 +13,7 @@ Before you install, you will require the following:
 ## Setup
 
 ### Installing on your registry
-If you haven't already, download the Tanzu RabbitMQ release tar file.
+If you haven't already, download the Tanzu RabbitMQ release tar file from [VMware Tanzu Network](https://network.pivotal.io/products/p-rabbitmq-for-kubernetes/).
 
 You must then place this tar file on the filesystem of a machine within the network you are hosting your registry. On that machine, you can load the tarball into your registry by running:
 <pre class="lang-bash">

--- a/site/kubernetes/tanzu/installation.md
+++ b/site/kubernetes/tanzu/installation.md
@@ -1,47 +1,87 @@
+<!--
+Copyright (c) 2020-2021 VMware, Inc. or its affiliates.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Installing VMware Tanzu RabbitMQ for Kubernetes
 
-Before you install, you will require the following:
+## Overview
+
+This guide covers installation of [VMware Tanzu RabbitMQ](https://tanzu.vmware.com/rabbitmq) to Kubernetes
+using the [Carvel toolchain](https://carvel.dev/#install), e.g. from TanzuNet:
+
+* [imgpkg](https://network.pivotal.io/products/imgpkg/)
+* [kapp](https://network.pivotal.io/products/kapp/)
+* [kbld](https://network.pivotal.io/products/kbld/)
+* [ytt](https://network.pivotal.io/products/ytt/)
+
+## Prerequisite
+
+This guide assumes you have the following:
 
 * A running Kubernetes cluster
-* The Carvel toolchain installed on your system
-  * This can be installed by either visiting the [Carvel website](https://carvel.dev/#install) or installing the following components from TanzuNet:
-    * [imgpkg](https://network.pivotal.io/products/imgpkg/)
-    * [kapp](https://network.pivotal.io/products/kapp/)
-    * [kbld](https://network.pivotal.io/products/kbld/)
-    * [ytt](https://network.pivotal.io/products/ytt/)
+* Kubernetes CLI tools such as `kubectl` installed
+* The [Carvel toolchain](https://carvel.dev/#install) installed
+* A local (private) container image registry
 
-## Setup
+## <a id='installation' class='anchor' href='#installation'>Installation</a>
 
-### Installing on your registry
-If you haven't already, download the Tanzu RabbitMQ release tar file from [VMware Tanzu Network](https://network.pivotal.io/products/p-rabbitmq-for-kubernetes/).
+### Installing to a Local Registry
 
-You must then place this tar file on the filesystem of a machine within the network you are hosting your registry. On that machine, you can load the tarball into your registry by running:
+First download the Tanzu RabbitMQ release tarball (`.tar` file) from [VMware Tanzu Network](https://network.pivotal.io/products/p-rabbitmq-for-kubernetes/).
+
+The file then must be placed on the filesystem of a machine within the network hosting the target registry.
+On that machine, load the tarball into the registry by running:
+
 <pre class="lang-bash">
+# upload the file to the target registry reachable on the local network
 imgpkg copy --to-repo your.company.domain/registry/tanzu-rabbitmq-bundle --tar tanzu-rabbitmq-1.1.0.tar
 </pre>
 
-On the machine targeting the Kubernetes cluster, you can now use this bundle by running:
+On a machine that targets (has access to) the target Kubernetes cluster,
+pull bundle by running:
+
 <pre class="lang-bash">
 imgpkg pull -b your.company.domain/registry/tanzu-rabbitmq-bundle:1.1.0 -o /your/output/directory
 cd /your/output/directory
 </pre>
 
-### Creating a namespace
-Create `rabbitmq-system` namespace by running:
+### Creating a Namespace
+
+Create a new namespace, `rabbitmq-system`, by running:
+
 <pre class="lang-bash">
 kubectl create namespace rabbitmq-system
 </pre>
 
 ### Providing imagePullSecrets
-Since your cluster will be pulling images from your registry, you will need to provide `imagePullSecrets` in order to access those images.
 
-First, create a registry credential Secret named `tanzu-registry-creds` following
-[these instructions](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line).
+Since the target Kubernetes cluster will be pulling images from the local registry,
+`imagePullSecrets` must be provided in order for the cluster to access those images.
 
-You will need to create this secret, with this exact name, in each namespace you plan on deploying RabbitmqClusters, as well as the `rabbitmq-system` namespace.
+First, create a registry credential Secret named `tanzu-registry-creds` [using `kubectl`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line).
 
-For example, if you plan on creating RabbitmqClusters on just the `default` namespace, you must create the secret on the `default` and `rabbitmq-system` namespaces. Since you are already
-authenticated with the registry, you can simply mount your local Docker authentication credentials as a Secret:
+This secret must be created **with this exact name**, in each namespace you plan on deploying RabbitmqClusters,
+as well as the `rabbitmq-system` namespace.
+
+For example, if RabbitmqClusters will be created in just the `default` namespace, create
+the secret on the `default` and `rabbitmq-system` namespaces.
+
+Assuming we have already authenticated with the registry, a more convenient options would be to simply mount
+the Docker authentication credentials as a Secret:
+
 <pre class="lang-bash">
 AUTH_TOKEN="$(cat $HOME/.docker/config.json | jq -r ".auths[\"$MY_PRIVATE_REGISTRY\"].auth")"
 kubectl create secret generic tanzu-registry-creds \
@@ -54,33 +94,41 @@ kubectl create secret generic tanzu-registry-creds \
     --from-literal=.dockerconfigjson="{\"auths\":{\"$MY_PRIVATE_REGISTRY\":{\"auth\":\"$AUTH_TOKEN\"}}}"
 </pre>
 
-## Installing the bundle
+## Installing the Bundle
 
-You now have two options for installing the components of this product:
+VMware Tanzu RabbitMQ uses TLS certificates for admission Webhooks in the cluster.
 
-1. (Recommended) Install using cert-manager
-2. Install using manually created Certificates
+There are two ways of installing the components of :
 
-### Option 1 (Recommended): Install using cert-manager
+1. Install using `cert-manager`. This option is **recommended**
+2. Install using manually created certificates
+
+### Option 1 (Recommended): Install Using cert-manager
 
 First, install Cert-manager version 1.2.0+ on your cluster. For example, for version 1.3.1, run:
+
 <pre class="lang-bash">
 kbld -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml | kapp deploy -y -a cert-manager -f-
 </pre>
 
-You can now install the RabbitMQ operators by running:
+Next install the RabbitMQ operators by running:
+
 <pre class="lang-bash">
 ytt -f manifests/cluster-operator.yml -f manifests/messaging-topology-operator-with-certmanager.yaml -f overlays/operator-deployments.yml | kbld -f .imgpkg/images.yml -f config/ -f- | kapp -y deploy -a rabbitmq-operator -f -
 </pre>
 
-### Option 2. Install using manually created Certificates
+### Option 2. Install Using Manually Created Certificates
 
-If you do not wish to use cert-manager to generate TLS certificates for the product, you can generate them manually instead.
+If using `cert-manager` to generate TLS certificates to be used by RabbitMQ nodes and  is not an option,
+certificates can be generated manually instead.
 
-You will need to generate TLS certificates used for admission webhooks in the cluster through whichever tool you prefer.
-Certificates must be valid for `webhook-service.rabbitmq-system.svc`.
+Certificates can be generated using any tool you prefer. They must include
+a Subject Alternative Name for `webhook-service.rabbitmq-system.svc`.
 
-Create a manifest for a Kubernetes Secret with name `webhook-server-cert` in namespace `rabbitmq-system`. The secret object must contain following keys: `ca.crt`, `tls.key`, and `tls.key`. For example:
+The secret object must contain following keys: `ca.crt`, `tls.key`, and `tls.key`.
+
+This example will create a manifest for a Kubernetes Secret with name `webhook-server-cert` in namespace `rabbitmq-system`:
+
 <pre class="lang-yaml">
 apiVersion: v1
 kind: Secret
@@ -93,26 +141,41 @@ data:
   tls.crt: # generated certificate
   tls.key: # generated key
 </pre>
-You do not yet need to deploy this Secret.
 
-Edit the Messaging Topology Operator manifest within the bundle, with an editor of your choice:
+There are some steps to perform **before** deploying the above manifest.
+
+Edit the Messaging Topology Operator manifest within the bundle
+using any text editor:
+
 <pre class="lang-bash">
 vim manifests/messaging-topology-operator.yaml
 </pre>
-You will need to replace the values of all `caBundle` keys in this file with the value of `ca.crt` in the Secret manifest you just created.
 
-Finally, install the RabbitMQ operators by running:
+In it, replace the values of all `caBundle` keys in this file with the value of `ca.crt` in the Secret manifest created earlier.
+
+Now install the RabbitMQ operators by running:
+
 <pre class="lang-bash">
 ytt -f manifests/cluster-operator.yml -f manifests/messaging-topology-operator.yaml -f overlays/operator-deployments.yml | kbld -f .imgpkg/images.yml -f config/ -f $SECRET_PATH -f- | kapp -y deploy -a rabbitmq-operator -f -
 </pre>
 
 ## Observability
-At this point you may choose to setup observability on your cluster. To do so, you can follow the instructions [in the Cluster Operator repo](https://github.com/rabbitmq/cluster-operator/tree/v1.7.0/observability)
-or the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/operator-monitoring.html).
 
-## Deploying your RabbitmqClusters and Topology objects
-Once this installation is complete, you can now create your RabbitMQ objects with the Carvel tooling. As long as you render the `overlays/rabbitmqcluster.yml` with the manifest of the `RabbitmqCluster` object,
-the resultant cluster will use the bundled Tanzu RabbitMQ container image. For example, to create a simple RabbitmqCluster:
+Setting up observability for RabbitMQ clusters is [very important](../../monitoring.html#approaches-to-monitoring).
+To do so, follow the instructions [in the Cluster Operator repo](https://github.com/rabbitmq/cluster-operator/tree/v1.7.0/observability)
+or the [RabbitMQ website](../operator/operator-monitoring.html).
+
+## Deploying your RabbitmqClusters and Topology Objects
+
+Once this installation is complete, the Carvel tooling can also be used to create RabbitMQ objects (virtual hosts, users, queues, exchanges, bindings:
+everything that can be managed via [definitions](../../definitions.html))
+using the [RabbitMQ Topology Operator](../operator/using-topology-operator.html).
+
+To do so, render `overlays/rabbitmqcluster.yml` with a manifest of the `RabbitmqCluster` object,
+the resultant cluster will use the bundled Tanzu RabbitMQ container image.
+
+This example creates a very minimalistic RabbitmqCluster:
+
 <pre class="lang-bash">
 cat &lt;&lt;EOF &gt; rabbitmq.yaml
 apiVersion: rabbitmq.com/v1beta1

--- a/site/kubernetes/tanzu/installation.md
+++ b/site/kubernetes/tanzu/installation.md
@@ -162,8 +162,8 @@ ytt -f manifests/cluster-operator.yml -f manifests/messaging-topology-operator.y
 ## Observability
 
 Setting up observability for RabbitMQ clusters is [very important](../../monitoring.html#approaches-to-monitoring).
-To do so, follow the instructions [in the Cluster Operator repo](https://github.com/rabbitmq/cluster-operator/tree/v1.7.0/observability)
-or the [RabbitMQ website](../operator/operator-monitoring.html).
+To do so, follow the instructions [in the Cluster Operator repository](https://github.com/rabbitmq/cluster-operator/tree/v1.7.0/observability)
+or the [Operator monitoring guide](../operator/operator-monitoring.html).
 
 ## Deploying your RabbitmqClusters and Topology Objects
 

--- a/site/kubernetes/tanzu/installation.md
+++ b/site/kubernetes/tanzu/installation.md
@@ -1,0 +1,124 @@
+# Installing VMware Tanzu RabbitMQ for Kubernetes
+
+Before you install, you will require the following:
+
+* A running Kubernetes cluster
+* The Carvel toolchain installed on your system
+  * This can be installed by either visiting the [Carvel website](https://carvel.dev/#install) or installing the following components from TanzuNet:
+    * [imgpkg](https://network.pivotal.io/products/imgpkg/)
+    * [kapp](https://network.pivotal.io/products/kapp/)
+    * [kbld](https://network.pivotal.io/products/kbld/)
+    * [ytt](https://network.pivotal.io/products/ytt/)
+
+## Setup
+
+### Installing on your registry
+If you haven't already, download the Tanzu RabbitMQ release tar file.
+
+You must then place this tar file on the filesystem of a machine within the network you are hosting your registry. On that machine, you can load the tarball into your registry by running:
+<pre class="lang-bash">
+imgpkg copy --to-repo your.company.domain/registry/tanzu-rabbitmq-bundle --tar tanzu-rabbitmq-1.1.0.tar
+</pre>
+
+On the machine targeting the Kubernetes cluster, you can now use this bundle by running:
+<pre class="lang-bash">
+imgpkg pull -b your.company.domain/registry/tanzu-rabbitmq-bundle:1.1.0 -o /your/output/directory
+cd /your/output/directory
+</pre>
+
+### Creating a namespace
+Create `rabbitmq-system` namespace by running:
+<pre class="lang-bash">
+kubectl create namespace rabbitmq-system
+</pre>
+
+### Providing imagePullSecrets
+Since your cluster will be pulling images from your registry, you will need to provide `imagePullSecrets` in order to access those images.
+
+First, create a registry credential Secret named `tanzu-registry-creds` following
+[these instructions](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line).
+
+You will need to create this secret, with this exact name, in each namespace you plan on deploying RabbitmqClusters, as well as the `rabbitmq-system` namespace.
+
+For example, if you plan on creating RabbitmqClusters on just the `default` namespace, you must create the secret on the `default` and `rabbitmq-system` namespaces. Since you are already
+authenticated with the registry, you can simply mount your local Docker authentication credentials as a Secret:
+<pre class="lang-bash">
+AUTH_TOKEN="$(cat $HOME/.docker/config.json | jq -r ".auths[\"$MY_PRIVATE_REGISTRY\"].auth")"
+kubectl create secret generic tanzu-registry-creds \
+    -n default \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-literal=.dockerconfigjson="{\"auths\":{\"$MY_PRIVATE_REGISTRY\":{\"auth\":\"$AUTH_TOKEN\"}}}"
+kubectl create secret generic tanzu-registry-creds \
+    -n rabbitmq-system \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-literal=.dockerconfigjson="{\"auths\":{\"$MY_PRIVATE_REGISTRY\":{\"auth\":\"$AUTH_TOKEN\"}}}"
+</pre>
+
+## Installing the bundle
+
+You now have two options for installing the components of this product:
+
+1. (Recommended) Install using cert-manager
+2. Install using manually created Certificates
+
+### Option 1 (Recommended): Install using cert-manager
+
+First, install Cert-manager version 1.2.0+ on your cluster. For example, for version 1.3.1, run:
+<pre class="lang-bash">
+kbld -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml | kapp deploy -y -a cert-manager -f-
+</pre>
+
+You can now install the RabbitMQ operators by running:
+<pre class="lang-bash">
+ytt -f manifests/cluster-operator.yml -f manifests/messaging-topology-operator-with-certmanager.yaml -f overlays/operator-deployments.yml | kbld -f .imgpkg/images.yml -f config/ -f- | kapp -y deploy -a rabbitmq-operator -f -
+</pre>
+
+### Option 2. Install using manually created Certificates
+
+If you do not wish to use cert-manager to generate TLS certificates for the product, you can generate them manually instead.
+
+You will need to generate TLS certificates used for admission webhooks in the cluster through whichever tool you prefer.
+Certificates must be valid for `webhook-service.rabbitmq-system.svc`.
+
+Create a manifest for a Kubernetes Secret with name `webhook-server-cert` in namespace `rabbitmq-system`. The secret object must contain following keys: `ca.crt`, `tls.key`, and `tls.key`. For example:
+<pre class="lang-yaml">
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: webhook-server-cert
+  namespace: rabbitmq-system
+data:
+  ca.crt: # ca cert that can be used to validate the webhook's server certificate
+  tls.crt: # generated certificate
+  tls.key: # generated key
+</pre>
+You do not yet need to deploy this Secret.
+
+Edit the Messaging Topology Operator manifest within the bundle, with an editor of your choice:
+<pre class="lang-bash">
+vim manifests/messaging-topology-operator.yaml
+</pre>
+You will need to replace the values of all `caBundle` keys in this file with the value of `ca.crt` in the Secret manifest you just created.
+
+Finally, install the RabbitMQ operators by running:
+<pre class="lang-bash">
+ytt -f manifests/cluster-operator.yml -f manifests/messaging-topology-operator.yaml -f overlays/operator-deployments.yml | kbld -f .imgpkg/images.yml -f config/ -f $SECRET_PATH -f- | kapp -y deploy -a rabbitmq-operator -f -
+</pre>
+
+## Observability
+At this point you may choose to setup observability on your cluster. To do so, you can follow the instructions [in the Cluster Operator repo](https://github.com/rabbitmq/cluster-operator/tree/v1.7.0/observability)
+or the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/operator-monitoring.html).
+
+## Deploying your RabbitmqClusters and Topology objects
+Once this installation is complete, you can now create your RabbitMQ objects with the Carvel tooling. As long as you render the `overlays/rabbitmqcluster.yml` with the manifest of the `RabbitmqCluster` object,
+the resultant cluster will use the bundled Tanzu RabbitMQ container image. For example, to create a simple RabbitmqCluster:
+<pre class="lang-bash">
+cat &lt;&lt;EOF &gt; rabbitmq.yaml
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: my-tanzu-rabbit
+EOF
+ytt -f rabbitmq.yaml -f overlays/rabbitmqcluster.yml | kbld -f- | kapp deploy -f- -a my-tanzu-rabbit -y
+</pre>


### PR DESCRIPTION
This adds a new page rabbitmq.com/kubernetes/tanzu/installation.html for this installation procedure.