### PR TITLE
Simplify wording re: Supported Distributions + PackageCloud one-liner note

### DIFF
--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -76,11 +76,7 @@ This option will require manual installation of all RabbitMQ package dependencie
 RabbitMQ is supported on several major Debian-based distributions that are still supported
 by their primary vendor or developer group.
 
-Note that modern versions of Erlang can have incompatibilities with older distributions (e.g. older than three to four years)
-or ship without much or any testing on older distributions or OS kernel versions.
-
-Older distributions can also lack a recent enough version of OpenSSL.
-Erlang 24 cannot be used on distributions that **do not** ship with OpenSSL 1.1 by default.
+Team RabbitMQ support and packaging efforts are focused on the current and prior release of Debian-based distributions, i.e. inline with distribution EOL policy.
 
 Currently the list of supported Debian-based distributions includes
 

--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -152,7 +152,7 @@ a package hosting service. It provides packages for most recent RabbitMQ release
 
 PackageCloud provides [repository setup instructions](https://packagecloud.io/rabbitmq/rabbitmq-server/install) that include
 a convenient one-liner. Please **always inspect scripts** that are downloaded from the Internet and executed via
-a privileged shell!
+a privileged shell!  Please also note that the PackageCloud script **does not** currently follow Debian best-practice in terms of GPG key handling and therefore you may wish to follow our guide instead.
 
 This guide will focus on a more traditional and explicit way of setting up an additional apt repository
 and installing packages.


### PR DESCRIPTION
Remove verbose discussion of OpenSSL versions etc. in favour of the easier to understand "current and previous distro version".

Also add note re: PackageCloud one liner.