### PR TITLE
Change distro name for Debian Bullseye release

### DIFF
--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -289,7 +289,7 @@ with the RabbitMQ apt repository on PackageCloud.
 | Ubuntu 20.04    | `focal`      |
 | Ubuntu 18.04    | `bionic`     |
 | Debian Buster   | `buster`     |
-| Debian Bullseye | `buster`     |
+| Debian Bullseye | `bullseye`   |
 | Debian Sid      | `buster`     |
 
 To add the apt repository to the source list directory (`/etc/apt/sources.list.d`), use:
@@ -506,7 +506,7 @@ with the RabbitMQ apt repository on PackageCloud.
 | Ubuntu 20.04    | `focal`      |
 | Ubuntu 18.04    | `bionic`     |
 | Debian Buster   | `buster`     |
-| Debian Bullseye | `buster`     |
+| Debian Bullseye | `bullseye`   |
 | Debian Sid      | `buster`     |
 
 To add the apt repository to the source list directory (`/etc/apt/sources.list.d`), use:


### PR DESCRIPTION
Installation on Debian Bullseye with `buster` as a name of RabbitMQ apt repository on PackageCloud breaking the deployment and rabbitmq-server can't be loaded. I decided to deploy RabbitMQ adding to /etc/apt/sources.list.d/rabbitmq.list `bullseye`:
```
#  # Provides RabbitMQ
#
deb [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/debian/ bullseye main
deb-src [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/debian/ bullseye main
```
And finally, my RabbitMQ started to work. 
That would definitely save us time if this information was already available in your documentation. Thank you in advance!