### PR TITLE
Replace outdated upgrade documentation

### DIFF
--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -26,6 +26,7 @@ Documentation of Cluster Operator spans several guides:
  * [Using](using-operator.html) RabbitMQ Cluster Kubernetes Operator
  * [Monitoring RabbitMQ Clusters on Kubernetes](operator-monitoring.html)
  * [Troubleshooting RabbitMQ Clusters on Kubernetes](troubleshooting-operator.html)
+ * [Upgrading the RabbitMQ Kubernetes Operators](upgrade-operator.html)
 
 In addition, a separate Operator for managing cluster objects collectively
 known as the messaging topology: virtual hosts, user, queues, etc.

--- a/site/kubernetes/operator/upgrade-operator.md
+++ b/site/kubernetes/operator/upgrade-operator.md
@@ -1,44 +1,45 @@
-# Upgrade Cluster Operator
+# Upgrading the RabbitMQ Kubernetes Operators
 
-This topic describes how to upgrade the Cluster Operator and its components.
+This topic describes how to upgrade the RabbitMQ Kubernetes Operators, and their components.
 
-## <a id="overview"> </a> Overview
+## <a id='overview' class='anchor' href='#overview'>Overview</a>
 
-Upgrades are not currently supported. The recommended method is a delete and re-install.
+Upgrading the RabbitMQ Cluster Kubernetes Operator or Messaging Topology Operator involves
+the following effects:
 
-Replacing the image reference in the Deployment manifest to a new version may work to deploy
-a newer version of the Cluster Operator, however that is not tested and has no guarantees.
+1. [Updating to the new operator manifest](#update-manifest)
+2. (For specified releases) [Rolling restart of RabbitmqCluster Pods](#rolling-restart)
 
+### <a id='update-manifest' class='anchor' href='#update-manifest'>Updating to the new operator manifest</a>
 
-## <a id='uninstall-manifests'></a> Uninstall Cluster Operator
+To upgrade to the new version of the operator, simply apply the new operator manifest for the desired version. For example,
+for the RabbitMQ Cluster Operator:
 
-To uninstall Cluster Operator:
+<pre class="lang-bash">
+kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml"
+# namespace/rabbitmq-system unchanged
+# customresourcedefinition.apiextensions.k8s.io/rabbitmqclusters.rabbitmq.com configured
+# serviceaccount/rabbitmq-cluster-operator unchanged
+# role.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-role unchanged
+# clusterrole.rbac.authorization.k8s.io/rabbitmq-cluster-operator-role unchanged
+# rolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-leader-election-rolebinding unchanged
+# clusterrolebinding.rbac.authorization.k8s.io/rabbitmq-cluster-operator-rolebinding unchanged
+# deployment.apps/rabbitmq-cluster-operator configured
+</pre>
 
-1. Delete `RabbitmqCluster` resources in all namespaces by running:
+This will cause the Custom Resource Definitions provided by the operator to be updated, and the Operator Pod to use the updated version
+of the operator container image.
 
-    ```
-    kubectl delete rabbitmqclusters --all --all-namespaces
-    ```
+New versions of the Cluster Operator typically include changes to the default version of RabbitMQ used in new clusters, if one is not specified in the
+`spec` of the RabbitmqCluster manifest. As a result, after upgrade, you will likely see that newly-created RabbitmqClusters will be running on a newer
+version of RabbitMQ if they do not specify a version in their `spec`. Note that this does not have an effect on existing RabbitmqClusters, whose
+manifests will have already been populated with the previous operator version's default.
 
-1. Verify that all `RabbitmqCluster` resources are deleted by running:
+### <a id='rolling-restart' class='anchor' href='#rolling-restart'>Rolling restart of RabbitmqCluster Pods</a>
 
-    <pre class="terminal">
-    kubectl wait --for delete pod \
-    -l "app.kubernetes.io/component=rabbitmq" --all-namespaces --timeout=300s
-    </pre>
+In some cases, upgrading the version of the RabbitMQ Cluster Operator (not the Messaging Topology Operator) will require the Pods of RabbitmqClusters
+to be restarted. This is usually due to a change in the underlying PodSpec of the RabbitmqCluster that the operator creates. In this case, upgrading the
+Cluster Operator will lead to the RabbitmqClusters on a Kubernetes distribution undergoing a rolling restart.
 
-1. Move to the Cluster Operator repository directory:
-
-1. Delete using the manifests:
-
-    <pre class="lang-bash">
-    kubectl delete --kustomize config/manager/
-    kubectl delete --kustomize config/rbac/
-    kubectl delete -f config/namespace/base/namespace.yaml
-    </pre>
-
-
-## <a id='install'></a> Install the Latest Version
-
-Follow the instructions in [Install Cluster Operator](/install-cluster-operator.html)
-
+If a Cluster Operator version will trigger a rolling restart of RabbitmqCluster Pods, it will be noted in the release notes for that version.
+For example, see https://github.com/rabbitmq/cluster-operator/releases/tag/v1.7.0.


### PR DESCRIPTION
Upgrading the operator is definitely supported, and information stating otherwise is legacy from pre-GA.