### PR TITLE
slight typo fix in java tutorial #6

### DIFF
--- a/site/tutorials/tutorial-six-java.md
+++ b/site/tutorials/tutorial-six-java.md
@@ -80,7 +80,7 @@ Let's try it:
 callbackQueueName = channel.queueDeclare().getQueue();
 
 BasicProperties props = new BasicProperties()
-                            .builder()
+                            .Builder()
                             .replyTo(callbackQueueName)
                             .build();
 


### PR DESCRIPTION
Noticed this typo in the tutorial and thought I may as well do a PR to fix it. 

It also took a few seconds to figure out to import `com.rabbitmq.client.AMQP.BasicProperties` as I'd not scrolled down below the grey box yet, so I also think it's a bit more helpful to have the bit about the import above that box

Finally, the code snippet
```java
RPCClient fibonacciRpc = new RPCClient();

System.out.println(" [x] Requesting fib(30)");
String response = fibonacciRpc.call("30");
System.out.println(" [.] Got '" + response + "'");

fibonacciRpc.close();
```
Towards the bottom seems outdated as compared to the [example code](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/RPCClient.java).