### PR TITLE
Fix wording about ack in .NET/C# Client API Guide

### DIFF
--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -588,7 +588,7 @@ if (result == null) {
     ...
 </pre>
 
-The above example uses [automatic acknowledgements](/confirms.html) (`autoAck = false`), so the application must also call
+The above example uses [manual acknowledgements](/confirms.html) (`autoAck = false`), so the application must also call
 `IModel.BasicAck` to acknowledge the delivery after processing:
 
 <pre class="lang-csharp">

--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -578,8 +578,8 @@ The returned value is an instance of `BasicGetResult`, from which the header
 information (properties) and message body can be extracted:
 
 <pre class="lang-csharp">
-bool noAck = false;
-BasicGetResult result = channel.BasicGet(queueName, noAck);
+bool autoAck = false;
+BasicGetResult result = channel.BasicGet(queueName, autoAck);
 if (result == null) {
     // No message available at this time.
 } else {
@@ -588,7 +588,7 @@ if (result == null) {
     ...
 </pre>
 
-The above example uses [automatic acknowledgements](/confirms.html) (`noAck = false`), so the application must also call
+The above example uses [automatic acknowledgements](/confirms.html) (`autoAck = false`), so the application must also call
 `IModel.BasicAck` to acknowledge the delivery after processing:
 
 <pre class="lang-csharp">


### PR DESCRIPTION
Fix 2 things in .NET/C# Client API Guide (https://www.rabbitmq.com/dotnet-api-guide.html#basic-get)

1. Rename `noAck` to `autoAck`
Reference: https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/297

2. Fix the wording
`noAck` = `false`
⇒ no manual acknowledgements = `false`
⇒ manual acknowledgements = `true`
Reference: https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/255#issuecomment-323133972

For reference, same guide for Java: https://www.rabbitmq.com/api-guide.html#getting