### PR TITLE
Document design principles of Cluster Operator

### DIFF
--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -43,6 +43,19 @@ The operator provides the following key features:
 * Monitoring of RabbitMQ clusters using [Prometheus and Grafana](/prometheus.html)
 * Scaling up and automated [rolling upgrades](/upgrade.html) of RabbitMQ clusters
 
+### <a id='op-design-principles' class='anchor' href='#op-design-principles'>Design principles</a>
+
+RabbitMQ Cluster Kubernetes Operator was designed with the following ideas and concepts in mind:
+
+* It should provide flexible configurability of RabbitMQ
+* It should provide safe defaults
+* It should ease operability of RabbitMQ
+
+Following these ideas, the Operator will not modify an existing `RabbitmqCluster` spec. The only exception
+to this, is when a field is removed from the spec, by user action, the Operator will set back the default value.
+This also has the side-effect that, when the Operator is upgraded, it will not automatically upgrade
+existing instances of `RabbitmqCluster` to new defaults, if any, or to the latest version of RabbitMQ.
+
 ### <a id='limitations' class='anchor' href='#limitations'>Limitations</a>
 
 #### RabbitMQ Cluster Reconciliation

--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -51,10 +51,11 @@ RabbitMQ Cluster Kubernetes Operator was designed with the following ideas and c
 * It should provide safe defaults
 * It should ease operability of RabbitMQ
 
-Following these ideas, the Operator will not modify an existing `RabbitmqCluster` spec. The only exception
-to this, is when a field is removed from the spec, by user action, the Operator will set back the default value.
-This also has the side-effect that, when the Operator is upgraded, it will not automatically upgrade
-existing instances of `RabbitmqCluster` to new defaults, if any, or to the latest version of RabbitMQ.
+Following these ideas, the Operator will not modify an existing `RabbitmqCluster` spec.
+This implies that, when the Operator is upgraded, it will not automatically update
+existing instances of `RabbitmqCluster` with new defaults, if any, or to the latest version of RabbitMQ.
+
+The only exception to this, is when a field is removed from the spec, by user action, the Operator will set the default value.
 
 ### <a id='limitations' class='anchor' href='#limitations'>Limitations</a>
 


### PR DESCRIPTION
Based on issue https://github.com/rabbitmq/cluster-operator/issues/712, I noticed we don't have any written reference of our design principles, and this can cause confusion, as there isn't an standarised behaviour in the Operator ecosystem.

These ideas/principles have been present in our decisions since the beginning, however there were not written anywhere. This PR flushes them in the Operator Overview page.