### PR TITLE
Fix incorrect wording

### DIFF
--- a/site/ha.md
+++ b/site/ha.md
@@ -250,7 +250,7 @@ See [Runtime Parameters and Policies](/parameters.html#policies) to learn more.
 ### <a id="queue-leader-location" class="anchor" href="#queue-leader-location">Queue Leader Location</a>
 
 Every queue in RabbitMQ has a primary replica. That replica is called
-_queue leader_ (originally "queue leader"). All queue operations go through the leader
+_queue leader_ (originally "queue master"). All queue operations go through the leader
 replica first and then are replicated to followers (mirrors). This is necessary to
 guarantee FIFO ordering of messages.
 

--- a/site/quorum-queues.md
+++ b/site/quorum-queues.md
@@ -321,7 +321,7 @@ launched to run on a random subset of the RabbitMQ cluster.
 ### <a id="leader-placement" class="anchor" href="#leader-placement">Queue Leader Location</a>
 
 Every quorum queue has a primary replica. That replica is called
-_queue leader_ (originally "queue leader"). All queue operations go through the leader
+_queue leader_ (originally "queue master"). All queue operations go through the leader
 first and then are replicated to followers (mirrors). This is necessary to
 guarantee FIFO ordering of messages.
 


### PR DESCRIPTION
Fix incorrect wording concerning the original name of "queue leader".