### PR TITLE
Fix code samples in .NET tutorial 7

### DIFF
--- a/site/tutorials/tutorial-seven-dotnet.md
+++ b/site/tutorials/tutorial-seven-dotnet.md
@@ -61,7 +61,7 @@ that is, publishing a message and waiting synchronously for its confirmation:
 while (ThereAreMessagesToPublish())
 {
     byte[] body = ...;
-    BasicProperties properties = ...;
+    IBasicProperties properties = ...;
     channel.BasicPublish(exchange, queue, properties, body);
     // uses a 5 second timeout
     channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, 5));
@@ -107,7 +107,7 @@ var outstandingMessageCount = 0;
 while (ThereAreMessagesToPublish())
 {
     byte[] body = ...;
-    BasicProperties properties = ...;
+    IBasicProperties properties = ...;
     channel.BasicPublish(exchange, queue, properties, body);
     outstandingMessageCount++;
     if (outstandingMessageCount == batchSize)


### PR DESCRIPTION
In [.NET tutorial seven][1], in code samples, replace `BasicProperties` by `IBasicProperties`.

This is because `BasicProperties` is `internal`, not `public`.
https://github.com/rabbitmq/rabbitmq-dotnet-client/commit/267bae75b217dd32bd4c116dd3cdf25a3e3b70f1#diff-a63ad46e4c793acbad8d98e9ac01d886fc968bc31115eef609f5111bd888a027

[1]: https://www.rabbitmq.com/tutorials/tutorial-seven-dotnet.html