### PR TITLE
Fixed broken kubernetes operator link

### DIFF
--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -1,6 +1,6 @@
 # RabbitMQ Cluster Operator for Kubernetes
 
-The RabbitMQ team develop and maintain two [kubernetes operators]((https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)):
+The RabbitMQ team develop and maintain two [kubernetes operators](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/):
 
 * RabbitMQ Cluster Kubernetes Operator automates provisioning, management, and operations of RabbitMQ clusters running on Kubernetes.
 * RabbitMQ Messaging Topology Operator manages RabbitMQ messaging topologies within a RabbitMQ cluster deployed via the RabbitMQ Cluster Kubernetes Operator.


### PR DESCRIPTION
Reading up on the k8s operator I noticed that this link is broken.

Instead of linking to https://kubernetes.io/docs/concepts/extend-kubernetes/operator/ it links to https://www.rabbitmq.com/kubernetes/operator/(https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) which is a broken link.