### PR TITLE
Correct consumer timeout

### DIFF
--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -232,9 +232,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 [Manual message acknowledgments](../confirms.html) are turned on by default. In previous
 examples we explicitly turned them off by setting the autoAck

--- a/site/tutorials/tutorial-two-elixir.md
+++ b/site/tutorials/tutorial-two-elixir.md
@@ -196,9 +196,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 [Manual message acknowledgments](../confirms.html) are turned on by default. In previous
 examples we explicitly turned them off via the `no_ack: true`

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -238,9 +238,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 In this tutorial we will use manual message acknowledgements by passing
 a `false` for the "auto-ack" argument and then send a proper acknowledgment

--- a/site/tutorials/tutorial-two-java.md
+++ b/site/tutorials/tutorial-two-java.md
@@ -209,9 +209,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 [Manual message acknowledgments](../confirms.html) are turned on by default. In previous
 examples we explicitly turned them off via the `autoAck=true`

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -215,9 +215,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 Manual consumer acknowledgments have been turned off in previous examples.
 It's time to turn them on using the `{noAck: false}` option and send a proper acknowledgment

--- a/site/tutorials/tutorial-two-objectivec.md
+++ b/site/tutorials/tutorial-two-objectivec.md
@@ -185,9 +185,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 Message acknowledgments are turned off by default in the client, but not in the
 AMQ protocol (the `AMQBasicConsumeNoAck` option is automatically sent by

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -203,9 +203,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 Message acknowledgments were previously turned off by ourselves.
 It's time to turn them on by setting the fourth parameter to `basic_consume` to `false`

--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -193,9 +193,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 [Manual message acknowledgments](../confirms.html) are turned on by default. In previous
 examples we explicitly turned them off via the `auto_ack=True`

--- a/site/tutorials/tutorial-two-ruby.md
+++ b/site/tutorials/tutorial-two-ruby.md
@@ -197,9 +197,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 Message acknowledgments are turned off by default.
 It's time to turn them on using the `:manual_ack` option and send a proper acknowledgment

--- a/site/tutorials/tutorial-two-swift.md
+++ b/site/tutorials/tutorial-two-swift.md
@@ -180,9 +180,10 @@ If there are other consumers online at the same time, it will then quickly redel
 to another consumer. That way you can be sure that no message is lost,
 even if the workers occasionally die.
 
-There aren't any message timeouts; RabbitMQ will redeliver the message when
-the consumer dies. It's fine even if processing a message takes a very, very
-long time.
+A timeout (30 minutes by default) is enforced on consumer delivery acknowledgement.
+This helps detect buggy (stuck) consumers that never acknowledge deliveries.
+You can increase this timeout as described in
+[acknowledgement-timeout](../consumers.html#acknowledgement-timeout).
 
 Message acknowledgments are turned off by default in the client, but not in the
 AMQ protocol (the `RMQBasicConsumeOptions.noAck` option is automatically sent by


### PR DESCRIPTION
It seems that no consumer timeout was the default a while ago.

Relates https://github.com/rabbitmq/rabbitmq-server/pull/2990