### PR TITLE
Broken link fixed in tutorial three of dotnet.

### DIFF
--- a/site/tutorials/tutorial-three-dotnet.md
+++ b/site/tutorials/tutorial-three-dotnet.md
@@ -174,7 +174,7 @@ var queueName = channel.QueueDeclare().QueueName;
 </pre>
 
 You can learn more about the `exclusive` flag and other queue
-properties in the [guide on queues](queues.html).
+properties in the [guide on queues](../queues.html).
 
 At that point `queueName` contains a random queue name. For example
 it may look like `amq.gen-JzTY20BRgKO-HjmUJj0wLg`.


### PR DESCRIPTION
Hey!
I just started learning rabbitmq and I'm reading the documentation and found a broken link in dotnet tutorial three.
When you click on the "queues guide" link at https://www.rabbitmq.com/tutorials/tutorial-three-dotnet.html it goes to https://www.rabbitmq.com/tutorials/queues.html which displays a page not found.