### PR TITLE
Remove old index configuration options

### DIFF
--- a/site/configure.md
+++ b/site/configure.md
@@ -1111,21 +1111,6 @@ cluster_keepalive_interval = 10000
       </p>
     </td>
   </tr>
-  <tr>
-    <td><code>queue_index_embed_msgs_below</code></td>
-    <td>
-      Size in bytes of message below which messages will
-      be embedded directly in the queue index. You are advised
-      to read the <a href="persistence-conf.html">persister
-      tuning</a> documentation before changing this.
-      <p>
-        Default:
-<pre class="lang-ini">
-queue_index_embed_msgs_below = 4096
-</pre>
-      </p>
-    </td>
-  </tr>
 
   <tr>
     <td><code>mnesia_table_loading_retry_timeout</code></td>
@@ -1331,21 +1316,6 @@ under the `rabbit` section.
 <pre class="lang-erlang">
 {rabbit, [
 {msg_store_credit_disc_bound, {4000, 800}}
-]}
-</pre>
-      </p>
-    </td>
-  </tr>
-  <tr>
-    <td><code>queue_index_max_journal_entries</code></td>
-    <td>
-      After how many queue index journal entries it will be
-      flushed to disk.
-      <p>
-        Default:
-<pre class="lang-erlang">
-{rabbit, [
-{queue_index_max_journal_entries, 32768}
 ]}
 </pre>
       </p>

--- a/site/lazy-queues.md
+++ b/site/lazy-queues.md
@@ -220,27 +220,17 @@ that should be considered.
 When a node is running and under normal operation, lazy queues will keep all messages on disk,
 the only exception being in-flight messages.
 
-When a RabbitMQ node starts, all queues, including the lazy ones, will load up to **16,384** messages into RAM.
-If [queue index embedding](persistence-conf.html) is enabled (the `queue_index_embed_msgs_below` configuration parameter is greater than 0),
-the payloads of those messages will be loaded into RAM as well.
+When a RabbitMQ node starts, all queues, including the lazy ones, will load up to **2,048** messages into RAM.
 
-For example, a lazy queue with **20,000** messages of **4,000** bytes each, will load **16,384** messages into memory.
-These messages will use **63MB** of system memory.
-The queue process will use another **8.4MB** of system memory, bringing the total to just over **70MB**.
+For example, a lazy queue with **20,000** messages of **4,000** bytes each, will load **2,048** messages into memory.
+These messages will use **8.2MB** of system memory.
+The queue process will use another **2MB** of system memory, bringing the total to just over **10MB**.
 
 This is an important consideration for capacity planning if the
 RabbitMQ node is memory constrained, or if there are many lazy queues
 hosted on the node.
 
 **It is important to remember that an under-provisioned RabbitMQ node in terms of memory or disk space will fail to start.**
-
-Setting `queue_index_embed_msgs_below` to `0` will disable payload embedding in the queue index.
-As a result, lazy queues will not load message payloads into memory on node startup.
-See the [Persistence Configuration guide](persistence-conf.html) for details.
-
-When setting `queue_index_embed_msgs_below` to `0` all messages will be stored
-to the message store. With many messages across many lazy queues,
-that can lead to higher disk usage and also higher file descriptor usage.
 
 Message store is append-oriented and uses a compaction mechanism to reclaim
 disk space. In extreme scenarios it can
@@ -257,31 +247,6 @@ For new installations it is possible to increase file size used by the message s
 `msg_store_file_size_limit` configuration key. **Never change segment file size for existing installations**
 as that can result in a subset of messages being ignored by the node
 and can break segment file compaction.
-
-#### Lazy Queues with Mixed Message Sizes
-
-If all messages in the first **10,000** messages are below the
-`queue_index_embed_msgs_below` value, and the rest are above this
-value, only the first **10,000** will be loaded into memory on node
-startup.
-
-#### Lazy Queues with Interleaved Message
-
-Given the following interleaved message sizes:
-
-| Position in queue | Message size in bytes |
-| -                 | -                     |
-| 1                 | 5,000                 |
-| 2                 | 100                   |
-| 3                 | 5,000                 |
-| 4                 | 200                   |
-| ...               | ...                   |
-| 79                | 4,000                 |
-| 80                | 5,000                 |
-
-Only the first **20** messages below the `queue_index_embed_msgs_below` value will be loaded into memory on node startup.
-In this scenario, messages will use **21KB** of system memory, and queue process will use another **32KB** of system memory.
-The total system memory required for the queue process to finish starting is **53KB**.
 
 
 ### Mirroring of Lazy Queues

--- a/site/persistence-conf.md
+++ b/site/persistence-conf.md
@@ -77,45 +77,6 @@ memory:
    index uses a small amount of memory for every message in the
    store.
 
-### <a id="index-embedding" class="anchor" href="#index-embedding">Message Embedding in Queue Indices</a>
-
-There are advantages and disadvantages to writing messages to
-the queue index.
-
-This feature has advantages and disadvantages. Main advantages are:
-
- * Messages can be written to disk in one operation rather than
-   two; for tiny messages this can be a substantial gain.
- * Messages that are written to the queue index do not require an
-   entry in the message store index and thus do not have a memory
-   cost when paged out.
-
-Disadvantages are:
-
- * The queue index keeps blocks of a fixed number of records in
-   memory; if non-tiny messages are written to the queue index then
-   memory use can be substantial.
- * If a message is routed to multiple queues by an exchange, the
-   message will need to be written to multiple queue indices. If
-   such a message is written to the message store, only one copy
-   needs to be written.
- * Unacknowledged messages whose destination is the queue index
-   are always kept in memory.
-
-The intent is for very small messages to be stored in the queue
-index as an optimisation, and for all other messages to be
-written to the message store. This is controlled by the
-configuration item <code>queue_index_embed_msgs_below</code>. By
-default, messages with a serialised size of less than 4096 bytes
-(including properties and headers) are stored in the queue
-index.
-
-Each queue index needs to keep at least one segment file in
-memory when reading messages from disk. The segment file
-contains records for 16,384 messages. Therefore be cautious if
-increasing <code>queue_index_embed_msgs_below</code>; a small
-increase can lead to a large amount of memory used.
-
 
 ## <a id="limits" class="anchor" href="#limits">OS and Runtime Limits Affecting </a>
 


### PR DESCRIPTION
This is the documentation changes for https://github.com/rabbitmq/rabbitmq-server/pull/3029

Currently does not include caveats with regard to the new index. One I can think of is that segment files are 2MB regardless of the number of messages in them (important for sizing if you have many queues). Another is that it uses up to 4 FDs.