### PR TITLE
Fix typo in changelog page

### DIFF
--- a/site/changelog.md
+++ b/site/changelog.md
@@ -51,7 +51,7 @@ published separately.
 
   <tr>
     <td class="centre">3.9.0</td>
-    <td class="centre">236July 2021</td>
+    <td class="centre">23 July 2021</td>
     <td>
       <ul>
         <li><a href="streams.html">Streams</a>: a new <a href="https://blog.rabbitmq.com/categories/streams/">messaging abstraction</a> complementary to queues</li>


### PR DESCRIPTION
Update release date of RabbitMQ 3.9.0 from `236July 2021` to `23 July 2021`.