### PR TITLE
/bin/sh -> /usr/bin/sh

### DIFF
--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -168,7 +168,7 @@ All steps covered below are **mandatory** unless otherwise specified.
 Below is shell snippet that performs those steps. They are documented in more detail below.
 
 <pre class="lang-bash">
-#!/bin/sh
+#!/usr/bin/sh
 
 sudo apt-get install curl gnupg apt-transport-https -y
 
@@ -377,7 +377,7 @@ All steps covered below are **mandatory** unless otherwise specified.
 Below is shell snippet that performs those steps. They are documented in more detail below.
 
 <pre class="lang-bash">
-#!/bin/sh
+#!/usr/bin/sh
 
 sudo apt-get install curl gnupg apt-transport-https -y
 


### PR DESCRIPTION
Debian Bullseye Release Notes 5.3.2:

> The historical justifications for the filesystem layout with /bin, /sbin, and /lib directories separate from their equivalents under /usr no longer apply today; see the Freedesktop.org summary. Debian bullseye will be the last Debian release that supports the non-merged-usr layout; for systems with a legacy layout that have been upgraded without a reinstall, the usrmerge package exists to do the conversion if desired. 

I have checked on a random Buster instance and /usr/bin/sh is present and points to the same place, so the change is non-breaking for Buster:

```
$ ls -l /usr/bin/sh
lrwxrwxrwx 1 root root 4 Jul  3 18:59 /usr/bin/sh -> dash
$ ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Jul  3 18:59 /bin/sh -> dash
```