### PR TITLE
Update install-rpm.md

### DIFF
--- a/site/install-rpm.md
+++ b/site/install-rpm.md
@@ -1044,5 +1044,5 @@ Next, install the packages:
 ## install these dependencies from standard OS repositories
 yum install socat logrotate -y
 
-yum install --repo rabbitmq_erlang --repo rabbitmq_server erlang rabbitmq-server -y
+yum install erlang rabbitmq-server -y
 </pre>


### PR DESCRIPTION
In centos 7 there is 'no such option: --repo' error with 
```
yum install --repo rabbitmq_erlang --repo rabbitmq_server erlang rabbitmq-server -y
```
but can install directly with
```
yum install erlang rabbitmq-server -y
```