### PR TITLE
Require field publishNotReadyAddresses to be set

### DIFF
--- a/site/cluster-formation.md
+++ b/site/cluster-formation.md
@@ -433,6 +433,7 @@ A RabbitMQ cluster deployed to Kubernetes will use a set of pods. The set must b
 A [headless service](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations) must be used to
 control [network identity of the pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)
 (their hostnames), which in turn affect RabbitMQ node names.
+On the headless service `spec`, field `publishNotReadyAddresses` must be set to `true` to propagate SRV DNS records for its Pods for the purpose of peer discovery.
 
 If a stateless set is used recreated nodes will not have their persisted data and will start as blank nodes.
 This can lead to data loss and higher network traffic volume due to more frequent


### PR DESCRIPTION
in headless service for K8s peer discovery to work with parallel pod management policy.

Example:

```
apiVersion: v1
kind: Service
spec:
  publishNotReadyAddresses: true
```

If NOT set, K8s peer discovery will determine the peers correctly (i.e.
both ready and not-ready pods in
https://github.com/rabbitmq/rabbitmq-server/blob/513a643e9123c7bb3b3059a127a103ad0d99c205/deps/rabbitmq_peer_discovery_k8s/src/rabbit_peer_discovery_k8s.erl#L79 ).
However, when setting the lock in
https://github.com/rabbitmq/rabbitmq-server/blob/513a643e9123c7bb3b3059a127a103ad0d99c205/deps/rabbitmq_peer_discovery_k8s/src/rabbit_peer_discovery_k8s.erl#L82
the headless service will route traffic to only ready pods
resulting in the locking mechanism not to work with podManagementPolicy
set to parallel. This will result in standalone clusters to be created.

See also https://groups.google.com/g/rabbitmq-users/c/HgiBFyRqEks

As specified in the K8s API field publishNotReadyAddresses must be
set "to propagate SRV DNS records for its Pods for the purpose of peer
discovery".