### PR TITLE
Document default_consumer_prefetch

### DIFF
--- a/site/consumer-prefetch.md
+++ b/site/consumer-prefetch.md
@@ -121,3 +121,8 @@ messages between them, with a maximum of 10 messages for each
 consumer. This will be slower than the above examples, due to
 the additional overhead of coordinating between the channel and
 the queues to enforce the global limit.
+
+## <a id="default-limit" class="anchor" href="#default-limit">Configurable default prefetch</a>
+
+RabbitMQ can use a default prefetch that will be applied if the consumer doesn't specify one.
+The value to set is `default_consumer_prefetch` and can be specified in the [configuration file](/configure.html#config-file)


### PR DESCRIPTION
This was introduced in https://github.com/rabbitmq/rabbitmq-server/pull/1408, but never documented.