### PR TITLE
doc: fix typos for Erlang guide

### DIFF
--- a/site/erlang-client-user-guide.md
+++ b/site/erlang-client-user-guide.md
@@ -735,7 +735,7 @@ result, as illustrated here:
 </pre>
 
 Note that the previous example sets the no_ack flag on the
-#'basic.get'{} command. This tells the broker that the receiver
+`#'basic.get'{}` command. This tells the broker that the receiver
 will not send an acknowledgement of the message. In doing so, the
 broker can absolve itself of the responsibility for delivery -
 once it believes it has delivered a message, then it is free to
@@ -753,7 +753,7 @@ Get = #'basic.get'{queue = Q},
 amqp_channel:cast(Channel, #'basic.ack'{delivery_tag = Tag})
 </pre>
 
-Notice that the #'basic.ack'{} method was sent using
+Notice that the `#'basic.ack'{}` method was sent using
 `amqp_channel:cast/2` instead of `amqp_channel:call/2`. This is
 because acknowledgements are entirely asynchronous and the server
 will not produce a response for them.


### PR DESCRIPTION

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/31410892/144876649-9d8594b6-ff02-4f89-b5c4-6a0f0aab3752.png) | ![image](https://user-images.githubusercontent.com/31410892/144876935-96fa5c89-f067-4164-bdce-f35b2525f5c3.png)  |