### PR TITLE
Ordering tweaks + remove "older linux distributions"

### DIFF
--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -820,26 +820,6 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 }
 </pre>
 
-### Without systemd (Older Linux Distributions)
-
-The most straightforward way to adjust the per-user limit for
-RabbitMQ on distributions that do not use systemd is to edit the `/etc/default/rabbitmq-server`
-(provided by the RabbitMQ Debian package) or [rabbitmq-env.conf](https://www.rabbitmq.com/configure.html)
-to invoke `ulimit` before the service is started.
-
-<pre class="lang-bash">
-ulimit -S -n 4096
-</pre>
-
-This <em>soft</em> limit cannot go higher than the <em>hard</em> limit (which defaults to 4096 in many distributions).
-[The hard limit can be increased](https://github.com/basho/basho_docs/blob/master/content/riak/kv/2.2.3/using/performance/open-files-limit.md) via
-`/etc/security/limits.conf`. This also requires enabling the [pam_limits.so](http://askubuntu.com/a/34559) module
-and re-login or reboot. Note that limits cannot be changed for running OS processes.
-
-For more information about controlling `fs.file-max`
-with `sysctl`, please refer to the excellent
-[Riak guide on open file limit tuning](https://github.com/basho/basho_docs/blob/master/content/riak/kv/2.2.3/using/performance/open-files-limit.md#debian--ubuntu).
-
 ### <a id="verifying-limits" class="anchor" href="#verifying-limits">Verifying the Limit</a>
 
 [RabbitMQ management UI](management.html) displays the number of file descriptors available

--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -372,26 +372,6 @@ and installing packages.
 
 All steps covered below are **mandatory** unless otherwise specified.
 
-### <a id="cloudsmith-signing-keys" class="anchor" href="#cloudsmith-signing-keys">Add Repository Signing Keys</a>
-
-Cloudsmith signs distributed packages using their own GPG keys, one per repository.
-
-In order to use the repositories, their signing keys must be added to the system.
-This will enable apt to trust packages signed by that key.
-
-<pre class="lang-bash">
-sudo apt-get install curl gnupg apt-transport-https -y
-
-## Team RabbitMQ's main signing key
-curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
-## Cloudsmith: modern Erlang repository
-curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key | gpg --dearmor &gt; /usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg
-## Cloudsmith: RabbitMQ repository
-curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key | gpg --dearmor &gt; /usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg
-</pre>
-
-See the [guide on signatures](signatures.html) to learn more.
-
 ### <a id="apt-quick-start-cloudsmith" class="anchor" href="#apt-quick-start-cloudsmith">Cloudsmith Quick Start Script</a>
 
 Below is shell snippet that performs those steps. They are documented in more detail below.
@@ -452,6 +432,26 @@ the `apt-transport-https` package must be installed:
 <pre class="lang-bash">
 sudo apt-get install apt-transport-https
 </pre>
+
+### <a id="cloudsmith-signing-keys" class="anchor" href="#cloudsmith-signing-keys">Add Repository Signing Keys</a>
+
+Cloudsmith signs distributed packages using their own GPG keys, one per repository.
+
+In order to use the repositories, their signing keys must be added to the system.
+This will enable apt to trust packages signed by that key.
+
+<pre class="lang-bash">
+sudo apt-get install curl gnupg apt-transport-https -y
+
+## Team RabbitMQ's main signing key
+curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
+## Cloudsmith: modern Erlang repository
+curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key | gpg --dearmor &gt; /usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg
+## Cloudsmith: RabbitMQ repository
+curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key | gpg --dearmor &gt; /usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg
+</pre>
+
+See the [guide on signatures](signatures.html) to learn more.
 
 #### Add a Source List File
 

--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -163,21 +163,6 @@ and installing packages.
 
 All steps covered below are **mandatory** unless otherwise specified.
 
-### Add Repository Signing Key
-
-In order for `apt` to use the repository, [RabbitMQ signing key](signatures.html) must be available to the system for validation.
-
-<pre class="lang-bash">
-## Team RabbitMQ's main signing key
-curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
-## Launchpad PPA that provides modern Erlang releases
-curl -1sLf "https://keyserver.ubuntu.com/pks/lookup?op=get&amp;search=0xf77f1eda57ebb1cc" | gpg --dearmor &gt; /usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg
-## PackageCloud RabbitMQ repository
-curl -1sLf "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | gpg --dearmor &gt; /usr/share/keyrings/io.packagecloud.rabbitmq.gpg
-</pre>
-
-See the [guide on signatures](signatures.html) to learn more.
-
 ### <a id="apt-quick-start-packagecloud" class="anchor" href="#apt-quick-start-packagecloud">PackageCloud Quick Start Script</a>
 
 Below is shell snippet that performs those steps. They are documented in more detail below.
@@ -233,6 +218,21 @@ the `apt-transport-https` package must be installed:
 <pre class="lang-bash">
 sudo apt-get install apt-transport-https
 </pre>
+
+### Add Repository Signing Key
+
+In order for `apt` to use the repository, [RabbitMQ signing key](signatures.html) must be available to the system for validation.
+
+<pre class="lang-bash">
+## Team RabbitMQ's main signing key
+curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor &gt; /usr/share/keyrings/com.rabbitmq.team.gpg
+## Launchpad PPA that provides modern Erlang releases
+curl -1sLf "https://keyserver.ubuntu.com/pks/lookup?op=get&amp;search=0xf77f1eda57ebb1cc" | gpg --dearmor &gt; /usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg
+## PackageCloud RabbitMQ repository
+curl -1sLf "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | gpg --dearmor &gt; /usr/share/keyrings/io.packagecloud.rabbitmq.gpg
+</pre>
+
+See the [guide on signatures](signatures.html) to learn more.
 
 #### Add a Source List File
 

--- a/site/signatures.md
+++ b/site/signatures.md
@@ -80,7 +80,7 @@ gpg --keyserver "pgp.mit.edu" --recv-keys "0x0A9AF2115F4687BD29803A206B73A36E602
 ### <a id="importing-apt" class="anchor" href="#importing-apt">With apt</a>
 
 On Debian and Ubuntu systems, assuming that [apt repositories](/install-debian.html) are used for installation,
-trusted repository signing keys must be added to `apt-key` before any packages can be installed.
+trusted repository signing keys must be added to the system before any packages can be installed.
 
 This can be done using key servers or (for the RabbitMQ main signing key) a direct download.
 
@@ -176,8 +176,9 @@ gpg --sign-key 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
 
 [Cloudsmith.io](https://cloudsmith.io/~rabbitmq/repos/) is a hosted package distribution
 service that uses their own signing keys to sign the artifacts uploaded to it. The key(s) then
-must be imported with GPG, `apt-key` and similar tools. Cloudsmith provides repository
-setup script that include signing key import.
+must be added to the system. 
+
+Cloudsmith provides repository setup script that include signing key import. However, note that the PackageCloud script **does not** currently follow Debian best practices in terms of GPG key handling.
 
 To import the key:
 
@@ -195,8 +196,9 @@ After importing the key please follow the installation instructions in the [Debi
 
 [Package Cloud](https://packagecloud.io/rabbitmq) is a hosted package distribution
 service that uses their own signing keys to sign the artifacts uploaded to it. The key(s) then
-must be imported with GPG, `apt-key` and similar tools. Package Cloud provides repository
-setup script that include signing key import.
+must be added to the system. 
+
+Package Cloud provides repository setup script that include signing key import. However, note that the PackageCloud script **does not** currently follow Debian best practices in terms of GPG key handling.
 
 To import the key:
 


### PR DESCRIPTION
1. Removed "Without systemd (Older Linux Distributions)"
2. Tweak PackageCloud section ordering
3. Tweak Cloudsmith ordering
4. Remove `apt-key` references from signatures page