### PR TITLE
Use named constant in the Python tutorial

### DIFF
--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -278,15 +278,15 @@ This `queue_declare` change needs to be applied to both the producer
 and consumer code.
 
 At that point we're sure that the `task_queue` queue won't be lost
-even if RabbitMQ restarts. Now we need to mark our messages as persistent
-- by supplying a `delivery_mode` property with a value `2`.
+even if RabbitMQ restarts. Now we need to mark our messages as persistent -
+by supplying a `delivery_mode` property with the value of `pika.spec.PERSISTENT_DELIVERY_MODE`
 
 <pre class="lang-python">
 channel.basic_publish(exchange='',
                       routing_key="task_queue",
                       body=message,
                       properties=pika.BasicProperties(
-                         delivery_mode = 2, # make message persistent
+                         delivery_mode = pika.spec.PERSISTENT_DELIVERY_MODE
                       ))
 </pre>
 
@@ -379,7 +379,7 @@ channel.basic_publish(
     routing_key='task_queue',
     body=message,
     properties=pika.BasicProperties(
-        delivery_mode=2,  # make message persistent
+        delivery_mode=pika.spec.PERSISTENT_DELIVERY_MODE
     ))
 print(" [x] Sent %r" % message)
 connection.close()


### PR DESCRIPTION
Use `pika.spec.PERSISTENT_DELIVERY_MODE` instead of `2`.