### PR TITLE
Add Delivery-Limit Dead-Lettered Reason

### DIFF
--- a/site/dlx.md
+++ b/site/dlx.md
@@ -193,6 +193,7 @@ message was dead-lettered and is one of the following:
  * `rejected`: the message was rejected with `requeue` parameter set to `false`
  * `expired`: the [message TTL](/ttl.html) has expired
  * `maxlen`: the [maximum allowed queue length](/maxlength.html) was exceeded
+ * `delivery-limit`: the message has been returned more times than the limit (set by policy argument [delivery-limit](/quorum-queues.html#poison-message-handling) of quorum queues).
 
 Three top-level headers are added for the very first dead-lettering
 event. They are


### PR DESCRIPTION
If a message is dead-lettered after it has been returned more times than the limit, the `reason` field of the `x-death` header will be "delivery-limit".