### PR TITLE
add paths for configuration files to documentation

### DIFF
--- a/site/install-homebrew.md
+++ b/site/install-homebrew.md
@@ -46,7 +46,8 @@ Installing the RabbitMQ formula will install key dependencies such as a [support
 ## <a id="operations" class="anchor" href="#operations">Operations</a>
 
 The RabbitMQ server scripts and [CLI tools](/cli.html) are installed into the `sbin` directory under `/usr/local/Cellar/rabbitmq/<version>/`,
-which is accessible from `/usr/local/opt/rabbitmq/sbin`. Links to binaries have been created under `/usr/local/sbin`.
+which is accessible from `/usr/local/opt/rabbitmq/sbin`. Links to binaries have been created under `/usr/local/sbin`. Configuration files for RabbitMQ reside in `/usr/local/etc/rabbitmq/`, for example, the `rabbitmq-env.conf`.
+
 In case that directory is not in `PATH` it's recommended to append it:
 
 <pre class="lang-bash">


### PR DESCRIPTION
Hello,

I was trying to open my rabbitmq server on all interfaces (0.0.0.0) in order to test out something with another device on my network. I was confused why it wasn't working. When I searched around I found [a GitHub gist](https://gist.github.com/robcowie/1317580) which finally told me the path of the configuration file where I changed `NODE_IP_ADDRESS` from `127.0.0.1` to `0.0.0.0` and it worked. When I was reading the documentation, I thought this page would be a helpful place to put this information.

I won't be offended if language is changed at all, but am happy to do it myself as well.

Nick