### PR TITLE
Exclusive queues are now always client-local

### DIFF
--- a/site/queues.md
+++ b/site/queues.md
@@ -251,6 +251,8 @@ are only suitable for client-specific transient state.
 
 It is common to make exclusive queues server-named.
 
+Exclusive queues are declared on the "client-local" node (the node that the client declaring
+the queue is connected to), regardless of the `queue_master_locator` value.
 
 ## <a id="distributed" class="anchor" href="#distributed">Replicated and Distributed Queues</a>
 


### PR DESCRIPTION
This will be true in 3.10+