### PR TITLE
Remove debian-keyring debian-archive-keyring

### DIFF
--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -185,7 +185,7 @@ Below is shell snippet that performs those steps. They are documented in more de
 <pre class="lang-bash">
 #!/bin/sh
 
-sudo apt-get install curl gnupg debian-keyring debian-archive-keyring apt-transport-https -y
+sudo apt-get install curl gnupg apt-transport-https -y
 
 ## Team RabbitMQ's main signing key
 curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
@@ -380,7 +380,7 @@ In order to use the repositories, their signing keys must be added to `apt-key`.
 This will instruct apt to trust packages signed by that key.
 
 <pre class="lang-bash">
-sudo apt-get install curl gnupg debian-keyring debian-archive-keyring apt-transport-https -y
+sudo apt-get install curl gnupg apt-transport-https -y
 
 ## Team RabbitMQ's main signing key
 curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
@@ -399,7 +399,7 @@ Below is shell snippet that performs those steps. They are documented in more de
 <pre class="lang-bash">
 #!/bin/sh
 
-sudo apt-get install curl gnupg debian-keyring debian-archive-keyring apt-transport-https -y
+sudo apt-get install curl gnupg apt-transport-https -y
 
 ## Team RabbitMQ's main signing key
 curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
@@ -441,7 +441,7 @@ All steps covered below are **mandatory** unless otherwise specified.
 <pre class="lang-bash">
 sudo apt-get update -y
 
-sudo apt-get install curl gnupg debian-keyring debian-archive-keyring -y
+sudo apt-get install curl gnupg -y
 </pre>
 
 ### Enable apt HTTPS Transport
@@ -1023,7 +1023,7 @@ In order to use the repository, it is necessary to
 <pre class="lang-bash">
 sudo apt-get update -y
 
-sudo apt-get install curl gnupg debian-keyring debian-archive-keyring -y
+sudo apt-get install curl gnupg -y
 </pre>
 
 ### <a id="erlang-apt-repo-signing-key" class="anchor" href="#erlang-apt-repo-signing-key">Add Repository Signing Key</a>


### PR DESCRIPTION
I don't believe there is a dependency on `debian-keyring` `debian-archive-keyring` here since we are pulling in relevant keys, also:

1. `debian-archive-keyring` seems to be provided in a basic Debian install anyway:
```
$ dpkg-query -W --showformat='${Package}\t${Priority}\n' | grep "debian-archive-keyring" 
debian-archive-keyring	important
```
2.  Debian doesn't exactly have encouraging words to say about `debian-keyring`:

>  "this package is provided for convenience, it is not necessarily kept updated with the latest changes" 

(https://packages.debian.org/buster/debian-keyring) so probably best to play safe !