### PR TITLE
Update wording for ConnectionBlocked/ConnectionUnblocked in C#

### DIFF
--- a/site/connection-blocked.md
+++ b/site/connection-blocked.md
@@ -79,11 +79,8 @@ connection.addBlockedListener(new BlockedListener() {
 ## <a id="dotnet" class="anchor" href="#dotnet">Using Blocked Connection Notifications with .NET Client</a>
 
 With the [official .NET client](/dotnet-api-guide.html), blocked connection
-notifications are handled by the
-`RabbitMQ.Client.Events.ConnectionBlockedEventHandler`
-delegate. `IConnection` provides
-`IConnection.ConnectionBlocked` and
-`IConnection.ConnectionUnblocked` events:
+notifications can be received by registering for the
+`ConnectionBlocked` and `ConnectionUnblocked` events in `IConnection`:
 
 <pre class="lang-csharp">
   public void HandleBlocked(object sender, ConnectionBlockedEventArgs args)


### PR DESCRIPTION
There's no such thing as `ConnectionBlockedEventHandler`,
so I rewrote the sentence a bit.