### PR TITLE
Make explicitly clear the precedence of RABBITMQ_LOGS

### DIFF
--- a/site/logging.md
+++ b/site/logging.md
@@ -45,7 +45,8 @@ The `RABBITMQ_LOGS` variable value can be either a file path or a hyphen (`-`).
 See [Logging to Console (Standard Output)](#logging-to-console).
 
 The environment variable takes precedence over the configuration file. When in doubt, consider
-overriding log file location via the config file.
+overriding log file location via the config file. As a consequence of the environment variable precedence,
+if the environment variable is set, the configuration key `log.file` will not have any effect.
 
 
 ## <a id="configuration" class="anchor" href="#configuration">Configuration</a>


### PR DESCRIPTION
We recently received a question on how to configure logging to a file in the Cluster Operator:

https://github.com/rabbitmq/cluster-operator/issues/771

The conclusion was that the Docker image sets RABBITMQ_LOGS environment variable, therefore any configurations like `log.file` were simply ignored. To me, it was not clear that the environment variable is not additive. A user could think that setting `RABBITMQ_LOGS` to `-` and `log.file` to a path would log to both, standard output and a file. This is not true and we can be explicitly clear about it in the docs.