### PR TITLE
remove duplicate Link to https://github.com/cloudamqp/amqp-client.js

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -111,7 +111,6 @@ Miscellaneous projects:
  * [amqp-stats](https://github.com/timisbusy/node-amqp-stats): a node.js interface for RabbitMQ management statistics
  * [Rascal](https://github.com/guidesmiths/rascal): a config driven wrapper for [amqp.node](https://github.com/squaremo/amqp.node) supporting multi-host connections,
    automatic error recovery, redelivery flood protection, transparent encryption and channel pooling.
- * [amqp-client.js](https://github.com/cloudamqp/amqp-client.js) AMQP 0-9-1 client both for Node.js and browsers (using WebSocket)
 
 
 ## <a id="go-dev" class="anchor" href="#go-dev">Go</a>


### PR DESCRIPTION
The link to https://github.com/cloudamqp/amqp-client.js is included several times in the documentation. This pull request removed the second place.