### PR TITLE
Fix typo in tutorial-two-python. Bytes instead string

### DIFF
--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -206,7 +206,7 @@ from the worker, once we're done with a task.
 <pre class="lang-python">
 def callback(ch, method, properties, body):
     print(" [x] Received %r" % body.decode())
-    time.sleep( body.count('.') )
+    time.sleep(body.count(b'.') )
     print(" [x] Done")
     ch.basic_ack(delivery_tag = method.delivery_tag)
 


### PR DESCRIPTION
Tix typo in python-two tutorial descriptions.

This commit replace string and add bytes to time.sleep body in 'Message
acknowledgment' part.