### PR TITLE
Fix C# property name

### DIFF
--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -335,7 +335,7 @@ and consumer code.
 
 At this point we're sure that the `task_queue` queue won't be lost
 even if RabbitMQ restarts. Now we need to mark our messages as persistent
-- by setting `IBasicProperties.SetPersistent` to `true`.
+- by setting `IBasicProperties.Persistent` to `true`.
 
 <pre class="lang-csharp">
 var properties = channel.CreateBasicProperties();


### PR DESCRIPTION
The property name should be `Persistent` instead of `SetPersistent`, as shown in the snippet that follows.