### PR TITLE
Correct rabbit.default_consumer_prefetch example

### DIFF
--- a/site/consumer-prefetch.md
+++ b/site/consumer-prefetch.md
@@ -131,7 +131,7 @@ The value can be configured as `rabbit.default_consumer_prefetch` in the [advanc
 %% advanced.config file
 [
  {rabbit, [
-       {default_consumer_prefetch, 250}
+       {default_consumer_prefetch, {false,250}}
      ]
  }
 ].


### PR DESCRIPTION
The current example does not work and results in an error when trying to open a channel ("no match of right hand side value").