### PR TITLE
Fix typo in cluster-formation.md

### DIFF
--- a/site/cluster-formation.md
+++ b/site/cluster-formation.md
@@ -387,7 +387,7 @@ the `cluster_formation.aws.use_private_ip` key to `true`. For this setup to work
 [`RABBITMQ_NODENAME` must be set](configure.html#customise-environment) to the private IP address at node
 deployment time.
 
-`RABBITMQ_USE_LOGNAME` also has to be set to `true` or an IP address won't be considered a valid
+`RABBITMQ_USE_LONGNAME` also has to be set to `true` or an IP address won't be considered a valid
 part of node name.
 
 <pre class="lang-ini">


### PR DESCRIPTION
Fix an incorrect reference to RABBITMQ_USE_LONGNAME environment variable in cluster-formation.md file.