### PR TITLE
Updated Rabbitmqctl man page with correct example for 'set_log_level'

### DIFF
--- a/site/man/rabbitmqctl.8.html
+++ b/site/man/rabbitmqctl.8.html
@@ -1792,7 +1792,7 @@ Note that <code class="Nm">rabbitmqctl</code> manages the RabbitMQ internal user
       <li>none</li>
     </ul>
     <p class="Pp">Example:</p>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl log_level
+    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_log_level
       debug</code></div>
   </dd>
   <dt><a class="permalink" href="#set_vm_memory_high_watermark"><code class="Cm" id="set_vm_memory_high_watermark">set_vm_memory_high_watermark</code></a>


### PR DESCRIPTION
The example command for "set_log_level" was wrong. Updated Rabbitmqctl man page with correct example for 'set_log_level'