### PR TITLE
Document stream data conversion limitations

### DIFF
--- a/site/streams.md
+++ b/site/streams.md
@@ -472,3 +472,12 @@ When using the broker provided offset tracking features (currently only availabl
 when using the [Stream plugin](/stream.html)) offsets are persisted in the stream
 itself as non-message data. This means that as offset persistence is requested the
 stream will grow on disk by some small amount per offset persistence request.
+
+## <a id="limitations" class="anchor" href="#limitations">Limitations</a>
+
+Streams internally store their messages as AMQP 1.0 encoded data. This means when
+publishing using AMQP 0.9.1 a conversion takes place. Although the AMQP 1.0 data
+model is mostly capable of containing all of AMQP 0.9.1's data model there are some
+limitations. If an AMQP 0.9.1 message contains header entries with complex values
+such as arrays or tables these headers will not be converted. That is because headers are stored as application properties inside the AMQP 1.0 message and these can only
+contain values of simple types, such as strings and numbers.


### PR DESCRIPTION
To mention that AMQP 0.9.1 headers with array or table values will
not be converted.