### PR TITLE
Mention that the same channel must be used for publish and consume in direct reply-to

### DIFF
--- a/site/direct-reply-to.md
+++ b/site/direct-reply-to.md
@@ -93,6 +93,11 @@ or fail.
     client disconnects or rejects the reply message.
   </li>
   <li>
+    The RPC client must use the same connection and channel for 
+    both consuming from <code>amq.rabbitmq.reply-to</code> and
+    for publishing the request message.
+  </li>
+  <li>
     Reply messages sent using this mechanism are in general not
     fault-tolerant; they will be discarded if the client that
     published the original request subsequently disconnects. The


### PR DESCRIPTION
I know that this should be self-evident, but missing this fact just cost me 5 hours of mindless debugging. I hope that this will save time for someone in the future.

Context: we have a wrapper over php-amqplib which automatically uses separate connections for publish and subscribe operations. Given so, publishing direct reply-to messages was failing with `operation basic.publish caused a channel exception precondition_failed: fast reply consumer does not exist`. It took me a lot of time until I realised what the cause was.