### PR TITLE
Correct code example in .NET/C# Client API Guide

### DIFF
--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -142,7 +142,7 @@ IConnection conn = factory.CreateConnection();
 
 <pre class="lang-csharp">
 ConnectionFactory factory = new ConnectionFactory();
-factory.Uri = "amqp://user:pass@hostName:port/vhost";
+factory.Uri = new Uri("amqp://user:pass@hostName:port/vhost");
 
 IConnection conn = factory.CreateConnection();
 </pre>


### PR DESCRIPTION
The `Uri` property is a `Uri` object, not a `string`, so the old code didn't compile.

See https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/5ab37c795d8e333d84d245ed0e25e310c26feadb/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs#L323