### PR TITLE
Minor improvements in C# code samples

### DIFF
--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -310,7 +310,7 @@ factory.HostName = hostName;
 
 // this name will be shared by all connections instantiated by
 // this factory
-factory.ClientProvidedName = "app:audit component:event-consumer"
+factory.ClientProvidedName = "app:audit component:event-consumer";
 
 IConnection conn = factory.CreateConnection();
 </pre>
@@ -410,7 +410,7 @@ channel.QueueDelete("queue-name", true, false);
 A queue can be purged (all of its messages deleted):
 
 <pre class="lang-csharp">
-channel.QueuePurge("queue-name")
+channel.QueuePurge("queue-name");
 </pre>
 
 
@@ -462,7 +462,7 @@ byte[] messageBodyBytes = System.Text.Encoding.UTF8.GetBytes("Hello, world!");
 IBasicProperties props = channel.CreateBasicProperties();
 props.ContentType = "text/plain";
 props.DeliveryMode = 2;
-props.Expiration = "36000000"
+props.Expiration = "36000000";
 
 channel.BasicPublish(exchangeName, routingKey, props, messageBodyBytes);
 </pre>

--- a/site/ttl.md
+++ b/site/ttl.md
@@ -145,7 +145,7 @@ byte[] messageBodyBytes = System.Text.Encoding.UTF8.GetBytes("Hello, world!");
 IBasicProperties props = model.CreateBasicProperties();
 props.ContentType = "text/plain";
 props.DeliveryMode = 2;
-props.Expiration = "60000"
+props.Expiration = "60000";
 
 model.BasicPublish(exchangeName,
                    routingKey, props,

--- a/site/tutorials/tutorial-six-dotnet.md
+++ b/site/tutorials/tutorial-six-dotnet.md
@@ -333,8 +333,8 @@ public class RpcClient
     private readonly BlockingCollection&lt;string&gt; respQueue = new BlockingCollection&lt;string&gt;();
     private readonly IBasicProperties props;
 
-public RpcClient()
-{
+    public RpcClient()
+    {
         var factory = new ConnectionFactory() { HostName = "localhost" };
 
         connection = factory.CreateConnection();


### PR DESCRIPTION
1. Add missing semicolons.
2. Fix code indentation.