### PR TITLE
Update .md files to use relative linking

### DIFF
--- a/site/404.md
+++ b/site/404.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Page not found
 
 Oops! The page you were looking for has not been found. Please take a look at
-the [documentation ToC](/documentation.html) and [recent RabbitMQ releases](/changelog.html).
+the [documentation ToC](./documentation.html) and [recent RabbitMQ releases](./changelog.html).
 
 If you think you've found a broken link, feel free to [submit a pull request](https://github.com/rabbitmq/rabbitmq-website/)
 or report a documentation issue [on the mailing list](https://groups.google.com/forum/#!forum/rabbitmq-users).

--- a/site/access-control.md
+++ b/site/access-control.md
@@ -22,7 +22,7 @@ limitations under the License.
 This document describes [authentication](#authentication) and [authorisation](#authorisation) features
 in RabbitMQ. Together they allow the operator to control access to the system.
 
-Different users can be granted access only to specific [virtual hosts](/vhosts.html). Their
+Different users can be granted access only to specific [virtual hosts](./vhosts.html). Their
 permissions in each virtual hosts also can be limited.
 
 RabbitMQ supports two major [authentication mechanisms](#mechanisms)
@@ -43,8 +43,8 @@ This guide covers a variety of authentication, authorisation and user management
  * How to [pre-create users](#seeding) and their permissions
  * Troubleshooting of [authentication](#troubleshooting-authn) and [authorisation failures](#troubleshooting-authz)
 
-[Password-based](/passwords.html) authentication has a companion guide.
-A closely related topic of [TLS support](/ssl.html) is also covered in a dedicated guide.
+[Password-based](./passwords.html) authentication has a companion guide.
+A closely related topic of [TLS support](./ssl.html) is also covered in a dedicated guide.
 
 
 ## <a id="terminology-and-definitions" class="anchor" href="#terminology-and-definitions">Terminology and Definitions</a>
@@ -59,17 +59,17 @@ authorisation as "determining what the user is and isn't allowed to do."
 ## <a id="basics" class="anchor" href="#basics">The Basics</a>
 
 Clients use RabbitMQ features to [connect](connections.html) to it. Every connection has
-an associated user which is authenticated. It also targets a [virtual host](/vhosts.html) for which
+an associated user which is authenticated. It also targets a [virtual host](./vhosts.html) for which
 the user must have a certain set of permissions.
 
-User credentials, target virtual host and (optionally) client [certificate](/ssl.html) are specified at connection
+User credentials, target virtual host and (optionally) client [certificate](./ssl.html) are specified at connection
 initiation time.
 
 There is a default pair of credentials called the [default user](#default-state). This user can only
 be [used for **host-local connections**](#loopback-users) by default. Remote connections that use
 it will be refused.
 
-[Production environments](/production-checklist.html) should not use the default user and create
+[Production environments](./production-checklist.html) should not use the default user and create
 new user accounts with generated credentials instead.
 
 
@@ -79,7 +79,7 @@ When the server first starts running, and detects that its
 database is uninitialised or has been deleted, it
 initialises a fresh database with the following resources:
 
- * a [virtual host](/vhosts.html) named <code>/</code> (a slash)
+ * a [virtual host](./vhosts.html) named <code>/</code> (a slash)
  * a user named <code>guest</code> with a default password of <code>guest</code>, granted full access to the <code>/</code> virtual host
 
 It is advisable to [pre-configure a new user with a generated username and password](#seeding) or [delete](rabbitmqctl.8.html#delete_user)
@@ -92,13 +92,13 @@ to reasonably secure generated value that won't be known to the public.
 After an application connects to RabbitMQ and before it can perform operations, it must
 authenticate, that is, present and prove its identity. With that identity, RabbitMQ nodes can
 look up its permissions and [authorize](#authorisation) access to resources
-such as [virtual hosts](/vhosts.html), queues, exchanges, and so on.
+such as [virtual hosts](./vhosts.html), queues, exchanges, and so on.
 
-Two primary ways of authenticating a client are [username/password pairs](/passwords.html)
+Two primary ways of authenticating a client are [username/password pairs](./passwords.html)
 and [X.509 certificates](https://en.wikipedia.org/wiki/X.509). Username/password pairs
 can be used with a variety of [authentication backends](#backends) that verify the credentials.
 
-Connections that fail to authenticate will be closed with an error message in the [server log](/logging.html).
+Connections that fail to authenticate will be closed with an error message in the [server log](./logging.html).
 
 ### <a id="certificate-authentication" class="anchor" href="#certificate-authentication">Authentication using Client TLS (x.509) Certificate Data</a>
 
@@ -119,7 +119,7 @@ Any other users will not (by default) be restricted in this way.
 The recommended way to address this in production systems
 is to create a new user or set of users with the permissions
 to access the necessary virtual hosts. This can be done
-using [CLI tools](/cli.html), [HTTP API or definitions import](/management.html).
+using [CLI tools](./cli.html), [HTTP API or definitions import](./management.html).
 
 This is configured via the <code>loopback_users</code> item
 in the [configuration file](configure.html#configuration-files).
@@ -144,7 +144,7 @@ loopback_users = none
 
 ## <a id="user-management" class="anchor" href="#user-management">Managing Users and Permissions</a>
 
-Users and permissions can be managed using [CLI tools](/cli.html) and definition import (covered below).
+Users and permissions can be managed using [CLI tools](./cli.html) and definition import (covered below).
 
 ### <a id="passwords-and-shell-escaping" class="anchor" href="#passwords-and-shell-escaping">Before We Start: Shell Escaping and Generated Passwords</a>
 
@@ -165,13 +165,13 @@ When generating passwords that will be passed on the command line,
 long (say, 40 to 100 characters) alphanumeric value with a very limited set of
 symbols (e.g. `:`, `=`) is the safest option.
 
-When users are created via [HTTP API](/management.html) without using a shell (e.g. `curl`),
+When users are created via [HTTP API](./management.html) without using a shell (e.g. `curl`),
 the control character limitation does not apply. However, different escaping rules may be necessary
 depending on the programming language used.
 
 ### Adding a User
 
-To add a user, use `rabbitmqctl add_user`. It has multiple ways of specifying a [password](/passwords.html):
+To add a user, use `rabbitmqctl add_user`. It has multiple ways of specifying a [password](./passwords.html):
 
 <pre class="lang-bash">
 # will prompt for password, only use this option interactively
@@ -235,7 +235,7 @@ rabbitmqctl.bat delete_user 'username'
 
 ### Granting Permissions to a User
 
-To grant [permissions](#authorisation) to a user in a [virtual host](/vhosts.html), use `rabbitmqctl set_permissions`:
+To grant [permissions](#authorisation) to a user in a [virtual host](./vhosts.html), use `rabbitmqctl set_permissions`:
 
 <pre class="lang-bash">
 # First ".*" for configure permission on every entity
@@ -253,7 +253,7 @@ rabbitmqctl.bat set_permissions -p 'custom-vhost' 'username' '.*' '.*' '.*'
 
 ### Clearing Permissions of a User in a Virtual Host
 
-To revoke [permissions](#authorisation) from a user in a [virtual host](/vhosts.html), use `rabbitmqctl clear_permissions`:
+To revoke [permissions](#authorisation) from a user in a [virtual host](./vhosts.html), use `rabbitmqctl clear_permissions`:
 
 <pre class="lang-bash">
 # Revokes permissions in a virtual host
@@ -279,13 +279,13 @@ for v in $(rabbitmqctl list_vhosts --silent); do rabbitmqctl set_permissions -p 
 
 ## <a id="seeding" class="anchor" href="#seeding">Seeding (Pre-creating) Users and Permissions</a>
 
-[Production environments](/production-checklist.html) typically need to pre-configure (seed) a number
+[Production environments](./production-checklist.html) typically need to pre-configure (seed) a number
 of virtual hosts, users and user permissions.
 
 This can be done in a few ways:
 
- * Using [CLI tools](/cli.html)
- * [Definition export and import on node boot](/definitions.html) (recommended)
+ * Using [CLI tools](./cli.html)
+ * [Definition export and import on node boot](./definitions.html) (recommended)
  * Override [default credentials](#default-state) in configuration file(s)
 
 ### CLI Tools
@@ -301,11 +301,11 @@ This process involves the following steps:
  * Remove parts of the file that are not relevant
  * Configure the node to import the file on node boot or after
 
-See [importing definitions on node boot](/definitions.html#import-on-boot) in the definitions guide to learn more.
+See [importing definitions on node boot](./definitions.html#import-on-boot) in the definitions guide to learn more.
 
 ### Definition Import After Node Boot
 
-See [importing definitions after node boot](/definitions.html#import) in the definitions guide.
+See [importing definitions after node boot](./definitions.html#import) in the definitions guide.
 
 ### Override Default User Credentials
 
@@ -323,12 +323,12 @@ default_user = a-user
 default_pass = 768a852ed69ce916fa7faa278c962de3e4275e5f
 </pre>
 
-As with all values in [`rabbitmq.conf`](/configure.html#config-file), the `#` character
+As with all values in [`rabbitmq.conf`](./configure.html#config-file), the `#` character
 starts a comment so this character must be avoided in generated credentials.
 
 Default user credentials can also be encrypted.
-That requires the use of the [advanced configuration file](/configure.html#advanced-config-file), `advanced.config`.
-This topic is covered in more detail in [Configuration Value Encryption](/configure.html#configuration-encryption).
+That requires the use of the [advanced configuration file](./configure.html#advanced-config-file), `advanced.config`.
+This topic is covered in more detail in [Configuration Value Encryption](./configure.html#configuration-encryption).
 
 
 ## <a id="authorisation" class="anchor" href="#authorisation">Authorisation: How Permissions Work</a>
@@ -454,10 +454,10 @@ as well as the [rabbitmqctl man page](rabbitmqctl.8.html).
 In addition to the permissions covered above, users can have tags
 associated with them. Currently only management UI access is  controlled by user tags.
 
-The tags are managed using [rabbitmqctl](/rabbitmqctl.8.html#set_user_tags).
+The tags are managed using [rabbitmqctl](./rabbitmqctl.8.html#set_user_tags).
 Newly created users do not have any tags set on them by default.
 
-Please refer to the [management plugin guide](/management.html#permissions) to learn
+Please refer to the [management plugin guide](./management.html#permissions) to learn
 more about what tags are supported and how they limit management UI access.
 
 
@@ -578,14 +578,14 @@ The example above uses an alias, <code>internal</code> for <code>rabbit_auth_bac
 The following aliases are available:
 
  * <code>internal</code> for <code>rabbit_auth_backend_internal</code>
- * <code>ldap</code> for <code>rabbit_auth_backend_ldap</code> (from the [LDAP plugin](/ldap.html))
+ * <code>ldap</code> for <code>rabbit_auth_backend_ldap</code> (from the [LDAP plugin](./ldap.html))
  * <code>http</code> for <code>rabbit_auth_backend_http</code> (from the [HTTP auth backend plugin](https://github.com/rabbitmq/rabbitmq-auth-backend-http))
  * <code>amqp</code> for <code>rabbit_auth_backend_amqp</code> (from the [AMQP 0-9-1 auth backend plugin](https://github.com/rabbitmq/rabbitmq-auth-backend-amqp))
  * <code>dummy</code> for <code>rabbit_auth_backend_dummy</code>
 
 When using third party plugins, providing a full module name is necessary.
 
-The following example configures RabbitMQ to use the [LDAP backend](/ldap.html)
+The following example configures RabbitMQ to use the [LDAP backend](./ldap.html)
 for both authentication and authorisation. Internal database will not be consulted:
 
 <pre class="lang-ini">
@@ -628,7 +628,7 @@ auth_backends.1.authn = internal
 auth_backends.1.authz = rabbit_auth_backend_ip_range
 </pre>
 
-The following example configures RabbitMQ to use the [LDAP backend](/ldap.html)
+The following example configures RabbitMQ to use the [LDAP backend](./ldap.html)
 for authentication and the internal backend for authorisation:
 
 <pre class="lang-ini">
@@ -767,7 +767,7 @@ preference order for network connections.
 
 ## <a id="troubleshooting-authn" class="anchor" href="#troubleshooting-authn">Troubleshooting Authentication</a>
 
-[Server logs](/logging.html) will contain entries about failed authentication
+[Server logs](./logging.html) will contain entries about failed authentication
 attempts:
 
 <pre class="lang-ini">
@@ -778,9 +778,9 @@ PLAIN login refused: user 'user2' - invalid credentials
 </pre>
 
 Authentication failures on connections that [authenticate using X.509 certificates](#authentication)
-will be logged differently. See [TLS Troubleshooting guide](/troubleshooting-ssl.html) for details.
+will be logged differently. See [TLS Troubleshooting guide](./troubleshooting-ssl.html) for details.
 
-[rabbitmqctl authenticate_user](/cli.html) can be used to test authentication
+[rabbitmqctl authenticate_user](./cli.html) can be used to test authentication
 for a username and password pair:
 
 <pre class="lang-bash">
@@ -792,13 +792,13 @@ the code of zero. In case of a failure, a non-zero exit code will be used and a 
 
 <code>rabbitmqctl authenticate_user</code> will use a CLI-to-node communication connection to attempt to authenticate
 the username/password pair against an internal API endpoint.
-The connection is assumed to be trusted. If that's not the case, its traffic can be [encrypted using TLS](/clustering-ssl.html).
+The connection is assumed to be trusted. If that's not the case, its traffic can be [encrypted using TLS](./clustering-ssl.html).
 
 Per AMQP 0-9-1 spec, authentication failures should result
 in the server closing TCP connection immediately. However,
 with RabbitMQ clients can opt in to receive a more specific
 notification using the [authentication failure
-notification](/auth-notification.html) extension to AMQP 0-9-1. Modern client libraries
+notification](./auth-notification.html) extension to AMQP 0-9-1. Modern client libraries
 support that extension transparently to the user: no configuration would be necessary and
 authentication failures will result in a visible returned error, exception or other way of communicating
 a problem used in a particular programming language or environment.
@@ -806,7 +806,7 @@ a problem used in a particular programming language or environment.
 
 ## <a id="troubleshooting-authz" class="anchor" href="#troubleshooting-authz">Troubleshooting Authorisation</a>
 
-[rabbitmqctl list_permissions](/cli.html) can be used to inspect a user's
+[rabbitmqctl list_permissions](./cli.html) can be used to inspect a user's
 permission in a given virtual host:
 
 <pre class="lang-bash">
@@ -824,7 +824,7 @@ rabbitmqctl list_permissions --vhost gw1
 # =&gt; user2	^user2	^user2	^user2
 </pre>
 
-[Server logs](/logging.html) will contain entries about operation authorisation
+[Server logs](./logging.html) will contain entries about operation authorisation
 failures. For example, if a user does not have any permissions configured for a virtual host:
 
 <pre class="lang-ini">

--- a/site/admin-guide.md
+++ b/site/admin-guide.md
@@ -23,7 +23,7 @@ start the server, [enable]() the necessary plugins and it's ready to go.
 
 This guide provides a table of contents of documentation oriented at RabbitMQ operators.
 For a complete documentation ToC that includes developer-oriented guides,
-see <a href="/documentation.html">All Documentation Guides</a>.
+see <a href="./documentation.html">All Documentation Guides</a>.
 
 ## [Installation and Provisioning](download.html):
 

--- a/site/amqp-0-9-1-quickref.xml
+++ b/site/amqp-0-9-1-quickref.xml
@@ -18,7 +18,7 @@ limitations under the License.
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:x="https://www.rabbitmq.com/2011/extensions">
   <head>
     <title>AMQP 0-9-1 Quick Reference</title>
-    <link rel="stylesheet" rev="stylesheet" href="/css/amqp-0-9-1-quickref.css" type="text/css"/>
+    <link rel="stylesheet" rev="stylesheet" href="./css/amqp-0-9-1-quickref.css" type="text/css"/>
   </head>
   <body>
     <x:insert-spec-here />

--- a/site/amqp-0-9-1-quickref.xsl
+++ b/site/amqp-0-9-1-quickref.xsl
@@ -48,7 +48,7 @@ limitations under the License.
         specification downloads can be found on the <a href="protocol.html">protocol page</a>.
       </p>
       <p>
-        A brief <a href="/tutorials/amqp-concepts.html">AMQP 0-9-1 overview</a> is also available.
+        A brief <a href="./tutorials/amqp-concepts.html">AMQP 0-9-1 overview</a> is also available.
       </p>
       <p>
         For your convenience, links are provided from this guide to the relevant sections of the API guides

--- a/site/amqp-0-9-1-reference.xml
+++ b/site/amqp-0-9-1-reference.xml
@@ -18,7 +18,7 @@ limitations under the License.
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:x="https://www.rabbitmq.com/2011/extensions">
   <head>
     <title>AMQP 0-9-1 Complete Reference Guide</title>
-    <link rel="stylesheet" rev="stylesheet" href="/css/amqp-0-9-1-reference.css" type="text/css"/>
+    <link rel="stylesheet" rev="stylesheet" href="./css/amqp-0-9-1-reference.css" type="text/css"/>
   </head>
   <body>
     <x:insert-spec-here />

--- a/site/amqp-wireshark.md
+++ b/site/amqp-wireshark.md
@@ -30,7 +30,7 @@ Wireshark is based on the same foundation as [tcpdump](https://www.tcpdump.org/)
 
 Together, tcpdump and Wireshark provide a lot of information explaining what clients (applications) and RabbitMQ nodes
 do. This information can and should be used to derive insights into system behavior that is difficult
-to observe otherwise. These tools complement [monitoring systems](/monitoring.html) and allow operators and developers
+to observe otherwise. These tools complement [monitoring systems](./monitoring.html) and allow operators and developers
 troubleshoot a distributed system more efficiently.
 
 
@@ -55,7 +55,7 @@ Packet Details then indicate all arguments of the frame. It
 also includes dynamically calculated values enclosed in square
 brackets. This is explained in next section.
 
-<img src="img/wireshark-main-window.png" alt="Main window" title="Main window" />
+<img src="./img/wireshark-main-window.png" alt="Main window" title="Main window" />
 
 
 ## <a id="linking" class="anchor" href="#linking">Links Between Related Frames</a>
@@ -76,13 +76,13 @@ Wireshark automatically highlights AMQP 0-9-1 packets with:
 
  * [Connection errors](connections.html) (server-sent `connection.close` frames) and [channel errors](channels.html)
    (server-sent `channel.close` frames)
- * [Returned unroutable](/publishers.html) messages (`basic.return` frames)
+ * [Returned unroutable](./publishers.html) messages (`basic.return` frames)
 
 You may display summary of significant frames in a dedicated
 dialog. Go to Analyze > Expert Information and possibly apply
 the display filter:
 
-<img src="img/wireshark-expert-info.png" alt="More Metrics" title="Metrics" />
+<img src="./img/wireshark-expert-info.png" alt="More Metrics" title="Metrics" />
 
 ## <a id="inspecting-tls-connections" class="anchor" href="#inspecting-tls-connections">Inspecting Traffic on TLS-enabled Connections</a>
 

--- a/site/api-guide.md
+++ b/site/api-guide.md
@@ -161,7 +161,7 @@ remains unassigned prior to creating a connection:
 
     <td>
       <code>5672</code> for regular connections,
-      <code>5671</code> for <a href="/ssl.html">connections that use TLS</a>
+      <code>5671</code> for <a href="./ssl.html">connections that use TLS</a>
     </td>
   </tr>
 </table>

--- a/site/api-guide.md
+++ b/site/api-guide.md
@@ -19,9 +19,9 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers [RabbitMQ Java client](/java-client.html) and its public API.
+This guide covers [RabbitMQ Java client](./java-client.html) and its public API.
 It assumes that the [most recent major version of the client](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22amqp-client%22) is used
-and the reader is familiar with [the basics](/getstarted.html).
+and the reader is familiar with [the basics](./getstarted.html).
 
 Key sections of the guide are:
 
@@ -48,14 +48,14 @@ An [API reference](https://rabbitmq.github.io/rabbitmq-java-client/api/current/)
 
 ## <a id="support-timeline" class="anchor" href="#support-timeline">Support Timeline</a>
 
-Please see the [RabbitMQ Java libraries support page](/java-versions.html) for the support timeline.
+Please see the [RabbitMQ Java libraries support page](./java-versions.html) for the support timeline.
 
 ## <a id="jdk-versions" class="anchor" href="#jdk-versions">JDK and Android Version Support</a>
 
-5.x release series of this library [require JDK 8](/java-versions.html), both for compilation and at runtime. On Android,
+5.x release series of this library [require JDK 8](./java-versions.html), both for compilation and at runtime. On Android,
 this means only [Android 7.0 or later](https://developer.android.com/guide/platform/j8-jack.html) versions are supported.
 
-4.x release series [support JDK 6](/java-versions.html) and Android versions prior to 7.0.
+4.x release series [support JDK 6](./java-versions.html) and Android versions prior to 7.0.
 
 
 ## <a id="license" class="anchor" href="#license">License</a>
@@ -73,7 +73,7 @@ a commercial product. Codebases that are licensed under the GPLv2 may choose GPL
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-The client API exposes key entities in the [AMQP 0-9-1 protocol model](/tutorials/amqp-concepts.html),
+The client API exposes key entities in the [AMQP 0-9-1 protocol model](./tutorials/amqp-concepts.html),
 with additional abstractions for ease of use.
 
 RabbitMQ Java client uses `com.rabbitmq.client` as its top-level package.
@@ -179,13 +179,13 @@ Connection conn = factory.newConnection();
 All of these parameters have sensible defaults for a stock
 RabbitMQ server running locally.
 
-Successful and unsuccessful client connection events can be [observed in server node logs](/logging.html).
+Successful and unsuccessful client connection events can be [observed in server node logs](./logging.html).
 
-Note that [user guest can only connect from localhost](/access-control.html) by default.
+Note that [user guest can only connect from localhost](./access-control.html) by default.
 This is to limit well-known credential use in production systems.
 
 Application developers can [assign a custom name to a connection](#client-provided-names). If set,
-the name will be mentioned in RabbitMQ node logs as well as [management UI](/management.html).
+the name will be mentioned in RabbitMQ node logs as well as [management UI](./management.html).
 
 The `Connection` interface can then be used to open a channel:
 
@@ -237,7 +237,7 @@ conn.close();
 Note that closing the channel may be considered good practice, but is not strictly necessary here - it will be done
 automatically anyway when the underlying connection is closed.
 
-Client disconnection events can be [observed in server node logs](/networking.html#logging).
+Client disconnection events can be [observed in server node logs](./networking.html#logging).
 
 ## <a id="connection-and-channel-lifespan" class="anchor" href="#connection-and-channel-lifespan">Connection and Channel Lifespan</a>
 
@@ -251,7 +251,7 @@ result in channel closure, channel lifespan could be shorter than that of its co
 Closing and opening new channels per operation is usually unnecessary but can be
 appropriate. When in doubt, consider reusing channels first.
 
-[Channel-level exceptions](/channels.html#error-handling) such as attempts to consume from a
+[Channel-level exceptions](./channels.html#error-handling) such as attempts to consume from a
 queue that does not exist will result in channel closure. A closed channel can no
 longer be used and will not receive any more events from the server (such
 as message deliveries). Channel-level exceptions will be logged by RabbitMQ
@@ -265,9 +265,9 @@ RabbitMQ nodes have a limited amount of information about their clients:
  * the credentials used
 
 This information alone can make identifying applications and instances problematic, in particular when credentials can be
-shared and clients connect over a load balancer but [Proxy protocol](/networking.html#proxy-protocol) cannot be enabled.
+shared and clients connect over a load balancer but [Proxy protocol](./networking.html#proxy-protocol) cannot be enabled.
 
-To make it easier to identify clients in [server logs](/logging.html) and [management UI](/management.html),
+To make it easier to identify clients in [server logs](./logging.html) and [management UI](./management.html),
 AMQP 0-9-1 client connections, including the RabbitMQ Java client, can provide a custom identifier.
 If set, the identifier will be mentioned in log entries and management UI. The identifier is known as
 the **client-provided connection name**. The name can be used to identify an application or a specific component
@@ -289,11 +289,11 @@ Connection conn = factory.newConnection("app:audit component:event-consumer");
 ## <a id="exchanges-and-queues" class="anchor" href="#exchanges-and-queues">Using Exchanges and Queues</a>
 
 Client applications work with [exchanges] and [queues](queues.html),
-the high-level [building blocks of the protocol](/tutorials/amqp-concepts.html).
+the high-level [building blocks of the protocol](./tutorials/amqp-concepts.html).
 These must be declared before they can be used. Declaring either type of object
 simply ensures that one of that name exists, creating it if necessary.
 
-Continuing the previous example, the following code declares an exchange and a [server-named queue](/queues.html#server-named-queues),
+Continuing the previous example, the following code declares an exchange and a [server-named queue](./queues.html#server-named-queues),
 then binds them together.
 
 <pre class="lang-java">channel.exchangeDeclare(exchangeName, "direct", true);
@@ -337,7 +337,7 @@ This "short form, long form" pattern is used throughout the client API uses.
 Queues and exchanges can be declared "passively". A passive declare simply checks that the entity
 with the provided name exists. If it does, the operation is a no-op. For queues successful
 passive declares will return the same information as non-passive ones, namely the number of
-consumers and messages in [ready state](/confirms.html) in the queue.
+consumers and messages in [ready state](./confirms.html) in the queue.
 
 If the entity does not exist, the operation fails with a channel level exception. The channel
 cannot be used after that. A new channel should be opened. It is common to use one-off (temporary)
@@ -366,7 +366,7 @@ response, use
 <pre class="lang-java">channel.queueDeclareNoWait(queueName, true, false, false, null);</pre>
 
 The "no wait" versions are more efficient but offer lower safety guarantees, e.g. they
-are more dependent on the [heartbeat mechanism](/heartbeats.html) for detection of failed operations.
+are more dependent on the [heartbeat mechanism](./heartbeats.html) for detection of failed operations.
 When in doubt, start with the standard version. The "no wait" versions are only needed in scenarios
 with high topology (queue, binding) churn.
 
@@ -399,7 +399,7 @@ channel.basicPublish(exchangeName, routingKey, null, messageBodyBytes);
 </pre>
 
 For fine control, use overloaded variants to specify the `mandatory` flag,
-or send messages with pre-set message properties (see the [Publishers guide](/publishers.html) for details):
+or send messages with pre-set message properties (see the [Publishers guide](./publishers.html) for details):
 
 <pre class="lang-java">
 channel.basicPublish(exchangeName, routingKey, mandatory,
@@ -644,7 +644,7 @@ if (response == null) {
     // ...
 </pre>
 
-and since this example uses [manual acknowledgements](/confirms.html) (the `autoAck = false` above),
+and since this example uses [manual acknowledgements](./confirms.html) (the `autoAck = false` above),
 you must also call `Channel.basicAck` to acknowledge that you have successfully received the message:
 
 <pre class="lang-java">
@@ -1047,7 +1047,7 @@ Automatic connection recovery, if enabled, will be triggered by the following ev
 
  * An I/O exception is thrown in connection's I/O loop
  * A socket read operation times out
- * Missed server [heartbeats](/heartbeats.html) are detected
+ * Missed server [heartbeats](./heartbeats.html) are detected
  * Any other unexpected exception is thrown in connection's I/O loop
 
 whichever happens first.
@@ -1127,14 +1127,14 @@ it will be removed. This makes it possible to declare and delete entities on dif
 channels without having unexpected results. It also means that consumer tags (a channel-specific identifier)
 must be unique across all channels on connections that use automatic connection recovery.
 
-When a connection is down or lost, it [takes time to detect](/heartbeats.html).
+When a connection is down or lost, it [takes time to detect](./heartbeats.html).
 Therefore there is a window of time in which both the
 library and the application are unaware of effective
 connection failure.  Any messages published during this
 time frame are serialised and written to the TCP socket
 as usual. Their delivery to the broker can only be
 guaranteed via [publisher
-confirms](/confirms.html): publishing in AMQP 0-9-1 is entirely
+confirms](./confirms.html): publishing in AMQP 0-9-1 is entirely
 asynchronous by design.
 
 When a socket or I/O operation error is detected by a
@@ -1160,7 +1160,7 @@ with an exception. The client currently does not perform
 any internal buffering of such outgoing messages. It is
 an application developer's responsibility to keep track of such
 messages and republish them when recovery succeeds.
-[Publisher confirms](/confirms.html) is a protocol extension
+[Publisher confirms](./confirms.html) is a protocol extension
 that should be used by publishers that cannot afford message loss.
 
 Connection recovery will not kick in when a channel is closed due to a
@@ -1377,7 +1377,7 @@ being idempotent in RabbitMQ 3.3.x (deleting what's not there does not result in
 
 As a programming convenience, the Java client API offers a
 class `RpcClient` which uses a temporary reply
-queue to provide simple [RPC-style communication](/tutorials/tutorial-six-java.html) facilities via AMQP 0-9-1.
+queue to provide simple [RPC-style communication](./tutorials/tutorial-six-java.html) facilities via AMQP 0-9-1.
 
 The class doesn't impose any particular format on the RPC arguments and return values.
 It simply provides a mechanism for sending a message to a given exchange with a particular
@@ -1420,7 +1420,7 @@ transport mechanism, and just provide a wrapping layer on top of it.
 ## <a id="tls" class="anchor" href="#tls">TLS Support</a>
 
 It's possible to encrypt the communication between the client and the broker
-[using TLS](/ssl.html). Client and server authentication (a.k.a. peer verification) is also supported.
+[using TLS](./ssl.html). Client and server authentication (a.k.a. peer verification) is also supported.
 Here is the simplest, most naive way to use encryption with the Java client:
 
 <pre class="lang-java">
@@ -1435,10 +1435,10 @@ factory.setPort(5671);
 factory.useSslProtocol();
 </pre>
 
-Note the client doesn't enforce any server authentication ([peer certificate chain verification](/ssl.html#peer-verification)) in the above
+Note the client doesn't enforce any server authentication ([peer certificate chain verification](./ssl.html#peer-verification)) in the above
 sample as the default, "trust all certificates" `TrustManager` is used.
 This is convenient for local development but **prone to man-in-the-middle attacks**
-and therefore [not recommended for production](/production-checklist.html).
+and therefore [not recommended for production](./production-checklist.html).
 
 To learn more about TLS support in RabbitMQ, see
 the [TLS guide](ssl.html). If you only want to configure

--- a/site/auth-notification.md
+++ b/site/auth-notification.md
@@ -36,5 +36,5 @@ If this capability is absent then authentication failures are reported
 in the legacy fashion: by abruptly closing the network connection. If this
 capability is present then the broker will send a <code>connection.close</code>
 command to the client indicating <code>ACCESS_REFUSED</code> as the reason. The broker
-will [create a log entry](/logging.html#connection-lifecycle-events)
+will [create a log entry](./logging.html#connection-lifecycle-events)
 for the authentication failure in either case.

--- a/site/backup.md
+++ b/site/backup.md
@@ -18,7 +18,7 @@ message store data.
 Nodes and clusters store information that can be thought of schema, metadata or topology.
 Users, vhosts, queues, exchanges, bindings, runtime parameters all fall into this category.
 
-Definitions can be [exported and imported](/definitions.html) as JSON files.
+Definitions can be [exported and imported](./definitions.html) as JSON files.
 
 Definitions are stored in an internal database and replicated across all cluster nodes.
 Every node in a cluster has its own replica of all definitions. When a part of definitions changes,
@@ -53,11 +53,11 @@ Definitions can be exported to a JSON file. This is the recommended way of backi
 
 ### <a id="definitions-export" class="anchor" href="#definitions-export">Exporting Definitions</a>
 
-Definition export is covered in the dedicated [Definitions guide](/definitions.html#export).
+Definition export is covered in the dedicated [Definitions guide](./definitions.html#export).
 
 ### <a id="definitions-import" class="anchor" href="#definitions-import">Importing Definitions</a>
 
-Definition import is covered in the dedicated [Definitions guide](/definitions.html#import).
+Definition import is covered in the dedicated [Definitions guide](./definitions.html#import).
 
 Importing a definitions file is sufficient for creating a broker with
 an identical set of definitions (e.g. users, vhosts, permissions,
@@ -73,7 +73,7 @@ command against a running RabbitMQ node:
 rabbitmqctl eval 'rabbit_mnesia:dir().'
 </pre>
 
-If the node isn't running, it is possible to inspect [default data directories](/relocate.html).
+If the node isn't running, it is possible to inspect [default data directories](./relocate.html).
 
 * For Debian and RPM packages: `/var/lib/rabbitmq/mnesia`
 * For Windows: `%APP_DATA%\RabbitMQ\db`
@@ -85,7 +85,7 @@ copy the messages, skip copying the [message directories](#manual-messages-backu
 ### <a id="manual-definitions-restore" class="anchor" href="#manual-definitions-restore">Restoring from a Manual Definitions Backup</a>
 
 Internal node database stores node's name in certain records. Should node name change, the database must first
-be updated to reflect the change using the following [rabbitmqctl](/cli.html) command:
+be updated to reflect the change using the following [rabbitmqctl](./cli.html) command:
 
 <pre class="lang-sh">
 rabbitmqctl rename_cluster_node &lt;oldnode&gt; &lt;newnode&gt;
@@ -102,7 +102,7 @@ the upgrade steps as needed and proceed booting.
 
 To back up messages on a node it **must be first stopped**.
 
-In the case of a cluster with [mirrored queues](/ha.html), you need to
+In the case of a cluster with [mirrored queues](./ha.html), you need to
 stop the entire cluster to take a backup. If you stop one node at a
 time, you may lose messages or have duplicates, exactly like when you
 back up a single running node.
@@ -111,7 +111,7 @@ back up a single running node.
 
 Presently this is the only way of backing up messages.
 
-Message data is stored in the [node's data directory](/relocate.html) mentioned above.
+Message data is stored in the [node's data directory](./relocate.html) mentioned above.
 
 In RabbitMQ versions starting with 3.7.0 all messages data is combined in the
 `msg_stores/vhosts` directory and stored in a subdirectory per vhost.

--- a/site/blue-green-upgrade.md
+++ b/site/blue-green-upgrade.md
@@ -26,7 +26,7 @@ The "blue" is the source cluster and the "green" one is the target.
 
 [RabbitMQ Federation plugin](federation.html) makes it easy to move consumers
 from "blue" to "green", without disrupting message consumption or losing messages.
-The principle of [federated queues](/federated-queues.html) is that the consumers
+The principle of [federated queues](./federated-queues.html) is that the consumers
 now connected to "green" will get messages published to "blue" as long as there are
 no consumers in "blue" (local consumers take precedence).
 
@@ -48,7 +48,7 @@ rabbitmqctl set_policy --apply-to queues blue-green-migration ".*" \
 </pre>
 
 Please read the guides linked above and the
-[federation reference](/federation-reference.html) for further details.
+[federation reference](./federation-reference.html) for further details.
 
 ## <a id="migrate-consumers" class="anchor" href="#migrate-consumers">Migrate Consumers Over</a>
 
@@ -67,7 +67,7 @@ still have a backlog of messages in "blue". The federation plugin doesn't help
 here because it doesn't **move** messages, it only allows remote consumers to
 dequeue messages.
 
-In case of a large backlog, use the [Shovel plugin](/shovel-dynamic.html)
+In case of a large backlog, use the [Shovel plugin](./shovel-dynamic.html)
 on "green" to really drain messages in "blue". This would require doing something
 like the following for each queue with a backlog:
 

--- a/site/build-erlang-client.md
+++ b/site/build-erlang-client.md
@@ -36,7 +36,7 @@ Additionally, you will need
 * The [Erlang](https://www.erlang.org/downloads)
   development and runtime tools. On a Debian-based
   system then you need the `erlang-nox`, `erlang-dev` and
-  `erlang-src` packages installed. See [Erlang Version Requirements guide](/which-erlang.html) to learn
+  `erlang-src` packages installed. See [Erlang Version Requirements guide](./which-erlang.html) to learn
   about the recommended ways of provisioning a recent supported version of Erlang.
  * A recent version of [Elixir](https://elixir-lang.org/)
  * a recent version of [GNU make](http://www.gnu.org/software/make/)

--- a/site/build-server.md
+++ b/site/build-server.md
@@ -56,17 +56,17 @@ core since 2.6 release.
 ### Erlang/OTP Toolchain and Headers
 
 The [Erlang](http://www.erlang.org/download.html) development and runtime tools
-are needed to compile RabbitMQ server, tools and [tier 1 plugins](/plugins.html).
+are needed to compile RabbitMQ server, tools and [tier 1 plugins](./plugins.html).
 
 On a Debian-based system, install the `erlang-nox`, `erlang-dev` and
 `erlang-src` packages.
 
-See [Erlang compatibility guide](/which-erlang.html) to learn more about supported versions of Erlang/OTP.
+See [Erlang compatibility guide](./which-erlang.html) to learn more about supported versions of Erlang/OTP.
 
 ### Elixir
 
 A recent version of [Elixir](https://elixir-lang.org/) is needed
-to build [RabbitMQ CLI tools](/cli.html).
+to build [RabbitMQ CLI tools](./cli.html).
 
 ### GNU Make
 

--- a/site/build-server.md
+++ b/site/build-server.md
@@ -132,7 +132,7 @@ make run-broker TEST_TMPDIR="/some/other/location/for/rabbitmq-test-instances"
 make run-broker RABBITMQ_NODENAME=rmq
 </pre>
 
-        See <a href="/configure.html">Configuration guide</a> for other
+        See <a href="./configure.html">Configuration guide</a> for other
         variables that may be useful.
       </td>
     </tr>

--- a/site/build.md
+++ b/site/build.md
@@ -24,7 +24,7 @@ of the RabbitMQ server and available client libraries:
 
 ## RabbitMQ Server
 
- * [RabbitMQ server](/build-server.html)
- * [Java client library](/build-java-client.html)
- * [.NET client library](/build-dotnet-client.html)
- * [Erlang client library](/build-erlang-client.html)
+ * [RabbitMQ server](./build-server.html)
+ * [Java client library](./build-java-client.html)
+ * [.NET client library](./build-dotnet-client.html)
+ * [Erlang client library](./build-erlang-client.html)

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -22,7 +22,7 @@ limitations under the License.
 RabbitMQ release notes are [available on GitHub](https://github.com/rabbitmq/rabbitmq-server/releases).
 See <a href="/versions.html">RabbitMQ support timeline</a> to find out what release series
 are supported.
-For guidance on upgrades, see the [Upgrade](/upgrade.html) and [Blue/Green Deployment Upgrade](/blue-green-upgrade.html) guides.
+For guidance on upgrades, see the [Upgrade](./upgrade.html) and [Blue/Green Deployment Upgrade](./blue-green-upgrade.html) guides.
 
 [Java client release notes](https://github.com/rabbitmq/rabbitmq-java-client/releases)
 and [.NET client release notes](https://github.com/rabbitmq/rabbitmq-dotnet-client/releases) are

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -20,7 +20,7 @@ limitations under the License.
 ## Overview
 
 RabbitMQ release notes are [available on GitHub](https://github.com/rabbitmq/rabbitmq-server/releases).
-See <a href="/versions.html">RabbitMQ support timeline</a> to find out what release series
+See <a href="./versions.html">RabbitMQ support timeline</a> to find out what release series
 are supported.
 For guidance on upgrades, see the [Upgrade](./upgrade.html) and [Blue/Green Deployment Upgrade](./blue-green-upgrade.html) guides.
 
@@ -429,7 +429,7 @@ published separately.
     <td class="centre">2 March 2021</td>
     <td>
       <ul>
-        <li>Restores Erlang 22.3 compatibility for <a href="/direct-reply-to.html">direct reply-to</a></li>
+        <li>Restores Erlang 22.3 compatibility for <a href="./direct-reply-to.html">direct reply-to</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.14">Release notes</a></td>
@@ -526,7 +526,7 @@ published separately.
     <td>
       <ul>
         <li>Security vulnerability patch (<a href="https://tanzu.vmware.com/security/cve-2020-5419">CVE-2020-5419</a>)</li>
-        <li>3.7.x release series <a href="/versions.html">has reached end of life</a></li>
+        <li>3.7.x release series <a href="./versions.html">has reached end of life</a></li>
       </ul>
     </td>
     <td class="centre">
@@ -553,7 +553,7 @@ published separately.
       <ul>
         <li>Bug Fixes</li>
         <li>Backports from 3.8.x series</li>
-        <li>3.7.x is out of general support and only <a href="/versions.html">covered under the extended support policy</a></li>
+        <li>3.7.x is out of general support and only <a href="./versions.html">covered under the extended support policy</a></li>
       </ul>
     </td>
     <td class="centre">
@@ -593,7 +593,7 @@ published separately.
     <td>
       <ul>
         <li>Bug Fixes</li>
-        <li>3.7.x is out of general support and only <a href="/versions.html">covered under the extended support policy</a></li>
+        <li>3.7.x is out of general support and only <a href="./versions.html">covered under the extended support policy</a></li>
       </ul>
     </td>
     <td class="centre">
@@ -607,7 +607,7 @@ published separately.
     <td>
       <ul>
         <li>Bug Fixes</li>
-        <li>3.7.x is out of general support and only <a href="/versions.html">covered under the extended support policy</a></li>
+        <li>3.7.x is out of general support and only <a href="./versions.html">covered under the extended support policy</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.25">Release notes</a></td>
@@ -644,7 +644,7 @@ published separately.
     <td>
       <ul>
         <li>Optimizations</li>
-        <li>This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a></li>
+        <li>This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.23">Release notes</a></td>
@@ -669,7 +669,7 @@ published separately.
     <td>
       <ul>
         <li>Bug fixes</li>
-        <li>This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a></li>
+        <li>This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.22">Release notes</a></td>
@@ -693,7 +693,7 @@ published separately.
       <ul>
         <li>Security vulnerability (<a href="https://pivotal.io/security/cve-2019-11287">CVE-2019-11287</a>) fix</li>
         <li>Bug fixes</li>
-        <li>This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a></li>
+        <li>This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.21">Release notes</a></td>
@@ -705,7 +705,7 @@ published separately.
     <td>
       <ul>
         <li>Bug fixes</li>
-        <li>This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a></li>
+        <li>This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.20">Release notes</a></td>
@@ -717,7 +717,7 @@ published separately.
     <td>
       <ul>
         <li>Bug fixes</li>
-        <li>First <code>3.7.x</code> release to <a href="/which-erlang.html">require Erlang/OTP 21.3</a></li>
+        <li>First <code>3.7.x</code> release to <a href="./which-erlang.html">require Erlang/OTP 21.3</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.19">Release notes</a></td>
@@ -729,11 +729,11 @@ published separately.
     <td>
       <ul>
         <li><a href="which-erlang.html">Minimum required Erlang version</a> is now 21.3</li>
-        <li><a href="/quorum-queues.html">Quorum Queues</a></li>
-        <li><a href="/monitoring.html">Monitoring</a> improvements: built-in <a href="/prometheus.html">Prometheus support</a> with a set of Grafana dashboards</li>
-        <li><a href="/feature-flags.html">Feature flags</a> and support for mixed version clusters <a href="/upgrade.html">during upgrades</a></li>
-        <li>New diagnostics CLI tools, new <a href="/monitoring.html#health-checks">health checks</a></li>
-        <li><a href="/consumers.html#single-active-consumer">Single Active Consumer</a></li>
+        <li><a href="./quorum-queues.html">Quorum Queues</a></li>
+        <li><a href="./monitoring.html">Monitoring</a> improvements: built-in <a href="./prometheus.html">Prometheus support</a> with a set of Grafana dashboards</li>
+        <li><a href="./feature-flags.html">Feature flags</a> and support for mixed version clusters <a href="./upgrade.html">during upgrades</a></li>
+        <li>New diagnostics CLI tools, new <a href="./monitoring.html#health-checks">health checks</a></li>
+        <li><a href="./consumers.html#single-active-consumer">Single Active Consumer</a></li>
         <li>New <a href="https://github.com/rabbitmq/rabbitmq-auth-backend-oauth2">authentication and authorisation backend</a> that uses OAuth 2.0 (JWT) tokens and scopes</li>
       </ul>
     </td>
@@ -747,7 +747,7 @@ published separately.
       <ul>
         <li>Security vulnerability (<a href="https://pivotal.io/security/cve-2019-11281">CVE-2019-11281</a>) fix</li>
         <li>Bug fixes</li>
-        <li>Last release to <a href="/which-erlang.html">support Erlang/OTP 20.3</a></li>
+        <li>Last release to <a href="./which-erlang.html">support Erlang/OTP 20.3</a></li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.18">Release notes</a></td>
@@ -833,7 +833,7 @@ published separately.
       <ul>
         <li>Bug fixes</li>
         <li>Usability improvements</li>
-        <li><a href="/which-erlang.html">Minimum required Erlang version</a> is now 20.3</li>
+        <li><a href="./which-erlang.html">Minimum required Erlang version</a> is now 20.3</li>
       </ul>
     </td>
     <td class="centre"><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.11">Release notes</a></td>
@@ -1205,13 +1205,13 @@ published separately.
     <td class="centre">22 December 2015</td>
     <td>
       <ul>
-        <li><a href="/lazy-queues.html">Lazy Queues</a></li>
+        <li><a href="./lazy-queues.html">Lazy Queues</a></li>
         <li>Batch (mirror) synchronisation</li>
         <li>Pagination in management UI</li>
         <li><a href="https://www.rabbitmq.com/passwords.html">Password hashing</a> now uses SHA-256 by default:
         please <a href="https://www.rabbitmq.com/passwords.html">read the docs</a> before importing definitions from 3.5.x!</li>
-        <li><a href="/web-stomp.html">Web STOMP</a> revamp, with new "pure WebSocket" endpoint</li>
-        <li><a href="/plugin-development.html">New build system</a> based on <a href="https://github.com/ninenines/erlang.mk">erlang.mk</a></li>
+        <li><a href="./web-stomp.html">Web STOMP</a> revamp, with new "pure WebSocket" endpoint</li>
+        <li><a href="./plugin-development.html">New build system</a> based on <a href="https://github.com/ninenines/erlang.mk">erlang.mk</a></li>
         <li>Development <a href="https://github.com/rabbitmq/">moved entirely to GitHub</a></li>
       </ul>
     </td>
@@ -2098,6 +2098,6 @@ published separately.
         <li>Initial release</li>
       </ul>
     </td>
-    <td class="centre"><a href="/resources/RabbitMQ_PressRelease_080207.pdf">Release notes</a><br/>(pdf)</td>
+    <td class="centre"><a href="./resources/RabbitMQ_PressRelease_080207.pdf">Release notes</a><br/>(pdf)</td>
   </tr>
 </table>

--- a/site/channels.md
+++ b/site/channels.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers various topics related to channels, an [AMQP 0-9-1](/tutorials/amqp-concepts.html)-specific abstraction.
+This guide covers various topics related to channels, an [AMQP 0-9-1](./tutorials/amqp-concepts.html)-specific abstraction.
 Channels cannot exist without a connection, so getting familiar with the [Connections guide](connections.html) first
 is highly recommended.
 
@@ -136,18 +136,18 @@ Certain scenarios are assumed to be recoverable ("soft") errors in the protocol.
 the channel closed but applications can open another one and try to recover or retry a number of
 times. Most common examples are:
 
- * [Redeclaring an existing queue](/queues.html#property-equivalence) or exchange with non-matching properties
+ * [Redeclaring an existing queue](./queues.html#property-equivalence) or exchange with non-matching properties
    will fail with a `406 PRECONDITION_FAILED` error
- * [Accessing a resource](/access-control.html) the user is not allowed to access will fail
+ * [Accessing a resource](./access-control.html) the user is not allowed to access will fail
    with a `403 ACCESS_REFUSED` error
  * Binding a non-existing queue or a non-existing exchange will fail with a `404 NOT_FOUND` error
  * Consuming from a queue that does not exist will fail with a `404 NOT_FOUND` error
  * Publishing to an exchange that does not exist will fail with a `404 NOT_FOUND` error
- * Accessing an [exclusive queue](/queues.html#exclusive-queues) from a connection other than its declaring one will
+ * Accessing an [exclusive queue](./queues.html#exclusive-queues) from a connection other than its declaring one will
    fail with a `405 RESOURCE_LOCKED`
 
 Client libraries provide a way to observe and react to channel exceptions. For example, in the Java
-client there is [a way to register an error handler](/api-guide.html#shutdown) and access a channel
+client there is [a way to register an error handler](./api-guide.html#shutdown) and access a channel
 shutdown (closure) reason.
 
 Any attempted operation on a closed channel will fail with an exception. Note that when RabbitMQ
@@ -159,7 +159,7 @@ Some client libraries may use blocking operations that wait for
 a response. In this case they may communicate channel exceptions differently, e.g. using
 runtime exceptions, an error type, or other means appropriate for the language.
 
-See the [AMQP 0-9-1 Reference](/amqp-0-9-1-reference.html) for a more complete list of
+See the [AMQP 0-9-1 Reference](./amqp-0-9-1-reference.html) for a more complete list of
 error codes.
 
 
@@ -176,7 +176,7 @@ and not those of clients.
 
 Given both of these factors, limiting the number of channels used per connection is highly recommended.
 As a rule of thumb, most applications can use a single digit number of channels per connection.
-Those with particularly high concurrency rates (usually such applications are [consumers](/consumers.html))
+Those with particularly high concurrency rates (usually such applications are [consumers](./consumers.html))
 can start with one channel per thread/process/coroutine and switch to channel pooling
 when metrics suggest that the original model is no longer sustainable, e.g. because it consumes
 too much memory.
@@ -205,7 +205,7 @@ error:
  operation none caused a connection exception not_allowed: "number of channels opened (22) has reached the negotiated channel_max (22)"
 </pre>
 
-Clients can be configured to allow fewer channels per connection. With [RabbitMQ Java client](/api-guide.html),
+Clients can be configured to allow fewer channels per connection. With [RabbitMQ Java client](./api-guide.html),
 `ConnectionFactory#setRequestedChannelMax` is the method that controls the limit:
 
 <pre class="lang-java">
@@ -215,7 +215,7 @@ ConnectionFactory cf = new ConnectionFactory();
 cf.setRequestedChannelMax(32);
 </pre>
 
-With [RabbitMQ .NET client](/dotnet-api-guide.html), use the `ConnectionFactory#RequestedChannelMax`
+With [RabbitMQ .NET client](./dotnet-api-guide.html), use the `ConnectionFactory#RequestedChannelMax`
 property:
 
 <pre class="lang-csharp">
@@ -238,7 +238,7 @@ failed to negotiate connection parameters: negotiated channel_max = 2047 is high
 ## <a id="monitoring" class="anchor" href="#monitoring">Monitoring, Metrics and Diagnostics</a>
 
 Number of currently open channels and channel opening/closure rates are important metrics
-of the system that should be [monitored](/monitoring.html). Monitoring them will help detect a number of
+of the system that should be [monitored](./monitoring.html). Monitoring them will help detect a number of
 common problems:
 
  * Channel leaks
@@ -246,22 +246,22 @@ common problems:
 
 Both problems eventually lead to node exhaustion of [resources](#resource-usage).
 
-Individual channel metrics such as the number of [unacknowledged messages](/confirms.html#acknowledgement-modes)
+Individual channel metrics such as the number of [unacknowledged messages](./confirms.html#acknowledgement-modes)
 or `basic.get` operation rate can help identify irregularities and inefficiencies
 in application behavior.
 
 ### <a id="memory-use" class="anchor" href="#memory-use">Memory Use</a>
 
-[Monitoring systems](/monitoring.html) and operators alike may need to inspect how much memory
+[Monitoring systems](./monitoring.html) and operators alike may need to inspect how much memory
 channels consume on a node, the total
 number of channels on a node and then identify how many there are on each connection.
 
-The number of channels is displayed in the [management UI](/management.html) on the Overview tab,
-as is the [number of connections](/connections.html#monitoring).
+The number of channels is displayed in the [management UI](./management.html) on the Overview tab,
+as is the [number of connections](./connections.html#monitoring).
 By dividing the number of channels by the number of connections
 the operator can determine an average number of channels per connection.
 
-To find out how much memory on a node is used by channels, use [`rabbitmq-diagnostics memory_breakdown`](/rabbitmq-diagnostics.8.html):
+To find out how much memory on a node is used by channels, use [`rabbitmq-diagnostics memory_breakdown`](./rabbitmq-diagnostics.8.html):
 
 <pre class="lang-bash">
 rabbitmq-diagnostics memory_breakdown -q --unit mb
@@ -272,7 +272,7 @@ rabbitmq-diagnostics memory_breakdown -q --unit mb
 # => [elided for brevity]
 </pre>
 
-See the [RabbitMQ Memory Use Analysis guide](/memory-use.html) for details.
+See the [RabbitMQ Memory Use Analysis guide](./memory-use.html) for details.
 
 
 ### <a id="channel-leaks" class="anchor" href="#channel-leaks">Channel Leaks</a>
@@ -294,7 +294,7 @@ to the Connections tab and enable the relevant columns if they are not displayed
 
 <img class="screenshot" src="img/monitoring/channels/mgmt-ui-per-connection-channel-max-and-count.png" alt="Per connection channel count in management UI" title="Per connection channel count in management UI" />
 
-Overview and individual node pages provide a chart of channel churn rate as of [RabbitMQ 3.7.9](/changelog.html).
+Overview and individual node pages provide a chart of channel churn rate as of [RabbitMQ 3.7.9](./changelog.html).
 If the rate of channel open operations is consistently higher than that of channel close operations,
 this is evidence of a channel leak in one of the applications:
 
@@ -312,7 +312,7 @@ uses short lived channels or channels are often closed due to channel-level exce
 While with some workloads this is a natural state of the system,
 long lived channels should be used instead when possible.
 
-[Management UI](/management.html) provides a chart of channel churn rate.
+[Management UI](./management.html) provides a chart of channel churn rate.
 Below is a chart that demonstrates a fairly low channel churn with a virtually identical number of channel open and closed
 in the given period of time:
 
@@ -335,9 +335,9 @@ as needed:
 
 ### <a id="inspect-using-cli-tools" class="anchor" href="#inspect-using-cli-tools">Inspecting Channels and Their State Using CLI Tools</a>
 
-[`rabbitmqctl list_connections`](/rabbitmqctl.8.html) and [`rabbitmqctl list_channels`](/rabbitmqctl.8.html) are the
+[`rabbitmqctl list_connections`](./rabbitmqctl.8.html) and [`rabbitmqctl list_channels`](./rabbitmqctl.8.html) are the
 primary commands for inspecting per-connection channel count and channel details such as the number of
-consumers, [unacknowledged messages](/confirms.html#acknowledgement-modes), [prefetch](/confirms.html#channel-qos-prefetch) and so on.
+consumers, [unacknowledged messages](./confirms.html#acknowledgement-modes), [prefetch](./confirms.html#channel-qos-prefetch) and so on.
 
 <pre class="lang-bash">
 rabbitmqctl list_connections name channels -q
@@ -356,7 +356,7 @@ rabbitmqctl list_connections name channels -q --no-table-headers
 # =&gt; 127.0.0.1:52964 -&gt; 127.0.0.1:5672	33
 </pre>
 
-To inspect individual channels, use [`rabbitmqctl list_channels`](/rabbitmqctl.8.html):
+To inspect individual channels, use [`rabbitmqctl list_channels`](./rabbitmqctl.8.html):
 
 <pre class="lang-bash">
 rabbitmqctl list_channels -q
@@ -416,14 +416,14 @@ rabbitmqctl list_channels -s vhost connection number confirm
 ## <a id="flow-control" class="anchor" href="#flow-control">Publisher Flow Control</a>
 
 Channels that publish messages can outpace other parts of the system, most likely busy queues and queues
-that perform replication. When that happens, [flow control](/flow-control.html) is applied to
+that perform replication. When that happens, [flow control](./flow-control.html) is applied to
 publishing channels and, in turn, connections. Channels and connections that only consume messages
 are not affected.
 
-With slower consumers that use [automatic acknowledgement mode](/confirms.html#acknowledgement-modes)
+With slower consumers that use [automatic acknowledgement mode](./confirms.html#acknowledgement-modes)
 it is very likely that connections and channels will experience flow control when writing to
 the TCP socket.
 
-[Monitoring](/monitoring.html) systems can collect metrics on the number of connections in flow state.
+[Monitoring](./monitoring.html) systems can collect metrics on the number of connections in flow state.
 Applications that experience flow control regularly may consider to use separate connections
 to publish and consume to avoid flow control effects on non-publishing operations (e.g. queue management).

--- a/site/cli.md
+++ b/site/cli.md
@@ -341,7 +341,7 @@ location for users running commands like `rabbitmqctl.bat`.
 ### Overriding Using CLI and Runtime Command Line Arguments
 
 As an alternative, the option "`-setcookie <value>`" can be added
-to `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` <a href="/configure.html">environment variable value</a>
+to `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` <a href="./configure.html">environment variable value</a>
 to override the cookie value used by a RabbitMQ node:
 
 <pre class="lang-bash">

--- a/site/cli.md
+++ b/site/cli.md
@@ -21,11 +21,11 @@ limitations under the License.
 
 RabbitMQ ships with multiple command line tools, each with a set of related commands:
 
- * [`rabbitmqctl`](/rabbitmqctl.8.html) for service management and general operator tasks
- * [`rabbitmq-diagnostics`](/rabbitmq-diagnostics.8.html) for diagnostics and [health checking](/monitoring.html)
- * [`rabbitmq-plugins`](/rabbitmq-plugins.8.html) for [plugin management](/plugins.html)
- * [`rabbitmq-queues`](/rabbitmq-queues.8.html) for maintenance tasks on [queues](queues.html), in particular [quorum queues](/quorum-queues.html)
- * [`rabbitmq-upgrade`](/rabbitmq-upgrade.8.html) for maintenance tasks related to [upgrades](/upgrade.html)
+ * [`rabbitmqctl`](./rabbitmqctl.8.html) for service management and general operator tasks
+ * [`rabbitmq-diagnostics`](./rabbitmq-diagnostics.8.html) for diagnostics and [health checking](./monitoring.html)
+ * [`rabbitmq-plugins`](./rabbitmq-plugins.8.html) for [plugin management](./plugins.html)
+ * [`rabbitmq-queues`](./rabbitmq-queues.8.html) for maintenance tasks on [queues](queues.html), in particular [quorum queues](./quorum-queues.html)
+ * [`rabbitmq-upgrade`](./rabbitmq-upgrade.8.html) for maintenance tasks related to [upgrades](./upgrade.html)
 
 they can be found under the `sbin` directory in installation root.
 
@@ -34,7 +34,7 @@ be named `rabbitmqctl.bat`.
 
 Additional tools are optional and can be obtained from GitHub:
 
- * [`rabbitmqadmin`](/management-cli.html) for operator tasks over [HTTP API](/management.html)
+ * [`rabbitmqadmin`](./management-cli.html) for operator tasks over [HTTP API](./management.html)
  * [`rabbitmq-collect-env`](https://github.com/rabbitmq/support-tools) which collects relevant cluster and environment information
     as well as server logs. This tool is specific to Linux and UNIX-like operating systems.
 
@@ -44,7 +44,7 @@ including virtual host, user and permission management, destructive operations
 on node's data and so on.
 
 `rabbitmqadmin` is built on top of the HTTP API and uses a different mechanism, and only
-requires that the [HTTP API](/management.html) port is open for outside connections.
+requires that the [HTTP API](./management.html) port is open for outside connections.
 
 Even though CLI tools ship with the server, most commands [can be used to operate on remote nodes](#remote-nodes).
 Plugins can [provide CLI commands](#command-discovery) that will be discovered by CLI tools for explicitly enabled plugins.
@@ -52,7 +52,7 @@ Plugins can [provide CLI commands](#command-discovery) that will be discovered b
 
 ## <a id="requirements" class="anchor" href="#requirements">System and Environment Requirements</a>
 
-RabbitMQ CLI tools require a [compatible Erlang/OTP](/which-erlang.html) version to be installed.
+RabbitMQ CLI tools require a [compatible Erlang/OTP](./which-erlang.html) version to be installed.
 
 The tools assume that system locale is a UTF-8 one (e.g. `en_GB.UTF-8` or `en_US.UTF-8`). If that's
 not the case, the tools may still function correctly but it cannot be guaranteed.
@@ -66,15 +66,15 @@ directory in installation root. With most package types that directory is added 
 This means that core tools such as `rabbitmq-diagnostics` and `rabbitmqctl` are available on every node
 that has RabbitMQ installed.
 
-[Generic UNIX package](/install-generic-unix.html) users have to make sure that the `sbin` directory under installation
+[Generic UNIX package](./install-generic-unix.html) users have to make sure that the `sbin` directory under installation
 root is added to `PATH` for simpler interactive use. Non-interactive use cases can use full or relative paths without
 modifications to the `PATH` environment variable.
 
-[`rabbitmqadmin`](/management-cli.html) is a standalone tool (no dependencies other than Python 3)
+[`rabbitmqadmin`](./management-cli.html) is a standalone tool (no dependencies other than Python 3)
 that can be downloaded from a running node or [directly from GitHub](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_management/bin/rabbitmqadmin).
 
-If interaction from a remote node is required, download and extract the [generic UNIX package](/install-generic-unix.html)
-or use the [Windows installer](/install-windows.html).
+If interaction from a remote node is required, download and extract the [generic UNIX package](./install-generic-unix.html)
+or use the [Windows installer](./install-windows.html).
 
 Besides [authentication](#authentication), all configuration for core CLI tools is optional.
 
@@ -114,7 +114,7 @@ rabbitmq-diagnostics status --help
 
 ## <a id="rabbitmqctl" class="anchor" href="#rabbitmqctl">rabbitmqctl</a>
 
-[rabbitmqctl](/rabbitmqctl.8.html) is the original CLI tool that ships with RabbitMQ.
+[rabbitmqctl](./rabbitmqctl.8.html) is the original CLI tool that ships with RabbitMQ.
 It supports a wide range of operations, mostly administrative (operational) in nature.
 
 This includes
@@ -134,7 +134,7 @@ and more.
 
 ## <a id="rabbitmq-plugins" class="anchor" href="#rabbitmq-plugins">rabbitmq-plugins</a>
 
-[rabbitmq-plugins](/rabbitmq-plugins.8.html) is a tool that manages plugins:
+[rabbitmq-plugins](./rabbitmq-plugins.8.html) is a tool that manages plugins:
 lists, enables and disables them. It ships with RabbitMQ.
 
 It supports both online (when target node is running) and offline mode (changes
@@ -182,7 +182,7 @@ rabbitmqctl wait
 </pre>
 
 can only be run on the same host or in the same container as their target node. These commands typically
-rely on or modify something in the local environment, e.g. the local [enabled plugins file](/plugins.html).
+rely on or modify something in the local environment, e.g. the local [enabled plugins file](./plugins.html).
 
 
 ### <a id="node-names" class="anchor" href="#node-names">Node Names</a>
@@ -197,7 +197,7 @@ different prefixes, e.g. `rabbit1@hostname` and `rabbit2@hostname`.
 
 CLI tools identify and address server nodes using node names.
 Most CLI commands are invoked against a node called target node. To specify a target node,
-use the `--node` (`-n`) option. For example, to run a [health check](/monitoring.html)
+use the `--node` (`-n`) option. For example, to run a [health check](./monitoring.html)
 on node `rabbit@warp10.local`:
 
 <pre class="lang-bash">
@@ -208,16 +208,16 @@ Some commands accept both a target node and another node name. For example,
 `rabbitmqctl forget_cluster_node` accepts both a target node (that will perform the action)
 and a name of the node to be removed.
 
-In a cluster, nodes identify and contact each other using node names. See [Clustering guide](/clustering.html#node-names)
+In a cluster, nodes identify and contact each other using node names. See [Clustering guide](./clustering.html#node-names)
 for details.
 
 When a node starts up, it checks whether it has been assigned a node name. This is done
-via the `RABBITMQ_NODENAME` [environment variable](/configure.html#supported-environment-variables).
+via the `RABBITMQ_NODENAME` [environment variable](./configure.html#supported-environment-variables).
 If no value was explicitly configured, the node resolves its hostname and prepends `rabbit` to it to compute its node name.
 
 If a system uses fully qualified domain names (FQDNs) for hostnames, RabbitMQ nodes
 and CLI tools must be configured to use so called long node names.
-For server nodes this is done by setting the `RABBITMQ_USE_LONGNAME` [environment variable](/configure.html#supported-environment-variables)
+For server nodes this is done by setting the `RABBITMQ_USE_LONGNAME` [environment variable](./configure.html#supported-environment-variables)
 to `true`.
 
 For CLI tools, either `RABBITMQ_USE_LONGNAME` must be set or the `--longnames` option
@@ -360,7 +360,7 @@ Both are **the least secure options** and generally **not recommended**.
 
 #### CLI Tools
 
-Starting with [version `3.8.6`](/changelog.html), `rabbitmq-diagnostics` includes a command
+Starting with [version `3.8.6`](./changelog.html), `rabbitmq-diagnostics` includes a command
 that provides relevant information on the Erlang cookie file used by CLI tools:
 
 <pre class="lang-bash">
@@ -394,27 +394,27 @@ RABBITMQ_ERLANG_COOKIE value length: 0
 
 #### Server Nodes
 
-When a node starts, it will [log](/logging.html) the home directory location of its effective user:
+When a node starts, it will [log](./logging.html) the home directory location of its effective user:
 
 <pre class="lang-plaintext">
 node           : rabbit@cdbf4de5f22d
 home dir       : /var/lib/rabbitmq
 </pre>
 
-Unless any [server directories](/relocate.html) were overridden, that's the directory where
+Unless any [server directories](./relocate.html) were overridden, that's the directory where
 the cookie file will be looked for, and created by the node on first boot if it does not already exist.
 
 In the example above, the cookie file location will be `/var/lib/rabbitmq/.erlang.cookie`.
 
 #### Hostname Resolution
 
-Starting with [RabbitMQ `3.8.6`](/changelog.html), CLI tools provide two commands that help verify
+Starting with [RabbitMQ `3.8.6`](./changelog.html), CLI tools provide two commands that help verify
 that hostname resolution on a node works as expected. The commands are not meant to replace
 [`dig`](https://en.wikipedia.org/wiki/Dig_(command)) and other specialised DNS tools but rather
 provide a way to perform most basic checks while taking [Erlang runtime hostname resolver features](https://erlang.org/doc/apps/erts/inet_cfg.html)
 into account.
 
-The commands are covered in the [Networking guide](/networking.html#dns-verify-resolution).
+The commands are covered in the [Networking guide](./networking.html#dns-verify-resolution).
 
 ## <a id="cli-authentication-failures" class="anchor" href="#cli-authentication-failures">Authentication Failures</a>
 
@@ -529,9 +529,9 @@ and so on.
 
 ## <a id="http-api-cli" class="anchor" href="#http-api-cli">rabbitmqadmin</a>
 
-[rabbitmqadmin](/management-cli.html) is a command line tool that's built on top of [RabbitMQ HTTP API](/management.html).
+[rabbitmqadmin](./management-cli.html) is a command line tool that's built on top of [RabbitMQ HTTP API](./management.html).
 It is not a replacement for `rabbitmqctl` and provides access to a subset of most commonly
-performed operations provided by the [management UI](/management.html).
+performed operations provided by the [management UI](./management.html).
 
 The tool requires Python 2.7.9 or a more recent version.
 
@@ -542,10 +542,10 @@ downloaded separately from a running node or [GitHub](https://github.com/rabbitm
 ## <a id="cli-and-clustering" class="anchor" href="#cli-and-clustering">"Node-local" and "Clusterwide" Commands</a>
 
 Client connections, channels and queues will be distributed across cluster nodes.
-Operators need to be able to inspect and [monitor](/monitoring.html) such resources
+Operators need to be able to inspect and [monitor](./monitoring.html) such resources
 across all cluster nodes.
 
-CLI tools such as [rabbitmqctl](/rabbitmqctl.8.html) and
+CLI tools such as [rabbitmqctl](./rabbitmqctl.8.html) and
 `rabbitmq-diagnostics` provide commands that inspect resources and
 cluster-wide state. Some commands focus on the state of a single node
 (e.g. `rabbitmq-diagnostics environment` and `rabbitmq-diagnostics

--- a/site/clustering-compression.md
+++ b/site/clustering-compression.md
@@ -14,7 +14,7 @@ the workload.
 <p class="box-info">
 Inter-node traffic compression is <strong>available in VMware Tanzu RabbitMQ
 only</strong>, not in the standard FOSS RabbitMQ.
-<a href="/tanzu/">Learn more about VMware Tanzu RabbitMQ</a>
+<a href="./tanzu/">Learn more about VMware Tanzu RabbitMQ</a>
 </p>
 
 ## <a id="how-to-use-it" class="anchor" href="#how-to-use-it">How to use it</a>

--- a/site/clustering-compression.md
+++ b/site/clustering-compression.md
@@ -1,10 +1,10 @@
 # Inter-node and CLI Traffic Compression
 
-[VMware Tanzu RabbitMQ](/tanzu/) supports compression for [inter-node](/clustering.html)
-and [CLI tool](/cli.html) traffic.
+[VMware Tanzu RabbitMQ](./tanzu/) supports compression for [inter-node](./clustering.html)
+and [CLI tool](./cli.html) traffic.
 
 RabbitMQ nodes communicate with their peers and CLI tools using dedicated TCP connections,
-optionally [protected with TLS](/clustering-ssl.html).
+optionally [protected with TLS](./clustering-ssl.html).
 
 In heavily loaded system, inter-node traffic flows can be substantial, approaching
 or even saturating the bandwidth provided by network links. Compression of this traffic
@@ -20,7 +20,7 @@ only</strong>, not in the standard FOSS RabbitMQ.
 ## <a id="how-to-use-it" class="anchor" href="#how-to-use-it">How to use it</a>
 
 Inter-node traffic compression is enabled out-of-the-box in VMware Tanzu RabbitMQ:
-if two RabbitMQ nodes [form a cluster](/cluster-formation.html), they will try to use compression.
+if two RabbitMQ nodes [form a cluster](./cluster-formation.html), they will try to use compression.
 
 For the data to be compressed, the following conditions MUST be met:
 
@@ -37,7 +37,7 @@ to the other without stopping the entire cluster.
 ## <a id="how-it-works" class="anchor" href="#how-it-works">How it works</a>
 
 <div style="float: right;">
-<img src="/img/erlang-distribution-compression/negotiation.svg"
+<img src="./img/erlang-distribution-compression/negotiation.svg"
 style="width: 100%; max-width: 500px; margin: 10px;"/>
 </div>
 

--- a/site/clustering-ssl.md
+++ b/site/clustering-ssl.md
@@ -19,25 +19,25 @@ limitations under the License.
 
 ## Overview
 
-RabbitMQ nodes accept [connections from clients](connections.html) as well as [peer cluster nodes](/clustering.html)
-and [CLI tools](/cli.html).
+RabbitMQ nodes accept [connections from clients](connections.html) as well as [peer cluster nodes](./clustering.html)
+and [CLI tools](./cli.html).
 
-The main [TLS](/ssl.html) and [Troubleshooting TLS](/troubleshooting-ssl.html) guides explain
+The main [TLS](./ssl.html) and [Troubleshooting TLS](./troubleshooting-ssl.html) guides explain
 how to secure client connections with TLS. It may be desired to add a layer of encryption and an extra
 layer of authentication to the other two kinds of connections. This guide explains how to do that.
 
-Switching inter-node and CLI tool communication requires configuring a few [runtime](/runtime.html) flags.
-They provide the node with a [CA certificate bundle and a certificate/key pair](/ssl.html#certificates-and-keys).
+Switching inter-node and CLI tool communication requires configuring a few [runtime](./runtime.html) flags.
+They provide the node with a [CA certificate bundle and a certificate/key pair](./ssl.html#certificates-and-keys).
 CLI tools also have to be configured to use a certificate/key pair as TLS-enabled nodes
 won't accept unencrypted connections from CLI tools and peers.
 
-This guide assumes the reader is familiar with the [basics of TLS](/ssl.html#certificates-and-keys)
-and [peer verification](/ssl.html#peer-verification) (authentication) covered in the main TLS guide.
+This guide assumes the reader is familiar with the [basics of TLS](./ssl.html#certificates-and-keys)
+and [peer verification](./ssl.html#peer-verification) (authentication) covered in the main TLS guide.
 
 It also assumes that you already have a CA certificate bundle and a certificate/key pair generated for every
 cluster node and every host CLI tools will be use on. In production environments those certificates
 will often be produced by operators or deployment tools. For development and experimentation,
-there is a [quick way to generate them](/ssl.html#automated-certificate-generation) using OpenSSL
+there is a [quick way to generate them](./ssl.html#automated-certificate-generation) using OpenSSL
 and Python.
 
 This guide will reference three files:
@@ -52,7 +52,7 @@ Make sure you have them ready before we start.
 ## <a id="basics" class="anchor" href="#basics">The Basics</a>
 
 Configuring a node to communicate over TLS-enabled connections involves a few
-steps. With [supported Erlang versions](/which-erlang.html) there are two ways of doing it.
+steps. With [supported Erlang versions](./which-erlang.html) there are two ways of doing it.
 
 The steps are very similar on all operating systems supported but minor details will be
 [different on Windows](#windows) due to a different shell language.
@@ -65,7 +65,7 @@ The steps are very similar on all operating systems supported but minor details 
  * Tell the node about any additional TLS settings desired, using other `-ssl_dist_opt` options, for example: `-ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true` to enable [secure renegotiation](https://devcentral.f5.com/s/articles/ssl-profiles-part-6-ssl-renegotiation)
 
 [Strategy two](#linux-strategy-two) is very similar but instead of specifying a set of runtime flags, those options can be specified
-in a file similar to RabbitMQ's [advanced.config file](/configure.html#advanced-config-file) and the runtime
+in a file similar to RabbitMQ's [advanced.config file](./configure.html#advanced-config-file) and the runtime
 will be pointed at that file. Therefore the steps are:
 
  * Tell the node to use encrypted inter-node connections using a runtime flag, `-proto_dist inet_tls`
@@ -76,7 +76,7 @@ will be pointed at that file. Therefore the steps are:
 We encourage operators to choose the strategy that works best for their deployment tools of choice.
 
 With both options environment variables are used to pass those options to the runtime. This is best
-done using `rabbitmq-env.conf` as explained in the [Configuration guide](/configure.html#customise-environment).
+done using `rabbitmq-env.conf` as explained in the [Configuration guide](./configure.html#customise-environment).
 
 Once a node has inter-node connection configured with TLS, CLI tools such as `rabbitmqctl` and `rabbitmq-diagnostics`
 also must use TLS to talk to the node. Plain TCP connections will be fail.
@@ -89,12 +89,12 @@ This is because CLI tools configured to use TLS won't be able to connect to a no
 not expect TLS-enabled CLI tool connections.
 
 For nodes and CLI tools to perform TLS handshake and peer verification successfully,
-the same [peer verification](/ssl.html#peer-verification)
+the same [peer verification](./ssl.html#peer-verification)
 example, certificate/key pairs used by other nodes and CLI
 tools must be signed by the same certificate authority as the initial node or a
 different CA that is trusted on all cluster nodes.
 
-This is no different from how [peer verification works for client and plugin TLS connections](/ssl.html#peer-verification).
+This is no different from how [peer verification works for client and plugin TLS connections](./ssl.html#peer-verification).
 
 It is possible to reuse a single certificate/key pair for all nodes and CLI tools.
 The certificate can also use a wildcard Subject Alternative Name (SAN) or Common Name (CN) such as `*.rabbitmq.example.local`
@@ -239,7 +239,7 @@ RABBITMQ_CTL_ERL_ARGS="-pa $ERL_SSL_PATH
 </pre>
 
 Here is an example `/etc/rabbitmq/inter_node_tls.config` file that uses
-separate server certificate and private key files, enables [peer verification](/ssl.html#peer-verification)
+separate server certificate and private key files, enables [peer verification](./ssl.html#peer-verification)
 and requires peers to present a certificate:
 
 <pre class="lang-bash">
@@ -281,7 +281,7 @@ different due to Windows shell parsing rules. it looks like this
 erl -noinput -eval "io:format(""ERL_SSL_PATH=~s~n"", [filename:dirname(code:which(inet_tls_dist))])" -s init stop
 </pre>
 
-Next, the file containing the [custom environment variables](/configure.html#customise-environment)
+Next, the file containing the [custom environment variables](./configure.html#customise-environment)
 is named `rabbitmq-env-conf.bat` on Windows. This file **must** be saved to the `%AppData%\RabbitMQ` directory of the administrative
 user that installed RabbitMQ.
 
@@ -311,7 +311,7 @@ set CTL_ERL_ARGS=-pa %SSL_PATH% ^
 </pre>
 
 Below is an example `inter_node_tls.config` file.
-As with other operating systems, more [TLS options](/ssl.html) are available
+As with other operating systems, more [TLS options](./ssl.html) are available
 to be set if necessary.
 
 <pre class="lang-bash">

--- a/site/clustering.md
+++ b/site/clustering.md
@@ -249,7 +249,7 @@ location for users running commands like `rabbitmqctl.bat`.
 ### Overriding Using CLI and Runtime Command Line Arguments
 
 As an alternative, the option "`-setcookie <value>`" can be added
-to `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` <a href="/configure.html">environment variable value</a>
+to `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` <a href="./configure.html">environment variable value</a>
 to override the cookie value used by a RabbitMQ node:
 
 <pre class="lang-bash">

--- a/site/clustering.md
+++ b/site/clustering.md
@@ -33,9 +33,9 @@ This guide covers fundamental topics related to RabbitMQ clustering:
  * How to [remove a cluster node](#removing-nodes)
  * How to [reset a cluster node](#resetting-nodes) to a pristine (blank) state
 
-and more. [Cluster Formation and Peer Discovery](/cluster-formation.html) is a closely related guide
+and more. [Cluster Formation and Peer Discovery](./cluster-formation.html) is a closely related guide
 that focuses on peer discovery and cluster formation automation-related topics. For queue contents
-(message) replication, see the [Quorum Queues](/quorum-queues.html) guide.
+(message) replication, see the [Quorum Queues](./quorum-queues.html) guide.
 
 [Tanzu RabbitMQ](tanzu) provides an [inter-node traffic compression](clustering-compression.html) feature.
 
@@ -57,7 +57,7 @@ A RabbitMQ cluster can be formed in a number of ways:
  * Declaratively using [etcd-based discovery](https://github.com/rabbitmq/rabbitmq-peer-discovery-etcd) (via a plugin)
  * Manually with `rabbitmqctl`
 
-Please refer to the [Cluster Formation guide](/cluster-formation.html) for details.
+Please refer to the [Cluster Formation guide](./cluster-formation.html) for details.
 
 The composition of a cluster can be altered dynamically.
 All RabbitMQ brokers start out as running on a single
@@ -76,16 +76,16 @@ different prefixes, e.g. `rabbit1@hostname` and `rabbit2@hostname`.
 
 In a cluster, nodes identify and contact each other using node names. This means
 that the hostname part of every node name [must resolve](#hostname-resolution-requirement).
-[CLI tools](/cli.html) also identify and address nodes using node names.
+[CLI tools](./cli.html) also identify and address nodes using node names.
 
 When a node starts up, it checks whether it has been assigned a node name. This is done
-via the `RABBITMQ_NODENAME` [environment variable](/configure.html#supported-environment-variables).
+via the `RABBITMQ_NODENAME` [environment variable](./configure.html#supported-environment-variables).
 If no value was explicitly configured,
 the node resolves its hostname and prepends `rabbit` to it to compute its node name.
 
 If a system uses fully qualified domain names (FQDNs) for hostnames, RabbitMQ nodes
 and CLI tools must be configured to use so called long node names.
-For server nodes this is done by setting the `RABBITMQ_USE_LONGNAME` [environment variable](/configure.html#supported-environment-variables)
+For server nodes this is done by setting the `RABBITMQ_USE_LONGNAME` [environment variable](./configure.html#supported-environment-variables)
 to `true`.
 
 For CLI tools, either `RABBITMQ_USE_LONGNAME` must be set or the `--longnames` option
@@ -118,7 +118,7 @@ a local file, a non-standard hosts file location, or a mix
 of methods.  Those methods can work in concert with the
 standard OS hostname resolution methods.
 
-To use FQDNs, see `RABBITMQ_USE_LONGNAME` in the [Configuration guide](/configure.html#supported-environment-variables).
+To use FQDNs, see `RABBITMQ_USE_LONGNAME` in the [Configuration guide](./configure.html#supported-environment-variables).
 See [Node Names](#node-names) above.
 
 
@@ -158,7 +158,7 @@ are message queues, which by default reside on one node,
 though they are visible and reachable from all nodes. To
 replicate queues across nodes in a cluster, use a queue type
 that supports replication. This topic is covered in
-the [Quorum Queues](/quorum-queues.html) guide.
+the [Quorum Queues](./quorum-queues.html) guide.
 
 ### <a id="peer-equality" class="anchor" href="#peer-equality">Nodes are Equal Peers</a>
 
@@ -169,15 +169,15 @@ This topic becomes more nuanced when [quorum queues](quorum-queues.html) and plu
 are taken into consideration but for most intents and purposes,
 all cluster nodes should be considered equal.
 
-Many [CLI tool](/cli.html) operations can be executed against any node.
-An [HTTP API](/management.html) client can target any cluster node.
+Many [CLI tool](./cli.html) operations can be executed against any node.
+An [HTTP API](./management.html) client can target any cluster node.
 
 Individual plugins can designate (elect)
 certain nodes to be "special" for a period of time. For example, [federation links](federation.html)
 are colocated on a particular cluster node. Should that node fail, the links will
 be restarted on a different node.
 
-In versions older than 3.6.7, [RabbitMQ management plugin](/management.html) used
+In versions older than 3.6.7, [RabbitMQ management plugin](./management.html) used
 a dedicated node for stats collection and aggregation.
 
 ### <a id="erlang-cookie" class="anchor" href="#erlang-cookie">How CLI Tools Authenticate to Nodes (and Nodes to Each Other): the Erlang Cookie</a>
@@ -195,7 +195,7 @@ If the file does not exist, Erlang VM will try to create
 one with a randomly generated value when the RabbitMQ server
 starts up. Using such generated cookie files are appropriate in development
 environments only. Since each node will generate its own value independently,
-this strategy is not really viable in a [clustered environment](/clustering.html).
+this strategy is not really viable in a [clustered environment](./clustering.html).
 
 Erlang cookie generation should be done at cluster deployment stage, ideally using automation
 and orchestration tools.
@@ -266,14 +266,14 @@ Both are **the least secure options** and generally **not recommended**.
 
 ### Troubleshooting
 
-When a node starts, it will [log](/logging.html) the home directory location of its effective user:
+When a node starts, it will [log](./logging.html) the home directory location of its effective user:
 
 <pre class="lang-plaintext">
 node           : rabbit@cdbf4de5f22d
 home dir       : /var/lib/rabbitmq
 </pre>
 
-Unless any [server directories](/relocate.html) were overridden, that's the directory where
+Unless any [server directories](./relocate.html) were overridden, that's the directory where
 the cookie file will be looked for, and created by the node on first boot if it does not already exist.
 
 In the example above, the cookie file location will be `/var/lib/rabbitmq/.erlang.cookie`.
@@ -313,20 +313,20 @@ more information and cookie mismatches can be identified better:
 * Authentication failed (rejected by the remote node), please check the Erlang cookie
 </pre>
 
-See the [CLI Tools guide](/cli.html) for more information.
+See the [CLI Tools guide](./cli.html) for more information.
 
 ### <a id="cookie-file-troubleshooting" class="anchor" href="#cookie-file-troubleshooting">Troubleshooting</a> Cookie-based Authentication
 
 #### Server Nodes
 
-When a node starts, it will [log](/logging.html) the home directory location of its effective user:
+When a node starts, it will [log](./logging.html) the home directory location of its effective user:
 
 <pre class="lang-plaintext">
 node           : rabbit@cdbf4de5f22d
 home dir       : /var/lib/rabbitmq
 </pre>
 
-Unless any [server directories](/relocate.html) were overridden, that's the directory where
+Unless any [server directories](./relocate.html) were overridden, that's the directory where
 the cookie file will be looked for, and created by the node on first boot if it does not already exist.
 
 In the example above, the cookie file location will be `/var/lib/rabbitmq/.erlang.cookie`.
@@ -334,17 +334,17 @@ In the example above, the cookie file location will be `/var/lib/rabbitmq/.erlan
 #### Hostname Resolution
 
 Since hostname resolution is a [prerequisite for successful inter-node communication](#hostname-resolution-requirement),
-starting with [RabbitMQ `3.8.6`](/changelog.html), CLI tools provide two commands that help verify
+starting with [RabbitMQ `3.8.6`](./changelog.html), CLI tools provide two commands that help verify
 that hostname resolution on a node works as expected. The commands are not meant to replace
 [`dig`](https://en.wikipedia.org/wiki/Dig_(command)) and other specialised DNS tools but rather
 provide a way to perform most basic checks while taking [Erlang runtime hostname resolver features](https://erlang.org/doc/apps/erts/inet_cfg.html)
 into account.
 
-The commands are covered in the [Networking guide](/networking.html#dns-verify-resolution).
+The commands are covered in the [Networking guide](./networking.html#dns-verify-resolution).
 
 #### CLI Tools
 
-Starting with [version `3.8.6`](/changelog.html), `rabbitmq-diagnostics` includes a command
+Starting with [version `3.8.6`](./changelog.html), `rabbitmq-diagnostics` includes a command
 that provides relevant information on the Erlang cookie file used by CLI tools:
 
 <pre class="lang-bash">
@@ -378,7 +378,7 @@ RABBITMQ_ERLANG_COOKIE value length: 0
 
 ## <a id="node-count" class="anchor" href="#node-count">Node Counts and Quorum</a>
 
-Because several features (e.g. [quorum queues](/quorum-queues.html), [client tracking in MQTT](/mqtt.html))
+Because several features (e.g. [quorum queues](./quorum-queues.html), [client tracking in MQTT](./mqtt.html))
 require a consensus between cluster members, odd numbers of cluster nodes are highly recommended:
 1, 3, 5, 7 and so on.
 
@@ -389,7 +389,7 @@ MQTT client connections won't be accepted, quorum queues would lose their availa
 From the consensus point of view, four or six node clusters would have the same availability
 characteristics as three and five node clusters.
 
-The [Quorum Queues guide](/quorum-queues.html) covers this topic in more detail.
+The [Quorum Queues guide](./quorum-queues.html) covers this topic in more detail.
 
 
 ## <a id="clustering-and-clients" class="anchor" href="#clustering-and-clients">Clustering and Clients</a>
@@ -397,7 +397,7 @@ The [Quorum Queues guide](/quorum-queues.html) covers this topic in more detail.
 Assuming all cluster members
 are available, a client can connect to any node and
 perform any operation. Nodes will route operations to the
-[quorum queue leader](/quorum-queues.html) or [queue leader replica](ha.html#leader-migration-data-locality)
+[quorum queue leader](./quorum-queues.html) or [queue leader replica](ha.html#leader-migration-data-locality)
 transparently to clients.
 
 With all supported messaging protocols a client is only connected to one node
@@ -410,20 +410,20 @@ as a connection option. The list of hosts will be used during initial connection
 as well as connection recovery, if the client supports it. See documentation guides
 for individual clients to learn more.
 
-With [quorum queues](/quorum-queues.html), clients will only be able to perform
+With [quorum queues](./quorum-queues.html), clients will only be able to perform
 operations on queues that have a quorum of replicas online.
 
 With classic mirrored queues, there are scenarios where it may not be possible for a client to transparently continue
 operations after connecting to a different node. They usually involve
-[non-mirrored queues hosted on a failed node](/ha.html#non-mirrored-queue-behavior-on-node-failure).
+[non-mirrored queues hosted on a failed node](./ha.html#non-mirrored-queue-behavior-on-node-failure).
 
 ## <a id="clustering-and-observability" class="anchor" href="#clustering-and-observability">Clustering and Observability</a>
 
 Client connections, channels and queues will be distributed across cluster nodes.
-Operators need to be able to inspect and [monitor](/monitoring.html) such resources
+Operators need to be able to inspect and [monitor](./monitoring.html) such resources
 across all cluster nodes.
 
-RabbitMQ [CLI tools](/cli.html) such as `rabbitmq-diagnostics` and `rabbitmqctl`
+RabbitMQ [CLI tools](./cli.html) such as `rabbitmq-diagnostics` and `rabbitmqctl`
 provide commands that inspect resources and cluster-wide state. Some commands focus on the state of a single node
 (e.g. `rabbitmq-diagnostics environment` and `rabbitmq-diagnostics status`), others
 inspect cluster-wide state. Some examples of the latter include `rabbitmqctl list_connections`,
@@ -444,7 +444,7 @@ semantically identical results. "Node-local" commands, however, will not produce
 identical results since two nodes rarely have identical state: at the very least their
 node names will be different!
 
-[Management UI](/management.html) works similarly: a node that has to respond to an HTTP API request
+[Management UI](./management.html) works similarly: a node that has to respond to an HTTP API request
 will fan out to other cluster members and aggregate their responses. In a cluster with multiple nodes that have management plugin
 enabled, the operator can use any node to access management UI. The same goes for monitoring tools that use
 the HTTP API to collect data about the state of the cluster. There is no need to issue a request to every cluster node in turn.
@@ -460,7 +460,7 @@ known at the time of shutdown.
 across multiple cluster nodes with parallel replication and a predictable [leader election](#quorum-queues.html#leader-election)
 and [data safety](quorum-queues.html#data-safety) behavior as long as a majority of replicas are online.
 
-Non-replicated classic queues can also be used in clusters. Non-mirrored queue [behaviour in case of node failure](/ha.html#non-mirrored-queue-behavior-on-node-failure)
+Non-replicated classic queues can also be used in clusters. Non-mirrored queue [behaviour in case of node failure](./ha.html#non-mirrored-queue-behavior-on-node-failure)
 depends on [queue durability](queues.html#durability).
 
 RabbitMQ clustering has several modes of dealing with [network partitions](partitions.html),
@@ -475,10 +475,10 @@ WAN. Note that [Shovel and Federation are not equivalent to clustering](distribu
 
 Every node stores and aggregates its own metrics and stats, and provides an API for
 other nodes to access it. Some stats are cluster-wide, others are specific to individual nodes.
-Node that responds to an [HTTP API](/management.html) request contacts its peers
+Node that responds to an [HTTP API](./management.html) request contacts its peers
 to retrieve their data and then produces an aggregated result.
 
-In versions older than 3.6.7, [RabbitMQ management plugin](/management.html) used
+In versions older than 3.6.7, [RabbitMQ management plugin](./management.html) used
 a dedicated node for stats collection and aggregation.
 
 
@@ -487,7 +487,7 @@ a dedicated node for stats collection and aggregation.
 The following several sections provide a transcript of manually setting up and manipulating
 a RabbitMQ cluster across three machines: `rabbit1`, `rabbit2`,
 `rabbit3`. It is recommended that the example is studied before
-[more automation-friendly](/cluster-formation.html) cluster formation
+[more automation-friendly](./cluster-formation.html) cluster formation
 options are used.
 
 We assume that the user is logged into all three machines,
@@ -553,18 +553,18 @@ In order to link up our three nodes in a cluster, we tell
 two of the nodes, say `rabbit@rabbit2` and
 `rabbit@rabbit3`, to join the cluster of the
 third, say `rabbit@rabbit1`. Prior to that both
-newly joining members must be [reset](/rabbitmqctl.8.html#reset).
+newly joining members must be [reset](./rabbitmqctl.8.html#reset).
 
 We first join `rabbit@rabbit2` in a cluster
 with `rabbit@rabbit1`. To do that, on
 `rabbit@rabbit2` we stop the RabbitMQ
 application and join the `rabbit@rabbit1`
 cluster, then restart the RabbitMQ application. Note that
-a node must be [reset](/rabbitmqctl.8.html#reset) before it can join an existing cluster.
+a node must be [reset](./rabbitmqctl.8.html#reset) before it can join an existing cluster.
 Resetting the node <strong>removes all resources and data that were previously
 present on that node</strong>. This means that a node cannot be made a member
 of a cluster and keep its existing data at the same time. When that's desired,
-using the [Blue/Green deployment strategy](/blue-green-upgrade.html) or [backup and restore](/backup.html)
+using the [Blue/Green deployment strategy](./blue-green-upgrade.html) or [backup and restore](./backup.html)
 are the available options.
 
 <pre class="lang-bash">
@@ -731,26 +731,26 @@ By adjusting these settings and tweaking the time window in which
 known peer has to come back it is possible to account for cluster-wide
 redeployment scenarios that can be longer than 5 minutes to complete.
 
-During [upgrades](/upgrade.html), sometimes the last node to stop
+During [upgrades](./upgrade.html), sometimes the last node to stop
 must be the first node to be started after the upgrade. That node will be designated to perform
 a cluster-wide schema migration that other nodes can sync from and apply when they
 rejoin.
 
 ### <a id="restarting-readiness-probes" class="anchor" href="#restarting-readiness-probes">Restarts and Health Checks (Readiness Probes)</a>
 
-In some environments, node restarts are controlled with a designated [health check](/monitoring.html#health-checks).
+In some environments, node restarts are controlled with a designated [health check](./monitoring.html#health-checks).
 The checks verify that one node has started and the deployment process can proceed to the next one.
 If the check does not pass, the deployment of the node is considered to be incomplete and the deployment process
 will typically wait and retry for a period of time. One popular example of such environment is Kubernetes
 where an operator-defined [readiness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate)
 can prevent a deployment from proceeding when the [`OrderedReady` pod management policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#deployment-and-scaling-guarantees) is used. Deployments that use the `Parallel` pod management policy
-will not be affected but must worry about the [natural race condition during initial cluster formation](/cluster-formation.html#initial-formation-race-condition).
+will not be affected but must worry about the [natural race condition during initial cluster formation](./cluster-formation.html#initial-formation-race-condition).
 
 Given the [peer syncing behavior described above](#restarting-schema-sync), such a health check can prevent a cluster-wide restart
 from completing in time. Checks that explicitly or implicitly assume a fully booted node that's rejoined
 its cluster peers will fail and block further node deployments.
 
-[Most health check](/monitoring.html#health-checks), even relatively basic ones, implicitly assume that the node has
+[Most health check](./monitoring.html#health-checks), even relatively basic ones, implicitly assume that the node has
 finished booting. They are not suitable for nodes that are [awaiting schema table sync](#restarting-schema-sync) from a peer.
 
 One very common example of such check is
@@ -770,12 +770,12 @@ rabbitmq-diagnostics ping
 </pre>
 
 This basic check would allow the deployment to proceed and the nodes to eventually rejoin each other,
-assuming they are [compatible](/upgrade.html).
+assuming they are [compatible](./upgrade.html).
 
 
 ### <a id="restarting-with-hostname-changes" class="anchor" href="#restarting-with-hostname-changes">Hostname Changes Between Restarts</a>
 
-A node rejoining after a node name or host name change can start as [a blank node](/cluster-formation.html#peer-discovery-how-does-it-work)
+A node rejoining after a node name or host name change can start as [a blank node](./cluster-formation.html#peer-discovery-how-does-it-work)
 if its data directory path changes as a result. Such nodes will fail to rejoin the cluster.
 While the node is offline, its peers can be reset or started with a blank data directory.
 In that case the recovering node will fail to rejoin its peer as well since internal data store cluster
@@ -885,9 +885,9 @@ rabbitmqctl cluster_status
 
 In some cases the last node to go
 offline cannot be brought back up. It can be removed from the
-cluster using the `forget_cluster_node` [rabbitmqctl](/cli.html) command.
+cluster using the `forget_cluster_node` [rabbitmqctl](./cli.html) command.
 
-Alternatively `force_boot` [rabbitmqctl](/cli.html) command can be used
+Alternatively `force_boot` [rabbitmqctl](./cli.html) command can be used
 on a node to make it boot without trying to sync with any
 peers (as if they were last to shut down). This is
 usually only necessary if the last node to shut down or a
@@ -899,7 +899,7 @@ Sometimes it is necessary to remove a node from a
 cluster. The operator has to do this explicitly using a
 `rabbitmqctl` command.
 
-Some [peer discovery mechanisms](/cluster-formation.html)
+Some [peer discovery mechanisms](./cluster-formation.html)
 support node health checks and forced
 removal of nodes not known to the discovery backend. That feature is
 opt-in (disabled by default).
@@ -1024,7 +1024,7 @@ rabbitmqctl start_app
 </pre>
 
 Besides `rabbitmqctl forget_cluster_node` and the automatic cleanup of unknown nodes
-by some [peer discovery](/cluster-formation.html) plugins, there are no scenarios
+by some [peer discovery](./cluster-formation.html) plugins, there are no scenarios
 in which a RabbitMQ node will permanently remove its peer node from a cluster.
 
 ### <a id="resetting-nodes" class="anchor" href="#resetting-nodes">How to Reset a Node</a>
@@ -1033,7 +1033,7 @@ Sometimes it may be necessary to reset a node (wipe all of its data) and later m
 Generally speaking, there are two possible scenarios: when the node is running, and when the node cannot start
 or won't respond to CLI tool commands e.g. due to an issue such as [ERL-430](https://bugs.erlang.org/browse/ERL-430).
 
-Resetting a node will delete all of its data, cluster membership information, configured [runtime parameters](/parameters.html),
+Resetting a node will delete all of its data, cluster membership information, configured [runtime parameters](./parameters.html),
 users, virtual hosts and any other node data. It will also permanently remove the node from its cluster.
 
 To reset a running and responsive node, first stop RabbitMQ on it using `rabbitmqctl stop_app`
@@ -1048,7 +1048,7 @@ rabbitmqctl reset
 </pre>
 
 In case of a non-responsive node, it must be stopped first using any means necessary.
-For nodes that fail to start this is already the case. Then [override](/relocate.html)
+For nodes that fail to start this is already the case. Then [override](./relocate.html)
 the node's data directory location or [re]move the existing data store. This will make the node
 start as a blank one. It will have to be instructed to [rejoin its original cluster](#cluster-formation), if any.
 
@@ -1059,7 +1059,7 @@ Non-replicated queue contents on a reset node will be lost.
 
 ## <a id="upgrading" class="anchor" href="#upgrading">Upgrading clusters</a>
 You can find instructions for upgrading a cluster in
-[the upgrade guide](/upgrade.html#rabbitmq-cluster-configuration).
+[the upgrade guide](./upgrade.html#rabbitmq-cluster-configuration).
 
 
 ## <a id="single-machine" class="anchor" href="#single-machine">A Cluster on a Single Machine</a>
@@ -1077,9 +1077,9 @@ locations, and bind to different ports, including those
 used by plugins. See `RABBITMQ_NODENAME`,
 `RABBITMQ_NODE_PORT`, and
 `RABBITMQ_DIST_PORT` in the [Configuration
-guide](/configure.html#supported-environment-variables), as well as `RABBITMQ_MNESIA_DIR`,
+guide](./configure.html#supported-environment-variables), as well as `RABBITMQ_MNESIA_DIR`,
 `RABBITMQ_CONFIG_FILE`, and
-`RABBITMQ_LOG_BASE` in the [File and Directory Locations guide](/relocate.html).
+`RABBITMQ_LOG_BASE` in the [File and Directory Locations guide](./relocate.html).
 
 You can start multiple nodes on the same host manually by
 repeated invocation of `rabbitmq-server` (
@@ -1133,7 +1133,7 @@ defaults to the short name), and that full hostname is resolvable using DNS,
 you may want to investigate setting the environment variable
 `RABBITMQ_USE_LONGNAME=true`.
 
-See the section on [hostname resolution](/clustering.html#hostname-resolution-requirement) for more information.
+See the section on [hostname resolution](./clustering.html#hostname-resolution-requirement) for more information.
 
 
 ## <a id="firewall" class="anchor" href="#firewall">Firewalled Nodes</a>
@@ -1148,7 +1148,7 @@ Learn more in the [section on ports](#ports) above and dedicated [RabbitMQ Netwo
 
 ## <a id="erlang" class="anchor" href="#erlang">Erlang Versions Across the Cluster</a>
 
-All nodes in a cluster are *highly recommended* to run the same major [version of Erlang](/which-erlang.html): `22.2.0`
+All nodes in a cluster are *highly recommended* to run the same major [version of Erlang](./which-erlang.html): `22.2.0`
 and `22.2.8` can be mixed but `21.3.6` and `22.2.6` can potentially introduce breaking changes in
 inter-node communication protocols. While such breaking changes are relatively rare, they are possible.
 

--- a/site/configure.md
+++ b/site/configure.md
@@ -64,11 +64,11 @@ for different areas:
       contains server and plugin settings for
 
       <ul>
-        <li><a href="/networking.html">TCP listeners and other networking-related settings</a></li>
-        <li><a href="/ssl.html">TLS</a></li>
-        <li><a href="/alarms.html">resource constraints (alarms)</a></li>
-        <li><a href="/access-control.html">authentication and authorisation backends</a></li>
-        <li><a href="/persistence-conf.html">message store settings</a></li>
+        <li><a href="./networking.html">TCP listeners and other networking-related settings</a></li>
+        <li><a href="./ssl.html">TLS</a></li>
+        <li><a href="./alarms.html">resource constraints (alarms)</a></li>
+        <li><a href="./access-control.html">authentication and authorisation backends</a></li>
+        <li><a href="./persistence-conf.html">message store settings</a></li>
       </ul>
 
       and so on.
@@ -79,7 +79,7 @@ for different areas:
       <a href="#customise-environment">Environment Variables</a>
     </td>
     <td>
-      define <a href="/cli.html#node-names">node name</a>, file and directory locations, runtime flags taken from the shell, or set in
+      define <a href="./cli.html#node-names">node name</a>, file and directory locations, runtime flags taken from the shell, or set in
       the environment configuration file, <code>rabbitmq-env.conf</code> (Linux, MacOS, BSD)
       and <code>rabbitmq-env-conf.bat</code> (Windows)
     </td>
@@ -87,40 +87,40 @@ for different areas:
 
   <tr>
     <td>
-      <a href="/cli.html">rabbitmqctl</a>
+      <a href="./cli.html">rabbitmqctl</a>
     </td>
     <td>
-      When <a href="/access-control.html">internal authentication/authorisation backend</a> is used,
+      When <a href="./access-control.html">internal authentication/authorisation backend</a> is used,
       <code>rabbitmqctl</code> is the tool that manages virtual hosts, users and permissions. It
-      is also used to manage <a href="/parameters.html">runtime parameters and policies</a>.
+      is also used to manage <a href="./parameters.html">runtime parameters and policies</a>.
     </td>
   </tr>
 
   <tr>
     <td>
-      <a href="/cli.html">rabbitmq-queues</a>
+      <a href="./cli.html">rabbitmq-queues</a>
     </td>
     <td>
-      <code>rabbitmq-queues</code> is the tool that manages settings specific to <a href="/quorum-queues.html">quorum queues</a>.
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <a href="/cli.html">rabbitmq-plugins</a>
-    </td>
-    <td>
-      <code>rabbitmq-plugins</code> is the tool that manages <a href="/plugins.html">plugins</a>.
+      <code>rabbitmq-queues</code> is the tool that manages settings specific to <a href="./quorum-queues.html">quorum queues</a>.
     </td>
   </tr>
 
   <tr>
     <td>
-      <a href="/cli.html">rabbitmq-diagnostics</a>
+      <a href="./cli.html">rabbitmq-plugins</a>
+    </td>
+    <td>
+      <code>rabbitmq-plugins</code> is the tool that manages <a href="./plugins.html">plugins</a>.
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="./cli.html">rabbitmq-diagnostics</a>
     </td>
     <td>
       <code>rabbitmq-diagnostics</code> allows for inspection of node state, including effective configuration,
-      as well as many other metrics and <a href="/monitoring.html">health checks</a>.
+      as well as many other metrics and <a href="./monitoring.html">health checks</a>.
     </td>
   </tr>
 
@@ -150,7 +150,7 @@ for different areas:
       <a href="#kernel-limits">Operating System Kernel Limits</a>
     </td>
     <td>
-      Control process limits enforced by the kernel: <a href="/networking.html#open-file-handle-limit">max open file handle limit</a>,
+      Control process limits enforced by the kernel: <a href="./networking.html#open-file-handle-limit">max open file handle limit</a>,
       max number of processes and kernel threads, max resident set size and so on.
     </td>
   </tr>
@@ -273,7 +273,7 @@ cannot express. This is covered in more detail in the following sections.
       <td>Classic (Erlang terms)</td>
       <td>
         A limited number of settings that cannot be expressed
-        in the new style configuration format, such as <a href="/ldap.html">LDAP queries</a>.
+        in the new style configuration format, such as <a href="./ldap.html">LDAP queries</a>.
         Only should be used when necessary.
       </td>
     </tr>
@@ -417,7 +417,7 @@ any configuration files. Users and deployment tool should use the following loca
   <tbody>
     <tr>
       <td>
-        <a href="/install-generic-unix.html">Generic binary package</a>
+        <a href="./install-generic-unix.html">Generic binary package</a>
       </td>
       <td>
         <code>$RABBITMQ_HOME/etc/rabbitmq/</code>
@@ -428,7 +428,7 @@ any configuration files. Users and deployment tool should use the following loca
       </td>
     </tr>
     <tr>
-      <td><a href="/install-debian.html">Debian and Ubuntu</a></td>
+      <td><a href="./install-debian.html">Debian and Ubuntu</a></td>
       <td>
         <code>/etc/rabbitmq/</code>
       </td>
@@ -438,7 +438,7 @@ any configuration files. Users and deployment tool should use the following loca
       </td>
     </tr>
     <tr>
-      <td><a href="/install-rpm.html">RPM-based Linux</a></td>
+      <td><a href="./install-rpm.html">RPM-based Linux</a></td>
       <td>
         <code>/etc/rabbitmq/</code>
       </td>
@@ -448,7 +448,7 @@ any configuration files. Users and deployment tool should use the following loca
       </td>
     </tr>
     <tr>
-      <td><a href="/install-windows.html">Windows</a></td>
+      <td><a href="./install-windows.html">Windows</a></td>
       <td>
         <code>%APPDATA%\RabbitMQ\</code>
       </td>
@@ -458,7 +458,7 @@ any configuration files. Users and deployment tool should use the following loca
       </td>
     </tr>
     <tr>
-      <td><a href="/install-homebrew.html">MacOS Homebrew Formula</a></td>
+      <td><a href="./install-homebrew.html">MacOS Homebrew Formula</a></td>
       <td>
         <code>${install_prefix}/etc/rabbitmq/</code>,
         and the Homebrew cellar prefix is usually <code>/usr/local</code>
@@ -588,7 +588,7 @@ some settings are quite obscure.
     <td><code>listeners</code></td>
     <td>
       Ports or hostname/pair on which to listen for "plain" AMQP 0-9-1 and AMQP 1.0 connections
-      (without <a href="/ssl.html">TLS</a>). See the <a href="/networking.html">Networking guide</a> for more
+      (without <a href="./ssl.html">TLS</a>). See the <a href="./networking.html">Networking guide</a> for more
       details and examples.
 
       <p>
@@ -629,7 +629,7 @@ handshake_timeout = 10000
     <td><code>listeners.ssl</code></td>
     <td>
       Ports or hostname/pair on which to listen for TLS-enabled AMQP 0-9-1 and AMQP 1.0 connections.
-      See the <a href="/ssl.html">TLS guide</a> for more
+      See the <a href="./ssl.html">TLS guide</a> for more
       details and examples.
       <p>Default: <code>none</code> (not set)</p>
     </td>
@@ -840,7 +840,7 @@ channel_operation_timeout = 15000
       Value representing the heartbeat timeout suggested by the server during
       connection parameter negotiation.
       If set to 0 on both ends, heartbeats are disabled (this is not recommended).
-      See the <a href="/heartbeats.html">Heartbeats guide</a> for details.
+      See the <a href="./heartbeats.html">Heartbeats guide</a> for details.
 
       <p>
         Default:
@@ -926,7 +926,7 @@ default_permissions.write = .*
 
       <p>
         To allow the default `guest`
-        user to connect remotely (a security practice <a href="/production-checklist.html">unsuitable for production use</a>),
+        user to connect remotely (a security practice <a href="./production-checklist.html">unsuitable for production use</a>),
         set this to `none`:
 
 <pre class="lang-ini">
@@ -958,7 +958,7 @@ loopback_users.guest = true
   <tr>
     <td><code>cluster_formation.classic_config.nodes</code></td>
     <td>
-      Classic <a href="/cluster-formation.html">peer discovery</a> backend's list of nodes to contact.
+      Classic <a href="./cluster-formation.html">peer discovery</a> backend's list of nodes to contact.
 
       For example, to cluster with nodes `rabbit@hostname1` and `rabbit@hostname2` on first boot:
 
@@ -1036,8 +1036,8 @@ auth_mechanisms.2 = AMQPLAIN
     <td><code>auth_backends</code></td>
     <td>
       <p>
-        List of <a href="/access-control.html">authentication and authorisation backends</a> to
-        use. See the <a href="/access-control.html">access control guide</a> for details and examples.
+        List of <a href="./access-control.html">authentication and authorisation backends</a> to
+        use. See the <a href="./access-control.html">access control guide</a> for details and examples.
       </p>
       <p>
         Other databases
@@ -1184,7 +1184,7 @@ mnesia_table_loading_retry_limit = 10
     <td><code>mirroring_sync_batch_size</code></td>
     <td>
       Batch size used to transfer messages to an unsynchronised replica (queue mirror).
-      See <a href="/ha.html#batch-sync">documentation on eager batch synchronization</a>.
+      See <a href="./ha.html#batch-sync">documentation on eager batch synchronization</a>.
       <p>
         Default:
 <pre class="lang-ini">
@@ -1204,7 +1204,7 @@ mirroring_sync_batch_size = 4096
         <li><code>random</code></li>
       </ul>
       See the
-      <a href="/ha.html#queue-master-location">documentation
+      <a href="./ha.html#queue-master-location">documentation
       on queue leader location</a> for more information.
       <p>
         Default:
@@ -1673,7 +1673,7 @@ More variables are covered in the [File and Directory Locations guide](./relocat
   <tr>
     <td>RABBITMQ_NODE_PORT</td>
     <td>
-      See <a href="/networking.html">Networking guide</a> for more information on ports used by various
+      See <a href="./networking.html">Networking guide</a> for more information on ports used by various
       parts of RabbitMQ.
 
       <p>
@@ -1688,8 +1688,8 @@ More variables are covered in the [File and Directory Locations guide](./relocat
       Port used for inter-node and CLI tool communication. Ignored if node config
       file sets <code>kernel.inet_dist_listen_min</code> or
       <code>kernel.inet_dist_listen_max</code> keys.
-      See <a href="/networking.html">Networking</a> for details, and
-      <a href="/windows-quirks.html">Windows Quirks</a> for Windows-specific details.
+      See <a href="./networking.html">Networking</a> for details, and
+      <a href="./windows-quirks.html">Windows Quirks</a> for Windows-specific details.
 
       <p>
         <strong>Default</strong>: <code>RABBITMQ_NODE_PORT + 20000</code>
@@ -1700,7 +1700,7 @@ More variables are covered in the [File and Directory Locations guide](./relocat
   <tr>
     <td>ERL_EPMD_ADDRESS</td>
     <td>
-      Interface(s) used by <a href="/networking.html#epmd">epmd</a>, a component in inter-node and CLI tool communication.
+      Interface(s) used by <a href="./networking.html#epmd">epmd</a>, a component in inter-node and CLI tool communication.
 
       <p>
         <strong>Default</strong>: all available interfaces, both IPv6 and IPv4.
@@ -1711,7 +1711,7 @@ More variables are covered in the [File and Directory Locations guide](./relocat
   <tr>
     <td>ERL_EPMD_PORT</td>
     <td>
-      Port used by <a href="/networking.html#epmd">epmd</a>, a component in inter-node and CLI tool communication.
+      Port used by <a href="./networking.html#epmd">epmd</a>, a component in inter-node and CLI tool communication.
 
       <p>
         <strong>Default</strong>: <code>4369</code>
@@ -1736,7 +1736,7 @@ More variables are covered in the [File and Directory Locations guide](./relocat
     <td>RABBITMQ_NODENAME</td>
     <td>
       The node name should be unique per Erlang-node-and-machine combination.
-      To run multiple nodes, see the <a href="/clustering.html">clustering guide</a>.
+      To run multiple nodes, see the <a href="./clustering.html">clustering guide</a>.
 
       <p>
         <strong>Default</strong>:
@@ -1909,7 +1909,7 @@ More variables are covered in the [File and Directory Locations guide](./relocat
     <td>RABBITMQ_PLUGINS_DIR</td>
     <td>
       The list of directories where <a
-      href="/plugins.html">plugin</a> archive files are located and extracted
+      href="./plugins.html">plugin</a> archive files are located and extracted
       from. This is <code>PATH</code>-like variable, where
       different paths are separated by an OS-specific separator
       (<code>:</code> for Unix, <code>;</code> for Windows).
@@ -1936,7 +1936,7 @@ More variables are covered in the [File and Directory Locations guide](./relocat
   <tr>
     <td>RABBITMQ_PLUGINS_EXPAND_DIR</td>
     <td>
-      The directory the node expand (unpack) <a href="/plugins.html">plugins</a> to and use it as a code path location.
+      The directory the node expand (unpack) <a href="./plugins.html">plugins</a> to and use it as a code path location.
       Must not contain any characters mentioned in the <a href="#directory-and-path-restrictions">path restriction section</a>.
 
       <p>

--- a/site/configure.md
+++ b/site/configure.md
@@ -21,8 +21,8 @@ limitations under the License.
 
 RabbitMQ comes with default built-in settings. Those can be entirely
 sufficient in some environment (e.g. development and QA).
-For all other cases, as well as [production deployment tuning](/production-checklist.html),
-there is a way to configure many things in the broker as well as [plugins](/plugins.html).
+For all other cases, as well as [production deployment tuning](./production-checklist.html),
+there is a way to configure many things in the broker as well as [plugins](./plugins.html).
 
 This guide covers a number of topics related to configuration:
 
@@ -38,9 +38,9 @@ This guide covers a number of topics related to configuration:
 
 and more.
 
-Since configuration affects many areas of the system, including plugins, individual [documentation guides](/documentation.html)
-dive deeper into what can be configured. [Runtime Tuning](/runtime.html) is a companion to this guide that focuses
-on the configurable parameters in the runtime. [Production Checklist](/production-checklist.html) is a related guide
+Since configuration affects many areas of the system, including plugins, individual [documentation guides](./documentation.html)
+dive deeper into what can be configured. [Runtime Tuning](./runtime.html) is a companion to this guide that focuses
+on the configurable parameters in the runtime. [Production Checklist](./production-checklist.html) is a related guide
 that outlines what settings will likely need tuning in most production environments.
 
 
@@ -174,8 +174,8 @@ where to find examples, and more.
 
 ### <a id="config-file-location" class="anchor" href="#config-file-location">Config File Locations</a>
 
-[Default config file locations](/configure.html#config-location)
-vary between operating systems and [package types](/download.html).
+[Default config file locations](./configure.html#config-location)
+vary between operating systems and [package types](./download.html).
 
 This topic is covered in more detail in the rest of this guide.
 
@@ -204,7 +204,7 @@ home dir       : /var/lib/rabbitmq
 config file(s) : /var/lib/rabbitmq/hare.conf (not found)
 </pre>
 
-Alternatively, the location of configuration files used by a local node, use the [rabbitmq-diagnostics status](/rabbitmq-diagnostics.8.html) command:
+Alternatively, the location of configuration files used by a local node, use the [rabbitmq-diagnostics status](./rabbitmq-diagnostics.8.html) command:
 
 <pre class="lang-bash">
 # displays key
@@ -226,7 +226,7 @@ To inspect the locations of a specific node, including nodes running remotely, u
 rabbitmq-diagnostics status -n [node name]
 </pre>
 
-Finally, config file location can be found in the [management UI](/management.html),
+Finally, config file location can be found in the [management UI](./management.html),
 together with other details about nodes.
 
 When troubleshooting configuration settings, it is very useful to verify that the config file
@@ -235,13 +235,13 @@ Together, these steps help quickly narrow down most common misconfiguration prob
 
 ### <a id="config-file-formats" class="anchor" href="#config-file-formats">The New and Old Config File Formats</a>
 
-All [supported RabbitMQ versions](/versions.html) use an [ini-like, sysctl configuration file format](#config-file)
+All [supported RabbitMQ versions](./versions.html) use an [ini-like, sysctl configuration file format](#config-file)
 for the main configuration file. The file is typically named `rabbitmq.conf`.
 
 The new config format is much simpler, easier for humans to read
 and machines to generate. It is also relatively limited compared
 to the classic config format used prior to RabbitMQ 3.7.0.
-For example, when configuring [LDAP support](/ldap.html), it may be necessary to use deeply nested data structures to
+For example, when configuring [LDAP support](./ldap.html), it may be necessary to use deeply nested data structures to
 express desired configuration.
 
 To accommodate this need, modern RabbitMQ versions allow for both formats to be used at the same time
@@ -342,7 +342,7 @@ The same example in the <a href="#config-file-formats">classic config format</a>
 ].
 </pre>
 
-This example will alter the [port RabbitMQ listens on](/networking.html#ports) for
+This example will alter the [port RabbitMQ listens on](./networking.html#ports) for
 AMQP 0-9-1 and AMQP 1.0 client connections from 5672 to 5673.
 
 The RabbitMQ server source repository contains [an example rabbitmq.conf file](https://github.com/rabbitmq/rabbitmq-server/blob/v3.8.x/deps/rabbit/docs/rabbitmq.conf.example)
@@ -350,8 +350,8 @@ named `rabbitmq.conf.example`. It contains examples of
 most of the configuration items you might want to set (with some very obscure ones omitted), along with
 documentation for those settings.
 
-Documentation guides such as [Networking](networking.html), [TLS](/ssl.html), or
-[Access Control](/access-control.html) contain many examples in relevant formats.
+Documentation guides such as [Networking](networking.html), [TLS](./ssl.html), or
+[Access Control](./access-control.html) contain many examples in relevant formats.
 
 Note that this configuration file is not to be confused with the environment variable
 configuration files, [rabbitmq-env.conf](#environment-env-file-unix)
@@ -504,7 +504,7 @@ This would help avoid unnecessary confusion and Windows service re-installations
 ### <a id="verify-configuration-effective-configuration" class="anchor" href="#verify-configuration-effective-configuration">How to Inspect and Verify Effective Configuration of a Running Node</a>
 
 It is possible to print effective configuration (user provided values from all configuration files merged into defaults) using
-the [rabbitmq-diagnostics environment](/rabbitmq-diagnostics.8.html) command:
+the [rabbitmq-diagnostics environment](./rabbitmq-diagnostics.8.html) command:
 
 <pre class="lang-bash">
 # inspect effective configuration on a node
@@ -1418,16 +1418,16 @@ under the `rabbit` section.
   </tr>
 </table>
 
-Several [plugins](/plugins.html) that ship with RabbitMQ have
+Several [plugins](./plugins.html) that ship with RabbitMQ have
 dedicated documentation guides that cover plugin configuration:
 
- * [rabbitmq_management](/management.html#configuration)
- * [rabbitmq_management_agent](/management.html#configuration)
- * [rabbitmq_stomp](/stomp.html)
- * [rabbitmq_mqtt](/mqtt.html)
+ * [rabbitmq_management](./management.html#configuration)
+ * [rabbitmq_management_agent](./management.html#configuration)
+ * [rabbitmq_stomp](./stomp.html)
+ * [rabbitmq_mqtt](./mqtt.html)
  * [rabbitmq_shovel](shovel.html)
  * [rabbitmq_federation](federation.html)
- * [rabbitmq_auth_backend_ldap](/ldap.html)
+ * [rabbitmq_auth_backend_ldap](./ldap.html)
 
 ### <a id="configuration-encryption" class="anchor" href="#configuration-encryption">Configuration Value Encryption</a>
 
@@ -1483,7 +1483,7 @@ it can be in a separate file:
 RabbitMQ can also request an operator to enter the passphrase
 when it starts by using `{passphrase, prompt}`.
 
-Use [rabbitmqctl](/cli.html) and the `encode`
+Use [rabbitmqctl](./cli.html) and the `encode`
 command to encrypt values:
 
 <pre class="lang-bash">
@@ -1544,7 +1544,7 @@ These defaults can be changed in the configuration file:
     ]}
 ].</pre>
 
-Or using [CLI tools](/cli.html):
+Or using [CLI tools](./cli.html):
 
 <pre class="lang-bash">
 rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 \
@@ -1562,12 +1562,12 @@ rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 \
 ## <a id="customise-environment" class="anchor" href="#customise-environment">Configuration Using Environment Variables</a>
 
 Certain server parameters can be configured using environment variables:
-[node name](/cli.html#node-names), RabbitMQ [configuration file location](#configuration-files),
-[inter-node communication ports](/networking.html#ports), Erlang VM flags, and so on.
+[node name](./cli.html#node-names), RabbitMQ [configuration file location](#configuration-files),
+[inter-node communication ports](./networking.html#ports), Erlang VM flags, and so on.
 
 ### <a id="directory-and-path-restrictions" class="anchor" href="#directory-and-path-restrictions">Path and Directory Name Restrictions</a>
 
-Some of the environment variable configure paths and locations (node's base or data directory, [plugin source and expansion directories](/plugins.html),
+Some of the environment variable configure paths and locations (node's base or data directory, [plugin source and expansion directories](./plugins.html),
 and so on). Those paths have must exclude a number of characters:
 
  * `*` and `?` (on Linux, macOS, BSD and other UNIX-like systems)
@@ -1650,7 +1650,7 @@ in [rabbitmq-env.conf](#environment-env-file-unix) or
 RabbitMQ built-in defaults.
 
 The table below describes key environment variables that can be used to configure RabbitMQ.
-More variables are covered in the [File and Directory Locations guide](/relocate.html).
+More variables are covered in the [File and Directory Locations guide](./relocate.html).
 
 <table class="name-description">
   <tr>
@@ -2192,9 +2192,9 @@ Finally, some environment variables are operating system-specific.
 Most operating systems enforce limits on kernel resources: virtual memory, stack size, open file handles
 and more. To Linux users these limits can be known as "ulimit limits".
 
-RabbitMQ nodes are most commonly affected by the maximum [open file handle limit](/networking.html#open-file-handle-limit).
+RabbitMQ nodes are most commonly affected by the maximum [open file handle limit](./networking.html#open-file-handle-limit).
 Default limit value on most Linux distributions is usually 1024, which is very low for a messaging broker (or generally, any data service).
-See [Production Checklist](/production-checklist.html) for recommended values.
+See [Production Checklist](./production-checklist.html) for recommended values.
 
 ### Modifying Limits
 

--- a/site/confirms.md
+++ b/site/confirms.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers two related features related to [data safety](/reliability.html), consumer Acknowledgements
+This guide covers two related features related to [data safety](./reliability.html), consumer Acknowledgements
 and publisher confirms:
 
  * [Why acknowledgements exist](#basics)
@@ -33,7 +33,7 @@ and publisher confirms:
 and more. Acknowledgements on both consumer and publisher side are important for
 data safety in applications that use messaging.
 
-More related topics are covered in the [Publisher](/publishers.html) and [Consumer](/consumers.html) guides.
+More related topics are covered in the [Publisher](./publishers.html) and [Consumer](./consumers.html) guides.
 
 
 ## <a id="basics" class="anchor" href="#basics">The Basics</a>
@@ -47,9 +47,9 @@ protocols supported by RabbitMQ provide such features.
 This guide covers the features in AMQP 0-9-1 but the idea
 is largely the same in other supported protocols.
 
-Delivery processing acknowledgements from [consumers](/consumers.html) to RabbitMQ
+Delivery processing acknowledgements from [consumers](./consumers.html) to RabbitMQ
 are known as acknowledgements in messaging protocols; broker
-acknowledgements to [publishers](/publishers.html) are a protocol extension called
+acknowledgements to [publishers](./publishers.html) are a protocol extension called
 [publisher confirms](#publisher-confirms).
 Both features build on the same idea and are inspired by TCP.
 
@@ -69,7 +69,7 @@ the `basic.consume` method or a message is fetched on demand
 with the `basic.get` method.
 
 If you prefer a more example-oriented and step-by-step material, consumer acknowledgements are
-also covered in [RabbitMQ tutorial #2](/getstarted.html).
+also covered in [RabbitMQ tutorial #2](./getstarted.html).
 
 ### <a id="consumer-acks-delivery-tags" class="anchor" href="#consumer-acks-delivery-tags">Delivery Identifiers: Delivery Tags</a>
 
@@ -108,7 +108,7 @@ or when an explicit ("manual") client acknowledgement is received. Manually sent
 acknowledgements can be positive or negative and use one of the following protocol methods:
 
  * `basic.ack` is used for positive acknowledgements
- * `basic.nack` is used for negative acknowledgements (note: this is a [RabbitMQ extension to AMQP 0-9-1](/nack.html))
+ * `basic.nack` is used for negative acknowledgements (note: this is a [RabbitMQ extension to AMQP 0-9-1](./nack.html))
  * `basic.reject` is used for negative acknowledgements but has one limitation compared to `basic.nack`
 
 How these methods are exposed in client library APIs will be discussed below.
@@ -256,7 +256,7 @@ The methods are generally used to negatively acknowledge a delivery. Such delive
 be discarded or dead-lettered or requeued by the broker. This behaviour is controlled by the `requeue` field.
 When the field is set to `true`, the broker will requeue the delivery (or multiple
 deliveries, as will be explained shortly) with the specified delivery tag.
-Alternatively, when this field is set to `false`, the message will be routed to a [Dead Letter Exchange](/dlx.html) if it
+Alternatively, when this field is set to `false`, the message will be routed to a [Dead Letter Exchange](./dlx.html) if it
 is configured, otherwise it will be discarded.
 
 Both methods are usually exposed as operations on a channel in client libraries. Java
@@ -429,7 +429,7 @@ prefetch count unacknowledged messages on a channel.
 #### Per-channel, Per-consumer and Global Prefetch
 
 The QoS setting can be configured for a specific channel or a specific consumer.
-The [Consumer Prefetch](/consumer-prefetch.html) guide explains
+The [Consumer Prefetch](./consumer-prefetch.html) guide explains
 the effects of this scoping.
 
 #### Prefetch and Polling Consumers
@@ -470,7 +470,7 @@ is closed. This includes TCP connection loss by clients,
 consumer application (process) failures, and channel-level
 protocol exceptions (covered below).
 
-Note that it takes a period of time to [detect an unavailable client](/heartbeats.html).
+Note that it takes a period of time to [detect an unavailable client](./heartbeats.html).
 
 Due to this behavior, consumers must be prepared to handle redeliveries and otherwise
 be implemented with [idempotence](https://en.wikipedia.org/wiki/Idempotence) in mind.
@@ -492,7 +492,7 @@ channel.
 
 ## <a id="publisher-confirms" class="anchor" href="#publisher-confirms">Publisher Confirms</a>
 
-Networks can fail in less-than-obvious ways and detecting some failures [takes time](/heartbeats.html).
+Networks can fail in less-than-obvious ways and detecting some failures [takes time](./heartbeats.html).
 Therefore a client that's written a protocol frame or a set of frames (e.g. a published message) to
 its socket cannot assume that the message has reached the server and was successfully processed.
 It could have been lost along the way or its delivery can be significantly delayed.

--- a/site/connection-blocked.md
+++ b/site/connection-blocked.md
@@ -20,7 +20,7 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 It is sometimes desirable for clients to receive a notification
-when their connection gets [blocked](/alarms.html)
+when their connection gets [blocked](./alarms.html)
 due to the broker running low on resources (memory or disk).
 
 We have introduced an AMQP 0-9-1 protocol extension in which the
@@ -31,7 +31,7 @@ To receive these notifications, the client must present a
 `capabilities` table in its `client-properties` in which there is a key
 `connection.blocked` and a boolean value `true`.
 
-See the [capabilities](/connections.html#capabilities) section for further
+See the [capabilities](./connections.html#capabilities) section for further
 details on this. Our supported clients indicate this capability
 by default and provide a way to register handlers for the
 `connection.blocked` and `connection.unblocked` methods.
@@ -55,7 +55,7 @@ unblocked.
 
 ## <a id="java" class="anchor" href="#java">Using Blocked Connection Notifications with Java Client</a>
 
-With the [official Java client](/api-guide.html), blocked connection
+With the [official Java client](./api-guide.html), blocked connection
 notifications are handled by `BlockedListener`
 interface implementations. They can be registered on a
 `Connection` using the
@@ -78,7 +78,7 @@ connection.addBlockedListener(new BlockedListener() {
 
 ## <a id="dotnet" class="anchor" href="#dotnet">Using Blocked Connection Notifications with .NET Client</a>
 
-With the [official .NET client](/dotnet-api-guide.html), blocked connection
+With the [official .NET client](./dotnet-api-guide.html), blocked connection
 notifications can be received by registering for the
 `ConnectionBlocked` and `ConnectionUnblocked` events in `IConnection`:
 

--- a/site/connections.md
+++ b/site/connections.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 This guide covers various topics related to connections except for
 network tuning or most networking-related topics. Those
-are covered by the [Networking](networking.html) and [Troubleshooting Networking](/troubleshooting-networking.html) guides.
+are covered by the [Networking](networking.html) and [Troubleshooting Networking](./troubleshooting-networking.html) guides.
 
 RabbitMQ supports several protocols:
 
@@ -57,7 +57,7 @@ and other topics related to connections.
 
 ## <a id="basics" class="anchor" href="#basics">The Basics</a>
 
-Applications interact with RabbitMQ using client libraries. There are [client libraries](/devtools.html)
+Applications interact with RabbitMQ using client libraries. There are [client libraries](./devtools.html)
 available for many programming languages and platforms.
 Each protocol has its own set of client libraries. Most client libraries are open source.
 
@@ -73,21 +73,21 @@ After a client [connects](#lifecycle) and successfully authenticates with a Rabb
 publish and consume messages, define topology and perform other operations that are provided in the protocol
 and supported both by the client library and the target RabbitMQ node.
 
-Since connections are meant to be long-lived, clients usually [consume messages](/consumers.html) by registering
+Since connections are meant to be long-lived, clients usually [consume messages](./consumers.html) by registering
 a subscription and having messages delivered (pushed) to them instead of polling.
 
 When a connection is no longer necessary, applications must close them to conserve resources.
 Apps that fail to do it run the risk of eventually exhausting its target node of resources.
 
-Operating systems have a [limit around how many TCP connections (sockets) a single process can have open](/networking.html#open-file-handle-limit)
+Operating systems have a [limit around how many TCP connections (sockets) a single process can have open](./networking.html#open-file-handle-limit)
 simultaneously. The limit is often sufficient for development and some QA environments.
-[Production environments](/production-checklist.html) must be configured to use a higher limit in order to support
+[Production environments](./production-checklist.html) must be configured to use a higher limit in order to support
 a larger number of concurrent client connections.
 
 ### Protocol Differences
 
 Different messaging protocols use different ports. Ports also vary for plain TCP and TLS-enabled connections.
-The [Networking guide](/networking.html#ports) covers all ports used by RabbitMQ depending on what protocols are enabled, whether TLS
+The [Networking guide](./networking.html#ports) covers all ports used by RabbitMQ depending on what protocols are enabled, whether TLS
 is used and so on.
 
 #### AMQP 0-9-1
@@ -113,8 +113,8 @@ involves a number of steps:
  * The library resolves the hostname to one or more IP addresses
  * The library opens a TCP connection to the target IP address and port
  * After the server has accepted the TCP connection, protocol-specific negotiation procedure is performed
- * The server then [authenticates](/access-control.html) the client
- * The client now can perform operations, each of which involves an [authorisation check](/access-control.html) by the server.
+ * The server then [authenticates](./access-control.html) the client
+ * The client now can perform operations, each of which involves an [authorisation check](./access-control.html) by the server.
 
 This flow doesn't change significantly from protocol to protocol but there are minor differences.
 
@@ -122,7 +122,7 @@ This flow doesn't change significantly from protocol to protocol but there are m
 
 #### AMQP 0-9-1
 
-AMQP 0-9-1 has a [model](/tutorials/amqp-concepts.html) that includes connections and channels. Channels allow for
+AMQP 0-9-1 has a [model](./tutorials/amqp-concepts.html) that includes connections and channels. Channels allow for
 connection multiplexing (having multiple logical connections on a "physical" or TCP one).
 
 The maximum number of [channels](channels.html) that can be open on a connection simultaneously
@@ -160,13 +160,13 @@ checks from flooding the logs.
 
 Successful authentication, clean and unexpected connection closure will also be logged.
 
-This topic is covered in more detail in the [Logging guide](/logging.html#logged-events).
+This topic is covered in more detail in the [Logging guide](./logging.html#logged-events).
 
 
 ## <a id="monitoring" class="anchor" href="#monitoring">Monitoring</a>
 
 Number of currently open client connections and connection opening/closure rates are important metrics
-of the system that should be [monitored](/monitoring.html). Monitoring them will help detect a number of
+of the system that should be [monitored](./monitoring.html). Monitoring them will help detect a number of
 problems that are common in messaging-based system:
 
  * Connection leaks
@@ -179,13 +179,13 @@ Both problems eventually lead to node exhaustion of [resources](#resource-usage)
 A connection leak is a condition under which an application repeatedly opens connections without closing them,
 or at least closing only some of them.
 
-Connection leaks eventually exhaust the node (or multiple target nodes) of [file handles](/networking.html#open-file-handle-limit),
+Connection leaks eventually exhaust the node (or multiple target nodes) of [file handles](./networking.html#open-file-handle-limit),
 which means any new inbound client, peer or CLI tool connection will be rejected. A build-up in the number of concurrent
 connections also increases node's memory consumption.
 
 #### Relevant Metrics
 
-[Management UI](/management.html) provides a chart of the total number of connections opened cluster-wide:
+[Management UI](./management.html) provides a chart of the total number of connections opened cluster-wide:
 
 <img class="screenshot" src="img/monitoring/connections/mgmt-ui-global-connection-count.png" alt="Global connection count in management UI" title="Global connection count in management UI" />
 
@@ -204,14 +204,14 @@ This chart demonstrates a monotonically growing number of connections after a dr
 If the number of sockets used by a node keeps growing and growing, it is likely an indication
 of a connection leak in one of the applications.
 
-Some client libraries, [such as the Java client](/api-guide.html#metrics), expose metrics including the number of currently
+Some client libraries, [such as the Java client](./api-guide.html#metrics), expose metrics including the number of currently
 opened connections. Charting and monitoring application metrics around connections is the best way
 to identify what app leaks connections or uses them in a suboptimal way.
 
 In many applications that use long-lived connections and do not leak them the number of connections
 grows on application start and then moderates (stays mostly stable with little fluctuation).
 
-[Management UI](/management.html) provides a chart on the rate of newly opened connections as of [RabbitMQ 3.7.9](/changelog.html).
+[Management UI](./management.html) provides a chart on the rate of newly opened connections as of [RabbitMQ 3.7.9](./changelog.html).
 Below is a chart that demonstrates a fairly low new connection rate:
 
 <img class="screenshot" src="img/monitoring/connections/mgmt-ui-node-connection-churn.png" alt="Node connection churn in management UI" title="Node connection churn in management UI" />
@@ -224,7 +224,7 @@ its rate of closed connection is consistently high. This usually means that an a
 uses short lived connections. While with some workloads this scenario is difficult to avoid,
 long lived connections should be used instead when possible.
 
-RabbitMQ collects metrics on connection churn and exposes them via [Prometheus and Grafana](/prometheus.html) as well as [management UI](/management.html) churn rate chart.
+RabbitMQ collects metrics on connection churn and exposes them via [Prometheus and Grafana](./prometheus.html) as well as [management UI](./management.html) churn rate chart.
 Below is a chart that demonstrates a fairly low connection churn with a comparable number of connections open and closed
 in the given period of time:
 
@@ -239,7 +239,7 @@ Some clients and runtimes (notably PHP) do not use long-lived connections and hi
 churn rates are expected from them. A [specialized proxy](https://github.com/cloudamqp/amqproxy) should be
 used with those clients to mitigate the churn they naturally create.
 
-Environments that experience high connection churn require [TCP stack tuning to avoid resource exhaustion](/networking.html#dealing-with-high-connection-churn)
+Environments that experience high connection churn require [TCP stack tuning to avoid resource exhaustion](./networking.html#dealing-with-high-connection-churn)
 under churn.
 
 
@@ -247,11 +247,11 @@ under churn.
 
 Every connection consumes memory and one file handle on the target RabbitMQ node.
 
-Most of the memory is used by connection's TCP buffers. Their size can be [reduced](/networking.html#tuning-for-large-number-of-connections-tcp-buffer-size)
+Most of the memory is used by connection's TCP buffers. Their size can be [reduced](./networking.html#tuning-for-large-number-of-connections-tcp-buffer-size)
 significantly, which leads to significant per-connection memory consumption savings
 at the cost of a comparable reduction in connection throughput.
 
-The maximum number of file handles a RabbitMQ node can have open is [limited by the kernel](/networking.html#open-file-handle-limit) and must
+The maximum number of file handles a RabbitMQ node can have open is [limited by the kernel](./networking.html#open-file-handle-limit) and must
 be raised in order to support a large number of connections.
 
 
@@ -280,31 +280,31 @@ Increasing the interval value to 30-60s will reduce CPU footprint and peak memor
 This comes with a downside: with the value in the example above, metrics of said entities
 will refresh every 60 seconds.
 
-This can be perfectly reasonable in an [externally monitored](/monitoring.html#monitoring-frequency) production system
+This can be perfectly reasonable in an [externally monitored](./monitoring.html#monitoring-frequency) production system
 but will make management UI less convenient to use for operators.
 
-The [Networking guide](networking.html) has a section dedicated to [tuning for a large number of concurrent connections](/networking.html#tuning-for-large-number-of-connections).
+The [Networking guide](networking.html) has a section dedicated to [tuning for a large number of concurrent connections](./networking.html#tuning-for-large-number-of-connections).
 It explains how to reduce per-connection memory footprint.
 
 
 ## <a id="tls" class="anchor" href="#tls">TLS</a>
 
 Client connections can be encrypted with TLS. TLS also can be used as an additional
-or the primary way of authenticating clients. Learn more in the [TLS guide](/ssl.html).
+or the primary way of authenticating clients. Learn more in the [TLS guide](./ssl.html).
 
 
 ## <a id="flow-control" class="anchor" href="#flow-control">Flow Control</a>
 
 Connections that publish messages can outpace other parts of the system, most likely busy queues and queues
-that perform replication. When that happens, [flow control](/flow-control.html) is applied to
+that perform replication. When that happens, [flow control](./flow-control.html) is applied to
 publishing connections. Connections that only consume messages are not affected by the flow control
 applied to publishers.
 
-With slower consumers that use [automatic acknowledgement mode](/confirms.html#acknowledgement-modes)
+With slower consumers that use [automatic acknowledgement mode](./confirms.html#acknowledgement-modes)
 it is very likely that connections and channels will experience flow control when writing to
 the TCP socket.
 
-[Monitoring](/monitoring.html) systems can collect metrics on the number of connections in flow state.
+[Monitoring](./monitoring.html) systems can collect metrics on the number of connections in flow state.
 Applications that experience flow control regularly may consider to use separate connections
 to publish and consume to avoid flow control effects on non-publishing operations (e.g. queue management).
 
@@ -326,7 +326,7 @@ framing or connection state violations. For example, if a channel with the same 
 more than once. After sending an error to the client, the connection is closed.
 
 Errors that can be corrected and retried are communicated
-using [channel exceptions](/channels.html#error-handling) ("soft errors").
+using [channel exceptions](./channels.html#error-handling) ("soft errors").
 
 #### AMQP 1.0
 
@@ -353,7 +353,7 @@ This is a fundamental limitation of MQTT 3.1 design.
 Quite often MQTT clients are configured to automatically reconnect and retry operations, potentially
 creating loops of error triggering, connection storms and variations of the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
 
-With MQTT, inspecting [server logs](/logging.html) and [monitoring connections](#monitoring) is therefore of particular
+With MQTT, inspecting [server logs](./logging.html) and [monitoring connections](#monitoring) is therefore of particular
 importance.
 
 ## <a id="client-provided-names" class="anchor" href="#client-provided-names">Client-Provided Connection Name</a>
@@ -364,9 +364,9 @@ RabbitMQ nodes have a limited amount of information about their clients:
  * the credentials used
 
 This information alone can make identifying applications and instances problematic, in particular when credentials can be
-shared and clients connect over a load balancer but [Proxy protocol](/networking.html#proxy-protocol) cannot be enabled.
+shared and clients connect over a load balancer but [Proxy protocol](./networking.html#proxy-protocol) cannot be enabled.
 
-To make it easier to identify clients in [server logs](/logging.html) and [management UI](/management.html),
+To make it easier to identify clients in [server logs](./logging.html) and [management UI](./management.html),
 AMQP 0-9-1 client connections, including the RabbitMQ Java client, can provide a custom identifier.
 If set, the identifier will be mentioned in log entries and management UI. The identifier is known as
 the **client-provided connection name**. The name can be used to identify an application or a specific component
@@ -374,7 +374,7 @@ within an application. The name is optional; however, developers are strongly en
 as it would significantly simplify certain operational tasks.
 
 Connection name must be specified using the `"connection_name"` field in the [client capabilities table](#capabilities).
-Some client libraries, e.g. [Java](/api-guide.html#client-provided-names) and [.NET](/dotnet-api-guide.html#client-provided-names),
+Some client libraries, e.g. [Java](./api-guide.html#client-provided-names) and [.NET](./dotnet-api-guide.html#client-provided-names),
 provide more convenient ways of setting a custom name on a connection.
 
 ## <a id="capabilities" class="anchor" href="#capabilities">Client and Server Capabilities</a>
@@ -382,7 +382,7 @@ provide more convenient ways of setting a custom name on a connection.
 Some protocols, namely AMQP 0-9-1, provide for clients and servers to express
 their capabilities when opening a connection. This can be thought of as a
 table of optional features that specific versions of RabbitMQ and client libraries
-may or may not support. This mechanism is similar to [feature flags](/feature-flags.html)
+may or may not support. This mechanism is similar to [feature flags](./feature-flags.html)
 used by RabbitMQ nodes to determine what set of features is supported by all cluster
 members, and if a new member would be able to join the cluster.
 
@@ -408,18 +408,18 @@ actual table encoding is in a binary format and would not be human-friendly):
 
 The capabilities table for clients is optional: failure to present
 such a table does not preclude the client from being able to
-use extensions such as [exchange to exchange bindings](/e2e.html).
-However, in some cases such as [consumer cancellation notification](/consumer-cancel.html),
+use extensions such as [exchange to exchange bindings](./e2e.html).
+However, in some cases such as [consumer cancellation notification](./consumer-cancel.html),
 the client must present the associated capability, otherwise RabbitMQ nodes will have no
 way of knowing that the client is capable of receiving the additional notifications.
 
 ## <a id="automatic-recovery" class="anchor" href="#automatic-recovery">Recovery from Network Connection Failures</a>
 
 Client's TCP connection can fail or experience serious packet loss that would make RabbitMQ nodes
-consider them [unavailable](/heartbeats.html).
+consider them [unavailable](./heartbeats.html).
 
 Some client libraries provide a mechanism for automatic recovery from network connection failures.
-[RabbitMQ Java client](/api-guide.html#recovery) and [RabbitMQ .NET client](/dotnet-api-guide.html#recovery) support such feature, for example.
+[RabbitMQ Java client](./api-guide.html#recovery) and [RabbitMQ .NET client](./dotnet-api-guide.html#recovery) support such feature, for example.
 This feature is largely protocol- and client library-specific.
 
 Other clients may consider network failure recovery to be a responsibility of the application. In this

--- a/site/consumer-cancel.md
+++ b/site/consumer-cancel.md
@@ -41,7 +41,7 @@ asynchronously, and so in order to enable this behaviour,
 the client must present a `capabilities` table in
 its `client-properties` in which there is a key
 `consumer_cancel_notify` and a boolean value
-`true`. See the [section on capabilities](/connections.html#capabilities) for details.
+`true`. See the [section on capabilities](./connections.html#capabilities) for details.
 
 Our supported clients present this capability by default to
 the broker and thus will be sent the asynchronous

--- a/site/consumer-prefetch.md
+++ b/site/consumer-prefetch.md
@@ -19,10 +19,10 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-Consumer prefetch is an extension to the [channel prefetch mechanism](/confirms.html).
+Consumer prefetch is an extension to the [channel prefetch mechanism](./confirms.html).
 
 AMQP 0-9-1 specifies the `basic.qos` method to make it possible to
-[limit the number of unacknowledged messages](/confirms.html) on a channel (or
+[limit the number of unacknowledged messages](./confirms.html) on a channel (or
 connection) when consuming (aka "prefetch count"). Unfortunately
 the channel is not the ideal scope for this - since a single
 channel may consume from multiple queues, the channel and the

--- a/site/consumer-priority.md
+++ b/site/consumer-priority.md
@@ -48,7 +48,7 @@ Therefore for each queue, at least one of three things must be true:
 Note that consumers can switch between active and blocked many
 times per second. We therefore don't expose whether a consumer
 is active or blocked through the management plugin or
-[rabbitmqctl](/cli.html).
+[rabbitmqctl](./cli.html).
 
 When consumer priorities are in use, you can expect your highest
 priority consumers to receive all the messages until they become

--- a/site/consumers.md
+++ b/site/consumers.md
@@ -91,15 +91,15 @@ runs.
 
 Consumers can be more dynamic and register in reaction to a system event, unsubscribing
 when they are no longer necessary. This is common with WebSocket clients
-used via [Web STOMP](/web-stomp.html) and [Web MQTT](web-mqtt.html) plugins, mobile clients and so on.
+used via [Web STOMP](./web-stomp.html) and [Web MQTT](web-mqtt.html) plugins, mobile clients and so on.
 
 ### <a id="connection-recovery" class="anchor" href="#connection-recovery">Connection Recovery</a>
 
-Client can lose their connection to RabbitMQ. When connection loss is [detected](/heartbeats.html),
+Client can lose their connection to RabbitMQ. When connection loss is [detected](./heartbeats.html),
 message delivery stops.
 
 Some client libraries offer automatic connection recovery features that involves consumer recovery.
-[Java](/api-guide.html#recovery), [.NET](/dotnet-api-guide.html#recovery) and [Bunny](http://rubybunny.info/articles/error_handling.html)
+[Java](./api-guide.html#recovery), [.NET](./dotnet-api-guide.html#recovery) and [Bunny](http://rubybunny.info/articles/error_handling.html)
 are examples of such libraries.
 While connection recovery cannot cover 100% of scenarios and workloads, it generally works very well for consuming
 applications and is recommended.
@@ -130,11 +130,11 @@ It can later be used to cancel the consumer.
 
 ### Java Client
 
-See [Java client guide](/api-guide.html#consuming) for examples.
+See [Java client guide](./api-guide.html#consuming) for examples.
 
 ### .NET Client
 
-See [.NET client guide](/dotnet-api-guide.html#consuming) for examples.
+See [.NET client guide](./dotnet-api-guide.html#consuming) for examples.
 
 ### <a id="message-properties" class="anchor" href="#message-properties">Message Properties and Delivery Metadata</a>
 
@@ -312,7 +312,7 @@ When registering a consumer applications can choose one of two delivery modes:
  * Automatic (deliveries require no acknowledgement, a.k.a. "fire and forget")
  * Manual (deliveries require client acknowledgement)
 
-Consumer acknowledgements are a subject of a [separate documentation guide](/confirms.html), together with
+Consumer acknowledgements are a subject of a [separate documentation guide](./confirms.html), together with
 publisher confirms, a closely related concept for publishers.
 
 ## <a id="prefetch" class="anchor" href="#prefetch">Limiting Simultaneous Deliveries with Prefetch</a>
@@ -320,12 +320,12 @@ publisher confirms, a closely related concept for publishers.
 With manual acknowledgement mode consumers have a way of limiting how many deliveries can be "in flight" (in transit
 over the network or delivered but unacknowledged). This can avoid consumer overload.
 
-This feature, together with consumer acknowledgements are a subject of a [separate documentation guide](/confirms.html).
+This feature, together with consumer acknowledgements are a subject of a [separate documentation guide](./confirms.html).
 
 
 ## <a id="metrics-capacity" class="anchor" href="#metrics-capacity">The Consumer Capacity Metric</a>
 
-RabbitMQ [management UI](/management.html) as well as [monitoring data](/monitoring.html) endpoints such as that for [Prometheus scraping](/prometheus.html)
+RabbitMQ [management UI](./management.html) as well as [monitoring data](./monitoring.html) endpoints such as that for [Prometheus scraping](./prometheus.html)
 display a metric called consumer capacity (previously consumer utilisation) for individual queues.
 
 The metric is computed as a fraction of the time that the queue is able to immediately deliver messages to consumers.
@@ -355,11 +355,11 @@ Cancelling a consumer will not discard them.
 
 ### Java Client
 
-See [Java client guide](/api-guide.html#consuming) for examples.
+See [Java client guide](./api-guide.html#consuming) for examples.
 
 ### .NET Client
 
-See [.NET client guide](/dotnet-api-guide.html#consuming) for examples.
+See [.NET client guide](./dotnet-api-guide.html#consuming) for examples.
 
 ## <a id="fetching" class="anchor" href="#fetching">Fetching Individual Messages ("Pull API")</a>
 
@@ -376,11 +376,11 @@ When in doubt, prefer using a regular long-lived consumer.
 
 ### Java Client
 
-See [Java client guide](/api-guide.html#getting) for examples.
+See [Java client guide](./api-guide.html#getting) for examples.
 
 ### .NET Client
 
-See [.NET client guide](/dotnet-api-guide.html#basic-get) for examples.
+See [.NET client guide](./dotnet-api-guide.html#basic-get) for examples.
 
 
 ## <a id="acknowledgement-timeout" class="anchor" href="#acknowledgement-timeout">Delivery Acknowledgement Timeout</a>
@@ -474,8 +474,8 @@ Consumers just need to be registered and failover is handled automatically,
 there's no need to detect the active consumer failure and to register
 a new consumer.
 
-The [management UI](/management.html) and the
-[CLI](/rabbitmqctl.8.html) can [report](#active-consumer) which consumer is the current
+The [management UI](./management.html) and the
+[CLI](./rabbitmqctl.8.html) can [report](#active-consumer) which consumer is the current
 active one on a queue where the feature is enabled.
 
 Please note the following about single active consumer:
@@ -504,8 +504,8 @@ Please note the following about single active consumer:
 
 ## <a id="active-consumer" class="anchor" href="#active-consumer">Consumer Activity</a>
 
-The [management UI](/management.html) and the `list_consumers`
-[CLI](/rabbitmqctl.8.html#list_consumers) command report an `active`
+The [management UI](./management.html) and the `list_consumers`
+[CLI](./rabbitmqctl.8.html#list_consumers) command report an `active`
 flag for consumers. The value of this flag depends on several parameters.
 
  * for classic queues, the flag is always `true`
@@ -529,7 +529,7 @@ by effective [prefetch](#prefetch) setting.
 When consumer priorities are in use, messages are delivered round-robin if multiple active consumers
 exist with the same high priority.
 
-Consumer priorities are covered in a [separate guide](/consumer-priority.html).
+Consumer priorities are covered in a [separate guide](./consumer-priority.html).
 
 
 ## <a id="exceptions" class="anchor" href="#exceptions">Exception Handling</a>
@@ -539,7 +539,7 @@ or any other consumer operations. Such exceptions should be logged, collected an
 
 If a consumer cannot process deliveries due to a dependency not being available or similar reasons
 it should clearly log so and cancel itself until it is capable of processing deliveries again.
-This will make the consumer's unavailability visible to RabbitMQ and [monitoring systems](/monitoring.html).
+This will make the consumer's unavailability visible to RabbitMQ and [monitoring systems](./monitoring.html).
 
 
 ## <a id="concurrency" class="anchor" href="#concurrency">Concurrency Considerations</a>
@@ -560,7 +560,7 @@ the number of cores available to them.
 
 ### Queue Parallelism Considerations
 
-A single RabbitMQ queue is [bounded to a single core](/queues.html#runtime-characteristics). Use more than
+A single RabbitMQ queue is [bounded to a single core](./queues.html#runtime-characteristics). Use more than
 one queue to improve CPU utilisation on the nodes. Plugins such as [sharding](https://github.com/rabbitmq/rabbitmq-sharding)
 and [consistent hash exchange](https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange) can be helpful
 in increasing parallelism.

--- a/site/consumers.md
+++ b/site/consumers.md
@@ -158,13 +158,13 @@ and set by RabbitMQ at routing and delivery time:
       <td>Delivery tag</td>
       <td>Positive integer</td>
       <td>
-        Delivery identifier, see <a href="/confirms.html">Confirms</a>.
+        Delivery identifier, see <a href="./confirms.html">Confirms</a>.
       </td>
     </tr>
     <tr>
       <td>Redelivered</td>
       <td>Boolean</td>
-      <td>Set to `true` if this message was previously <a href="/confirms.html#consumer-nacks-requeue">delivered and requeued</a></td>
+      <td>Set to `true` if this message was previously <a href="./confirms.html#consumer-nacks-requeue">delivered and requeued</a></td>
     </tr>
     <tr>
       <td>Exchange</td>
@@ -239,19 +239,19 @@ at the time of publishing:
     <tr>
       <td>Correlation ID</td>
       <td>String</td>
-      <td>Helps correlate requests with responses, see <a href="/getstarted.html">tutorial 6</a></td>
+      <td>Helps correlate requests with responses, see <a href="./getstarted.html">tutorial 6</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Reply To</td>
       <td>String</td>
-      <td>Carries response queue name, see <a href="/getstarted.html">tutorial 6</a></td>
+      <td>Carries response queue name, see <a href="./getstarted.html">tutorial 6</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Expiration</td>
       <td>String</td>
-      <td><a href="/ttl.html">Per-message TTL</a></td>
+      <td><a href="./ttl.html">Per-message TTL</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -263,7 +263,7 @@ at the time of publishing:
     <tr>
       <td>User ID</td>
       <td>String</td>
-      <td>User ID, <a href="/validated-user-id.html">validated</a> if set</td>
+      <td>User ID, <a href="./validated-user-id.html">validated</a> if set</td>
       <td>No</td>
     </tr>
     <tr>

--- a/site/contact.md
+++ b/site/contact.md
@@ -49,7 +49,7 @@ There is no guarantee of response or specific turnaround time.
 ### GitHub
 
 Most of RabbitMQ development happens in the open under the [rabbitmq GitHub organization](https://github.com/rabbitmq).
-See [our GitHub guide](/github.html) for an overview of our development process.
+See [our GitHub guide](./github.html) for an overview of our development process.
 
 There is a dedicated GitHub repository, [rabbitmq/discussions](https://github.com/rabbitmq/discussions),
 for questions, discussions, investigations, root cause analysis, and so on. Questions or discussions

--- a/site/definitions-standby.md
+++ b/site/definitions-standby.md
@@ -1,6 +1,6 @@
 # Hot Standby via Continuous Definition Replication
 
-[VMware Tanzu RabbitMQ](/tanzu/) supports continuous schema definition replication
+[VMware Tanzu RabbitMQ](./tanzu/) supports continuous schema definition replication
 to a remote cluster, which makes it easy to run a hot standby cluster for disaster recovery.
 
 This feature is not available in the open source RabbitMQ distribution.

--- a/site/definitions-standby.md
+++ b/site/definitions-standby.md
@@ -14,7 +14,7 @@ for setting up one or more standby (passive) disaster recovery clusters.
 <p class="box-info">
 This guide covers a commercial feature that is <strong>only available in VMware Tanzu RabbitMQ</strong>,
 and not in the open source RabbitMQ distribution.
-<a href="/tanzu/">Learn more about VMware Tanzu RabbitMQ</a>
+<a href="./tanzu/">Learn more about VMware Tanzu RabbitMQ</a>
 </p>
 
 The plugin's replication model has a number of features and limitations:

--- a/site/definitions.md
+++ b/site/definitions.md
@@ -31,7 +31,7 @@ Every node in a cluster has its own replica of all definitions. When a part of d
 the update is performed on all nodes in a single transaction. This means that
 in practice, definitions can be exported from any cluster node with the same result.
 
-[VMware Tanzu RabbitMQ](/tanzu/) supports [continuous schema definition replication](definitions-standby.html) to a remote cluster,
+[VMware Tanzu RabbitMQ](./tanzu/) supports [continuous schema definition replication](definitions-standby.html) to a remote cluster,
 which makes it easy to run a hot standby cluster for disaster recovery.
 
 Definition import on node boot is the recommended way of [pre-configuring nodes at deployment time](#import-on-boot).

--- a/site/devtools.md
+++ b/site/devtools.md
@@ -178,12 +178,12 @@ Miscellaneous projects:
 
 ## <a id="monitoring-tools" class="anchor" href="#monitoring-tools">Monitoring</a>
 
- * See [Monitoring](/monitoring.html) and [Prometheus](/prometheus.html) guides.
+ * See [Monitoring](./monitoring.html) and [Prometheus](./prometheus.html) guides.
 
 
 ## <a id="viz" class="anchor" href="#viz">Visualisation</a>
 
- * [Rabbit Viz](https://plexsystems.github.io/rabbit-viz/), a tool for visualizing [exported definition files](/backup.html#rabbitmq-definitions).
+ * [Rabbit Viz](https://plexsystems.github.io/rabbit-viz/), a tool for visualizing [exported definition files](./backup.html#rabbitmq-definitions).
 
 
 ## <a id="unity-dev" class="anchor" href="#unity-dev">Unity 3D</a>
@@ -226,8 +226,8 @@ Miscellaneous projects:
 
 ## <a id="rabbitmq-cli" class="anchor" href="#rabbitmq-cli">CLI Tools</a>
 
- * [RabbitMQ CLI tools](/cli.html)
- * [rabbitmqadmin](/management-cli.html), a command line tool that targets RabbitMQ HTTP API
+ * [RabbitMQ CLI tools](./cli.html)
+ * [rabbitmqadmin](./management-cli.html), a command line tool that targets RabbitMQ HTTP API
  * [amqp-utils](https://github.com/dougbarth/amqp-utils), command line utils for interacting with an AMQP based queue (in Ruby)
  * [amqptools](https://github.com/rmt/amqptools), command line AMQP clients (in C)
  * [rabtap](https://github.com/jandelgado/rabtap), RabbitMQ wire tap and swiss army knife command line tool (in go)

--- a/site/direct-reply-to.md
+++ b/site/direct-reply-to.md
@@ -20,13 +20,13 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 Direct reply-to is a feature that allows RPC (request/reply) clients with a design
-similar to that demonstrated in [tutorial 6](/getstarted.html) to avoid
+similar to that demonstrated in [tutorial 6](./getstarted.html) to avoid
 declaring a response queue per request.
 
 ### <a id="motivation" class="anchor" href="#motivation">Motivation</a>
 
 RPC (request/reply) is a popular pattern to implement with a messaging broker
-like RabbitMQ. [Tutorial 6](/getstarted.html) demonstrates its implementation
+like RabbitMQ. [Tutorial 6](./getstarted.html) demonstrates its implementation
 with a variety of clients. The typical way to do this is for RPC clients to
 send requests that are routed to a long lived (known) server queue. The RPC server(s)
 consume requests from this queue and then send replies to each client

--- a/site/disk-alarms.md
+++ b/site/disk-alarms.md
@@ -45,7 +45,7 @@ The free space of the drive or partition that the broker database uses
 will be monitored at least every 10 seconds to determine whether the disk
 alarm should be raised or cleared.
 
-Monitoring will begin on node start. It will leave a [log entry](/logging.html) like this:
+Monitoring will begin on node start. It will leave a [log entry](./logging.html) like this:
 
 <pre class="lang-ini">
 2019-04-01 12:02:11.564 [info] &lt;0.329.0&gt; Enabling free disk space monitoring
@@ -87,7 +87,7 @@ section below).
 The disk free space limit is configured with
 the <code>disk_free_limit</code> setting. By default 50MB is
 required to be free on the database partition (see the description of
-[file locations](/relocate.html) for the default database location).
+[file locations](./relocate.html) for the default database location).
 This configuration file sets the disk free space limit to 1GB:
 
 <pre class="lang-ini">

--- a/site/distributed.md
+++ b/site/distributed.md
@@ -40,9 +40,9 @@ Inter-node communication is performed transparently to clients.
 The design of clustering assumes that network connections are reasonably reliable
 and provides a LAN-like latency.
 
-All nodes in the cluster must run compatible versions of RabbitMQ and [Erlang](/which-erlang.html).
+All nodes in the cluster must run compatible versions of RabbitMQ and [Erlang](./which-erlang.html).
 
-Nodes authenticate to each other using [a pre-shared secret](/clustering.html#erlang-cookie)
+Nodes authenticate to each other using [a pre-shared secret](./clustering.html#erlang-cookie)
 typically installed by deployment automation tools.
 
 Virtual hosts, exchanges, users, and permissions are

--- a/site/distributed.md
+++ b/site/distributed.md
@@ -131,12 +131,12 @@ single broker.
     <td>
       Brokers can be connected via unreliable WAN
       links. Communication is via AMQP 0-9-1 (optionally secured by
-      <a href="/ssl.html">TLS</a>), requiring appropriate users and permissions to be set up.
+      <a href="./ssl.html">TLS</a>), requiring appropriate users and permissions to be set up.
     </td>
     <td>
       Brokers must be connected via reasonably reliable LAN
       links. Nodes will authenticate to each other using a shared secret
-      and optionally <a href="/clustering-ssl.html">use TLS-enabled links</a>.
+      and optionally <a href="./clustering-ssl.html">use TLS-enabled links</a>.
     </td>
   </tr>
   <tr>

--- a/site/dlx.md
+++ b/site/dlx.md
@@ -22,10 +22,10 @@ limitations under the License.
 Messages from a queue can be "dead-lettered"; that is, republished to
 an exchange when any of the following events occur:
 
- * The message is [negatively acknowledged](/confirms.html) by a consumer using `basic.reject` or
+ * The message is [negatively acknowledged](./confirms.html) by a consumer using `basic.reject` or
    `basic.nack` with `requeue` parameter set to `false`.
- * The message expires due to [per-message TTL](/ttl.html); or
- * The message is dropped because its queue exceeded a [length limit](/maxlength.html)
+ * The message expires due to [per-message TTL](./ttl.html); or
+ * The message is dropped because its queue exceeded a [length limit](./maxlength.html)
 
 Note that expiration of a queue will not dead letter the messages in it.
 
@@ -33,8 +33,8 @@ Dead letter exchanges (DLXs) are normal exchanges. They can be
 any of the usual types and are declared as usual.
 
 For any given queue, a DLX can be defined by clients using the
-[queue's arguments](/queues.html#optional-arguments), or in the server
-using [policies](/parameters.html#policies). In the
+[queue's arguments](./queues.html#optional-arguments), or in the server
+using [policies](./parameters.html#policies). In the
 case where both policy and arguments specify a DLX, the one
 specified in arguments overrules the one specified in policy.
 
@@ -154,7 +154,7 @@ original queue immediately after publishing to the DLX target queue. This ensure
 that there is no chance of excessive message buildup that could exhaust broker
 resources, but messages can be lost if the target queue isn't available to accept messages.
 
-Since RabbitMQ 3.10 quorum queues support [at-least-once dead-lettering](/quorum-queues.html#dead-lettering)
+Since RabbitMQ 3.10 quorum queues support [at-least-once dead-lettering](./quorum-queues.html#dead-lettering)
 where messages are re-published with publisher confirms turned on internally.
 
 ## <a id="effects" class="anchor" href="#effects">Dead-Lettered Effects on Messages</a>
@@ -194,9 +194,9 @@ The `reason` is a name describing why the
 message was dead-lettered and is one of the following:
 
  * `rejected`: the message was rejected with `requeue` parameter set to `false`
- * `expired`: the [message TTL](/ttl.html) has expired
- * `maxlen`: the [maximum allowed queue length](/maxlength.html) was exceeded
- * `delivery_limit`: the message has been returned more times than the limit (set by policy argument [delivery-limit](/quorum-queues.html#poison-message-handling) of quorum queues).
+ * `expired`: the [message TTL](./ttl.html) has expired
+ * `maxlen`: the [maximum allowed queue length](./maxlength.html) was exceeded
+ * `delivery_limit`: the message has been returned more times than the limit (set by policy argument [delivery-limit](./quorum-queues.html#poison-message-handling) of quorum queues).
 
 Three top-level headers are added for the very first dead-lettering
 event. They are

--- a/site/documentation.md
+++ b/site/documentation.md
@@ -21,7 +21,7 @@ This page summarises the available RabbitMQ documentation for the [latest patch 
 
 ## Installation
 
-See the [Downloads and Installation](/download.html) page
+See the [Downloads and Installation](./download.html) page
 for information on the most recent release and how to install it.
 
 
@@ -33,7 +33,7 @@ for our tutorials for various programming languages.
 The tutorials offer a gentle introduction to messaging, one of the protocols RabbitMQ supports,
 key messaging features, and some common usage scenarios.
 
-[AMQP 0-9-1 Overview](/tutorials/amqp-concepts.html) provides a brief overview
+[AMQP 0-9-1 Overview](./tutorials/amqp-concepts.html) provides a brief overview
 for the original RabbitMQ protocol.
 
 
@@ -43,47 +43,47 @@ for the original RabbitMQ protocol.
 
 ### [Installation and Provisioning](download.html):
 
- * [Packages and repositories](/download.html)
- * [Kubernetes Operator](/kubernetes/operator/operator-overview.html)
- * [Provisioning Tools](/download.html) (Docker image, Chef cookbook, Puppet module, etc)
- * [Package Signatures](/signatures.html)
- * [Supported Erlang/OTP Versions](/which-erlang.html)
- * [Supported RabbitMQ Versions](/versions.html)
- * [Changelog](/changelog.html)
+ * [Packages and repositories](./download.html)
+ * [Kubernetes Operator](./kubernetes/operator/operator-overview.html)
+ * [Provisioning Tools](./download.html) (Docker image, Chef cookbook, Puppet module, etc)
+ * [Package Signatures](./signatures.html)
+ * [Supported Erlang/OTP Versions](./which-erlang.html)
+ * [Supported RabbitMQ Versions](./versions.html)
+ * [Changelog](./changelog.html)
 
 #### Operating Systems and Platforms
 
- * [Kubernetes](/kubernetes/operator/operator-overview.html)
- * [Debian and Ubuntu](/install-debian.html)
- * [Red Hat Enterprise Linux, CentOS, Fedora](/install-rpm.html)
- * [Windows Installer](/install-windows.html), [Windows-specific Issues](/windows-quirks.html)
- * [Generic UNIX Binary Build](/install-generic-unix.html)
- * [MacOS via Standalone Binary Build](/install-standalone-mac.html)
- * [MacOS via Homebrew](/install-homebrew.html)
- * [Amazon EC2](/ec2.html)
- * [Solaris](/install-solaris.html)
+ * [Kubernetes](./kubernetes/operator/operator-overview.html)
+ * [Debian and Ubuntu](./install-debian.html)
+ * [Red Hat Enterprise Linux, CentOS, Fedora](./install-rpm.html)
+ * [Windows Installer](./install-windows.html), [Windows-specific Issues](./windows-quirks.html)
+ * [Generic UNIX Binary Build](./install-generic-unix.html)
+ * [MacOS via Standalone Binary Build](./install-standalone-mac.html)
+ * [MacOS via Homebrew](./install-homebrew.html)
+ * [Amazon EC2](./ec2.html)
+ * [Solaris](./install-solaris.html)
 
 #### Snapshots
 
- * [Snapshot (Nightly) Builds](/snapshots.html)
+ * [Snapshot (Nightly) Builds](./snapshots.html)
 
 
 ### Upgrading
 
- * Main [Upgrading guide](/upgrade.html)
- * [Schema Definitions](/definitions.html)
- * [Blue-green deployment-based upgrade](/blue-green-upgrade.html)
+ * Main [Upgrading guide](./upgrade.html)
+ * [Schema Definitions](./definitions.html)
+ * [Blue-green deployment-based upgrade](./blue-green-upgrade.html)
 
 
 ### CLI tools
 
- * [RabbitMQ CLI Tools](/cli.html): general installation and usage topics
- * [rabbitmqctl](/rabbitmqctl.8.html): primary RabbitMQ CLI tool
- * [rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html): [monitoring](/monitoring.html), [health checking](/monitoring.html#health-checks), observability tooling
- * [rabbitmq-plugins](/rabbitmq-plugins.8.html): plugin management
- * [rabbitmq-queues](/rabbitmq-queues.8.html): operations on quorum queues
- * [rabbitmqadmin](/management-cli.html) ([HTTP API](/management.html)-based zero dependency management tool)
- * [man pages](/manpages.html)
+ * [RabbitMQ CLI Tools](./cli.html): general installation and usage topics
+ * [rabbitmqctl](./rabbitmqctl.8.html): primary RabbitMQ CLI tool
+ * [rabbitmq-diagnostics](./rabbitmq-diagnostics.8.html): [monitoring](./monitoring.html), [health checking](./monitoring.html#health-checks), observability tooling
+ * [rabbitmq-plugins](./rabbitmq-plugins.8.html): plugin management
+ * [rabbitmq-queues](./rabbitmq-queues.8.html): operations on quorum queues
+ * [rabbitmqadmin](./management-cli.html) ([HTTP API](./management.html)-based zero dependency management tool)
+ * [man pages](./manpages.html)
 
 
 ### Configuration
@@ -108,8 +108,8 @@ for the original RabbitMQ protocol.
  * [Credentials and Passwords](passwords.html)
  * x509 (TLS) [Certificate-based client authentication](https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl/tree/v3.8.x)
  * [LDAP](ldap.html)
- * [Validated User ID](/validated-user-id.html)
- * [Authentication Failure Notifications](/auth-notification.html)
+ * [Validated User ID](./validated-user-id.html)
+ * [Authentication Failure Notifications](./auth-notification.html)
 
 
 ### Networking and TLS
@@ -118,7 +118,7 @@ for the original RabbitMQ protocol.
  * [Networking](networking.html)
  * [Troubleshooting Network Connectivity](troubleshooting-networking.html)
  * [Using TLS for Client Connections](ssl.html)
- * [Using TLS for Inter-node Traffic](/clustering-ssl.html)
+ * [Using TLS for Inter-node Traffic](./clustering-ssl.html)
  * [Troubleshooting TLS](troubleshooting-ssl.html)
 
 
@@ -133,7 +133,7 @@ for the original RabbitMQ protocol.
  * [Internal Event Exchange](event-exchange.html)
  * [Per Virtual Host Limits](vhosts.html)
  * [Message Tracing](firehose.html)
- * [Capturing Traffic with Wireshark](/amqp-wireshark.html)
+ * [Capturing Traffic with Wireshark](./amqp-wireshark.html)
 
 
 ### Clustering
@@ -167,60 +167,60 @@ for the original RabbitMQ protocol.
 
 ### Message Store and Resource Management
 
- * [Memory Usage Analysis](/memory-use.html)
- * [Memory Management](/memory.html)
- * [Resource Alarms](/alarms.html)
- * [Free Disk Space Alarms](/disk-alarms.html)
+ * [Memory Usage Analysis](./memory-use.html)
+ * [Memory Management](./memory.html)
+ * [Resource Alarms](./alarms.html)
+ * [Free Disk Space Alarms](./disk-alarms.html)
  * [Runtime Tuning](runtime.html)
- * [Flow Control](/flow-control.html)
- * [Message Store Configuration](/persistence-conf.html)
- * [Queue and Message TTL](/ttl.html)
- * [Queue Length Limits](/maxlength.html)
- * [Lazy Queues](/lazy-queues.html)
+ * [Flow Control](./flow-control.html)
+ * [Message Store Configuration](./persistence-conf.html)
+ * [Queue and Message TTL](./ttl.html)
+ * [Queue Length Limits](./maxlength.html)
+ * [Lazy Queues](./lazy-queues.html)
 
 
 ### Queue and Consumer Features
 
  * [Queues guide](queues.html)
- * [Consumers guide](/consumers.html)
- * [Queue and Message TTL](/ttl.html)
- * [Queue Length Limits](/maxlength.html)
- * [Lazy Queues](/lazy-queues.html)
- * [Dead Lettering](/dlx.html)
- * [Priority Queues](/priority.html)
- * [Consumer Cancellation Notifications](/consumer-cancel.html)
- * [Consumer Prefetch](/consumer-prefetch.html)
- * [Consumer Priorities](/consumer-priority.html)
- * [Streams](/streams.html)
+ * [Consumers guide](./consumers.html)
+ * [Queue and Message TTL](./ttl.html)
+ * [Queue Length Limits](./maxlength.html)
+ * [Lazy Queues](./lazy-queues.html)
+ * [Dead Lettering](./dlx.html)
+ * [Priority Queues](./priority.html)
+ * [Consumer Cancellation Notifications](./consumer-cancel.html)
+ * [Consumer Prefetch](./consumer-prefetch.html)
+ * [Consumer Priorities](./consumer-priority.html)
+ * [Streams](./streams.html)
 
 
 ### Publisher Features
 
- * [Publishers guide](/publishers.html)
- * [Exchange-to-Exchange Bindings](/e2e.html)
- * [Alternate Exchanges](/ae.html)
- * [Sender-Selected Distribution](/sender-selected.html)
+ * [Publishers guide](./publishers.html)
+ * [Exchange-to-Exchange Bindings](./e2e.html)
+ * [Alternate Exchanges](./ae.html)
+ * [Sender-Selected Distribution](./sender-selected.html)
 
 
 ### STOMP, MQTT, WebSockets
 
  * [Client Connections](connections.html)
- * [STOMP](/stomp.html)
- * [MQTT](/mqtt.html)
+ * [STOMP](./stomp.html)
+ * [MQTT](./mqtt.html)
  * [STOMP over WebSockets](web-stomp.html)
  * [MQTT over WebSockets](web-mqtt.html)
 
 
 ## Man Pages
 
- * [man Pages](/manpages.html)
+ * [man Pages](./manpages.html)
 
 
 ## Client Libraries and Features
 
 [RabbitMQ clients documentation](clients.html) is organised in a number
-of guides and API references. A separate set of [tutorials](/getstarted.html) for
-many popular programming languages are also available, as is an [AMQP 0-9-1 Overview](/tutorials/amqp-concepts.html).
+of guides and API references. A separate set of [tutorials](./getstarted.html) for
+many popular programming languages are also available, as is an [AMQP 0-9-1 Overview](./tutorials/amqp-concepts.html).
 
 ### Client Documentation Guides
 
@@ -229,36 +229,36 @@ many popular programming languages are also available, as is an [AMQP 0-9-1 Over
  * [Ruby Client](http://rubybunny.info)
  * [JMS Client](jms-client.html)
  * [Erlang Client](erlang-client-user-guide.html)
- * [RabbitMQ extensions to AMQP 0-9-1](/extensions.html)
+ * [RabbitMQ extensions to AMQP 0-9-1](./extensions.html)
 
 ### Client-Driven Features
 
  * [Client Connections](connections.html)
- * [Consumers](/consumers.html)
- * [Publishers](/publishers.html)
+ * [Consumers](./consumers.html)
+ * [Publishers](./publishers.html)
  * [Channels](channels.html)
  * [Publisher Confirms and Consumer Acknowledgements](confirms.html)
  * [Queue and Message TTL](ttl.html)
  * [Queue Length Limits](maxlength.html)
  * [Lazy Queues](lazy-queues.html)
- * [Exchange-to-Exchange Bindings](/e2e.html)
- * [Sender-Selected Distribution](/sender-selected.html)
- * [Priority Queues](/priority.html)
- * [Consumer Cancellation Notifications](/consumer-cancel.html)
- * [Consumer Prefetch](/consumer-prefetch.html)
- * [Consumer Priorities](/consumer-priority.html)
- * [Dead Lettering](/dlx.html)
- * [Alternate Exchanges](/ae.html)
+ * [Exchange-to-Exchange Bindings](./e2e.html)
+ * [Sender-Selected Distribution](./sender-selected.html)
+ * [Priority Queues](./priority.html)
+ * [Consumer Cancellation Notifications](./consumer-cancel.html)
+ * [Consumer Prefetch](./consumer-prefetch.html)
+ * [Consumer Priorities](./consumer-priority.html)
+ * [Dead Lettering](./dlx.html)
+ * [Alternate Exchanges](./ae.html)
  * [Message Tracing](firehose.html)
- * [Capturing Traffic with Wireshark](/amqp-wireshark.html)
+ * [Capturing Traffic with Wireshark](./amqp-wireshark.html)
 
 
 ## References
 
  * [Java](https://rabbitmq.github.io/rabbitmq-java-client/api/current/)
  * [.NET](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html)
- * [AMQP 0-9-1 URI Specification](/uri-spec.html)
- * [URI Query Parameters](/uri-query-parameters.html)
+ * [AMQP 0-9-1 URI Specification](./uri-spec.html)
+ * [URI Query Parameters](./uri-query-parameters.html)
 
 See [Clients and Developer Tools](devtools.html)
 for community client libraries.
@@ -277,7 +277,7 @@ Popular tier 1 (built-in) plugins:
  * [Shovel](shovel.html)
  * [Internal Event Exchange](event-exchange.html)
 
-See [Community Plugins](/community-plugins.html),
+See [Community Plugins](./community-plugins.html),
 [RabbitMQ GitHub repositories](https://github.com/rabbitmq/)
 and the [Plugins Guide](plugins.html) for more information about plugins.
 

--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -212,7 +212,7 @@ remains unassigned prior to creating a connection:
 
     <td>
       <code>5672</code> for regular ("plain TCP") connections,
-      <code>5671</code> for <a href="/ssl.html">connections with TLS enabled</a>
+      <code>5671</code> for <a href="./ssl.html">connections with TLS enabled</a>
     </td>
   </tr>
 </table>

--- a/site/dotnet-api-guide.md
+++ b/site/dotnet-api-guide.md
@@ -19,9 +19,9 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers [RabbitMQ .NET/C# client](/dotnet.html) and its public API.
+This guide covers [RabbitMQ .NET/C# client](./dotnet.html) and its public API.
 It assumes that the [most recent major version of the client](https://www.nuget.org/packages/RabbitMQ.Client) is used
-and the reader is familiar with [the basics](/getstarted.html).
+and the reader is familiar with [the basics](./getstarted.html).
 
 Key sections of the guide are:
 
@@ -42,8 +42,8 @@ An [API reference](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitM
 
 ## <a id="dotnet-versions" class="anchor" href="#dotnet-versions">.NET Version Requirements</a>
 
-6.x release series of this library [require .NET 4.6.1+ or a .NET Standard 2.0+ implementation](/dotnet.html#overview).
-For 5.x releases, the requirements are [.NET 4.5.1+ or a .NET Standard 1.5+ implementation](/dotnet.html#overview).
+6.x release series of this library [require .NET 4.6.1+ or a .NET Standard 2.0+ implementation](./dotnet.html#overview).
+For 5.x releases, the requirements are [.NET 4.5.1+ or a .NET Standard 1.5+ implementation](./dotnet.html#overview).
 
 
 ## <a id="license" class="anchor" href="#license">License</a>
@@ -73,7 +73,7 @@ explicit.
 
 ## <a id="major-api-elements" class="anchor" href="#major-api-elements">Major namespaces, interfaces and classes</a>
 
-The client API is closely modelled on the [AMQP 0-9-1 protocol model](/tutorials/amqp-concepts.html),
+The client API is closely modelled on the [AMQP 0-9-1 protocol model](./tutorials/amqp-concepts.html),
 with additional abstractions for ease of use.
 
 An [API reference](https://rabbitmq.github.io/rabbitmq-dotnet-client/) is available separately.
@@ -120,11 +120,11 @@ for every operation (e.g. publishing a message) would be very inefficient and is
 **highly discouraged**.
 
 To open a connection with the .NET client, first instantiate a `ConnectionFactory`
-and configure it to use desired hostname, virtual host, credentials, [TLS settings](/ssl.html),
+and configure it to use desired hostname, virtual host, credentials, [TLS settings](./ssl.html),
 and any other parameters as needed.
 
 Then call the `ConnectionFactory.CreateConnection()` method to open a connection.
-Successful and unsuccessful client connection events can be [observed in server logs](/networking.html#logging).
+Successful and unsuccessful client connection events can be [observed in server logs](./networking.html#logging).
 
 The following two code snippets connect to a RabbitMQ node using a hostname configured
 using the `hostName` property:
@@ -171,7 +171,7 @@ IConnection conn = factory.CreateConnection(endpoints);
 
 ### <a id="connecting-uri" class="anchor" href="#connecting-uri"></a>
 
-Since the .NET client uses a stricter interpretation of the [AMQP 0-9-1 URI spec](/uri-spec.html)
+Since the .NET client uses a stricter interpretation of the [AMQP 0-9-1 URI spec](./uri-spec.html)
 than the other clients, care must be taken when using URIs.
 In particular, the host part must not be omitted and virtual hosts with
 empty names are not addressable.
@@ -217,7 +217,7 @@ remains unassigned prior to creating a connection:
   </tr>
 </table>
 
-Note that [user guest can only connect from localhost](/access-control.html) by default.
+Note that [user guest can only connect from localhost](./access-control.html) by default.
 This is to limit well-known credential use in production systems.
 
 The `IConnection` interface can then be used to open a [channel](channels.html):
@@ -236,7 +236,7 @@ protocol errors will automatically close channels. If applications can recover
 from them, they can open a new channel and retry the operation.
 
 This is covered in more detail in the [Channel guide](channels.html) as well as other
-guides such as [Consumer Acknowledgements](/confirms.html).
+guides such as [Consumer Acknowledgements](./confirms.html).
 
 
 ## <a id="disconnecting" class="anchor" href="#disconnecting">Disconnecting from RabbitMQ</a>
@@ -254,7 +254,7 @@ with the API methods from the example above.
 Note that closing the channel may be considered good practice, but isn&#8217;t strictly necessary here - it will be done
 automatically anyway when the underlying connection is closed.
 
-Client disconnection events can be [observed in server node logs](/networking.html#logging).
+Client disconnection events can be [observed in server node logs](./networking.html#logging).
 
 
 ## <a id="connection-and-channel-lifespan" class="anchor" href="#connection-and-channel-lifespan">Connection and Channel Lifespan</a>
@@ -284,9 +284,9 @@ RabbitMQ nodes have a limited amount of information about their clients:
  * the credentials used
 
 This information alone can make identifying applications and instances problematic, in particular when credentials can be
-shared and clients connect over a load balancer but [Proxy protocol](/networking.html#proxy-protocol) cannot be enabled.
+shared and clients connect over a load balancer but [Proxy protocol](./networking.html#proxy-protocol) cannot be enabled.
 
-To make it easier to identify clients in [server logs](/logging.html) and [management UI](/management.html),
+To make it easier to identify clients in [server logs](./logging.html) and [management UI](./management.html),
 AMQP 0-9-1 client connections, including the RabbitMQ .NET client, can provide a custom identifier.
 If set, the identifier will be mentioned in log entries and management UI. The identifier is known as
 the **client-provided connection name**. The name can be used to identify an application or a specific component
@@ -319,7 +319,7 @@ IConnection conn = factory.CreateConnection();
 ## <a id="exchanges-and-queues" class="anchor" href="#exchanges-and-queues">Using Exchanges and Queues</a>
 
 Client applications work with exchanges and [queues](queues.html),
-the high-level [building blocks of the protocol](/tutorials/amqp-concepts.html).
+the high-level [building blocks of the protocol](./tutorials/amqp-concepts.html).
 These must be "declared" before they can be
 used. Declaring either type of object simply ensures that one of that
 name exists, creating it if necessary.
@@ -354,7 +354,7 @@ This "short version, long version" pattern is used throughout the API.
 Queues and exchanges can be declared "passively". A passive declare simply checks that the entity
 with the provided name exists. If it does, the operation is a no-op. For queues successful
 passive declares will return the same information as non-passive ones, namely the number of
-consumers and messages in [ready state](/confirms.html) in the queue.
+consumers and messages in [ready state](./confirms.html) in the queue.
 
 If the entity does not exist, the operation fails with a channel level exception. The channel
 cannot be used after that. A new channel should be opened. It is common to use one-off (temporary)
@@ -383,7 +383,7 @@ response, use
 <pre class="lang-csharp">channel.QueueDeclareNoWait(queueName, true, false, false, null);</pre>
 
 The "no wait" versions are more efficient but offer lower safety guarantees, e.g. they
-are more dependent on the [heartbeat mechanism](/heartbeats.html) for detection of failed operations.
+are more dependent on the [heartbeat mechanism](./heartbeats.html) for detection of failed operations.
 When in doubt, start with the standard version. The "no wait" versions are only needed in scenarios
 with high topology (queue, binding) churn.
 
@@ -515,7 +515,7 @@ channel.BasicCancel(consumerTag);
 
 When calling the API methods, you always refer to consumers by their
 consumer tags, which can be either client- or server-generated as
-explained in the [AMQP 0-9-1 specification](/specification.html) document.
+explained in the [AMQP 0-9-1 specification](./specification.html) document.
 
 ## <a id="consuming-memory-safety" class="anchor" href="#consuming-memory-safety">Consumer Memory Safety Requirements</a>
 
@@ -588,7 +588,7 @@ if (result == null) {
     ...
 </pre>
 
-The above example uses [manual acknowledgements](/confirms.html) (`autoAck = false`), so the application must also call
+The above example uses [manual acknowledgements](./confirms.html) (`autoAck = false`), so the application must also call
 `IModel.BasicAck` to acknowledge the delivery after processing:
 
 <pre class="lang-csharp">
@@ -631,8 +631,8 @@ lock (ch) {
 Symptoms of incorrect serialisation of `IModel` operations
 include, but are not limited to,
 
- * [connection-level exceptions](/connections.html#error-handling) due to invalid frame
-   interleaving on the wire. RabbitMQ [server logs](/logging.html) will
+ * [connection-level exceptions](./connections.html#error-handling) due to invalid frame
+   interleaving on the wire. RabbitMQ [server logs](./logging.html) will
    contain unexpected frame errors in such scenario.
  * Pipelining and continuation exceptions thrown by the client
 
@@ -640,7 +640,7 @@ Consumption that involve sharing a channel between threads should be avoided
 when possible but can be done safely.
 
 Consumers that can be multi-threaded or use a thread pool internally, including TPL-based
-consumers, must use mutual exclusion of [acknowledgements](/confirms.html) operations
+consumers, must use mutual exclusion of [acknowledgements](./confirms.html) operations
 on a shared channel.
 
 ### <a id="concurrency-thread-usage" class="anchor" href="#concurrency-thread-usage">Per-Connection Thread Use</a>
@@ -756,7 +756,7 @@ Automatic connection recovery, if enabled, will be triggered by the following ev
 
 * An I/O exception is thrown in connection's I/O loop
 * A socket read operation times out
-* Missed server [heartbeats](/heartbeats.html) are detected
+* Missed server [heartbeats](./heartbeats.html) are detected
 * Any other unexpected exception is thrown in connection's I/O loop
 
 whichever happens first.
@@ -810,13 +810,13 @@ factory.TopologyRecoveryEnabled  = false;
 Automatic connection recovery has a number of limitations and intentional
 design decisions that applications developers need to be aware of.
 
-When a connection is down or lost, it [takes time to detect](/heartbeats.html).
+When a connection is down or lost, it [takes time to detect](./heartbeats.html).
 Therefore there is a window of time in which both the
 library and the application are unaware of effective
 connection failure.  Any messages published during this
 time frame are serialised and written to the TCP socket
 as usual. Their delivery to the broker can only be
-guaranteed via [publisher confirms](/confirms.html): publishing in AMQP 0-9-1 is entirely
+guaranteed via [publisher confirms](./confirms.html): publishing in AMQP 0-9-1 is entirely
 asynchronous by design.
 
 When a socket or I/O operation error is detected by a
@@ -834,7 +834,7 @@ with an exception. The client currently does not perform
 any internal buffering of such outgoing messages. It is
 an application developer's responsibility to keep track of such
 messages and republish them when recovery succeeds.
-[Publisher confirms](/confirms.html) is a protocol extension
+[Publisher confirms](./confirms.html) is a protocol extension
 that should be used by publishers that cannot afford message loss.
 
 Connection recovery will not kick in when a channel is closed due to a

--- a/site/dotnet.md
+++ b/site/dotnet.md
@@ -98,7 +98,7 @@ Release notes can be found [on GitHub](https://github.com/rabbitmq/rabbitmq-dotn
 
 ## <a id="documentation" class="anchor" href="#documentation">Documentation</a>
 
-Please refer to the [RabbitMQ tutorials](/getstarted.html) and [.NET client user guide](/dotnet-api-guide.html).
+Please refer to the [RabbitMQ tutorials](./getstarted.html) and [.NET client user guide](./dotnet-api-guide.html).
 
 There's also [an online API reference](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html).
 
@@ -141,7 +141,7 @@ Modern versions of this library (e.g. `6.x`) are distributed as a [NuGet package
 
 The .NET RabbitMQ client library is [hosted and developed on GitHub](https://github.com/rabbitmq/rabbitmq-dotnet-client).
 
-Please see the [.NET client build guide](/build-dotnet-client.html) for
+Please see the [.NET client build guide](./build-dotnet-client.html) for
 instructions on compiling from source.
 
 To clone the repo from GitHub:
@@ -151,7 +151,7 @@ git clone https://github.com/rabbitmq/rabbitmq-dotnet-client
 </pre>
 
 In order to compile or run the RabbitMQ .NET/C# client library,
-please follow the [build instructions](/build-dotnet-client.html).
+please follow the [build instructions](./build-dotnet-client.html).
 
 
 ## <a id="signing" class="anchor" href="#signing">Strong Naming</a>

--- a/site/download.md
+++ b/site/download.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Downloading and Installing RabbitMQ
 
 The latest [release](https://github.com/rabbitmq/rabbitmq-server/releases) of RabbitMQ is **&version-server;**. See [change log](changelog.html) for release notes.
-See [RabbitMQ support timeline](/versions.html) to find out what release series are supported.
+See [RabbitMQ support timeline](./versions.html) to find out what release series are supported.
 
 Experimenting with RabbitMQ on your workstation? Try the [community Docker image](https://registry.hub.docker.com/_/rabbitmq/):
 
@@ -36,7 +36,7 @@ docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.9-man
  * Linux, BSD, UNIX: [Debian, Ubuntu](install-debian.html) | [RHEL, CentOS, Fedora](install-rpm.html) | [Generic binary build](install-generic-unix.html) | [Solaris](install-solaris.html)
  * Windows: [Chocolatey or Installer](install-windows.html) (recommended) | [Binary build](install-windows-manual.html)
  * MacOS: [Homebrew](install-homebrew.html) | [Generic binary build](install-generic-unix.html)
- * [Erlang/OTP for RabbitMQ](/which-erlang.html)
+ * [Erlang/OTP for RabbitMQ](./which-erlang.html)
 
 ### Preview Releases (Betas, Release Candidates)
 
@@ -71,7 +71,7 @@ Open source [RabbitMQ Topology Kubernetes Operator](kubernetes/operator/using-to
 
 Other guides related to Kubernetes:
 
- * A [peer discovery](/cluster-formation.html) mechanism [for Kubernetes](/cluster-formation.html#peer-discovery-k8s)
+ * A [peer discovery](./cluster-formation.html) mechanism [for Kubernetes](./cluster-formation.html#peer-discovery-k8s)
 
 
 ## Docker
@@ -82,7 +82,7 @@ Other guides related to Kubernetes:
 ## Cloud
 
  * [Tanzu™ RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
- * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
+ * [RabbitMQ Cluster Kubernetes Operator](./kubernetes/operator/install-operator.html) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
  * [Tanzu™ RabbitMQ® on Kubernetes](kubernetes/tanzu/installation.html)
  * [CloudAMQP](https://www.cloudamqp.com): RabbitMQ-as-a-Service available in multiple clouds
  * [Amazon EC2](ec2.html)
@@ -112,8 +112,8 @@ Other guides related to Kubernetes:
 ## Release Signing Key
 
  * [Release Signing Key](https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc) <code>0x6B73A36E6026DFCA</code> (on GitHub)
- * [How to Verify Release Artifact Signatures](/signatures.html)
- * [Release Signing Key](/rabbitmq-release-signing-key.asc) (alternative download location on rabbitmq.com)
+ * [How to Verify Release Artifact Signatures](./signatures.html)
+ * [Release Signing Key](./rabbitmq-release-signing-key.asc) (alternative download location on rabbitmq.com)
 
 
 ## Client Libraries
@@ -123,9 +123,9 @@ Other guides related to Kubernetes:
  * On Maven Central: [RabbitMQ Java client](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.rabbitmq%22%20AND%20a%3A%22amqp-client%22)
  * Quick download: [Maven.org](http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&version-java-client;/amqp-client-&version-java-client;.jar) |
    [Source](http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/&version-java-client;/amqp-client-&version-java-client;-sources.jar)
- * [API guide](/api-guide.html)
+ * [API guide](./api-guide.html)
  * [API reference](https://rabbitmq.github.io/rabbitmq-java-client/api/current/) (JavaDoc)
- * [License and other information](/java-client.html)
+ * [License and other information](./java-client.html)
  * [Older versions](http://repo1.maven.org/maven2/com/rabbitmq/amqp-client/)
 
 ### JMS Client
@@ -135,9 +135,9 @@ Other guides related to Kubernetes:
 ### .NET/C# Client
 
  * On NuGet: [RabbitMQ .NET Client](https://www.nuget.org/packages/RabbitMQ.Client)
- * [API guide](/dotnet-api-guide.html)
+ * [API guide](./dotnet-api-guide.html)
  * [API reference](https://rabbitmq.github.io/rabbitmq-dotnet-client/)
- * [License and other information](/dotnet.html)
+ * [License and other information](./dotnet.html)
  * [Older versions](https://github.com/rabbitmq/rabbitmq-dotnet-client/releases)
 
 ### Erlang Client

--- a/site/e2e.md
+++ b/site/e2e.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-In [AMQP 0-9-1](/tutorials/amqp-concepts.html) the `queue.bind` method binds a queue to an
+In [AMQP 0-9-1](./tutorials/amqp-concepts.html) the `queue.bind` method binds a queue to an
 exchange so that messages flow (subject to various criteria)
 from the exchange (the <em>source</em>) to the queue (the
 <em>destination</em>). We have introduced an

--- a/site/ec2.md
+++ b/site/ec2.md
@@ -18,21 +18,21 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide assumes familiarity with the general [clustering guide](/clustering.html) as well
-the guide on [cluster peer discovery](/cluster-formation.html).
+This guide assumes familiarity with the general [clustering guide](./clustering.html) as well
+the guide on [cluster peer discovery](./cluster-formation.html).
 
 Using RabbitMQ on EC2 is quite similar to running it on other
 platforms. However, there are certain minor aspects to EC2 that need
 to be accounted for. They primarily have to do with hostnames and their resolution.
 
-This guide demonstrates manual ([CLI](/cli.html)-driven) RabbitMQ clustering.
-[Peer discovery plugin for AWS](/cluster-formation.html) (RabbitMQ 3.7.0 or later)
+This guide demonstrates manual ([CLI](./cli.html)-driven) RabbitMQ clustering.
+[Peer discovery plugin for AWS](./cluster-formation.html) (RabbitMQ 3.7.0 or later)
 is an option more suitable for automation.
 
 ## <a id="amis" class="anchor" href="#amis">AMIs</a>
 
 RabbitMQ works well on up-to-date Ubuntu, Debian and CentOS AMIs as long as
-a [compatible version of Erlang/OTP](/which-erlang.html) is installed.
+a [compatible version of Erlang/OTP](./which-erlang.html) is installed.
 
 ## <a id="instance-types" class="anchor" href="#instance-types">Choosing an Instance Type</a>
 
@@ -41,13 +41,13 @@ worth bearing in mind:
 
  * Use 64-bit instances.
  * Depending on the workload and settings, RabbitMQ can require substantial amounts of memory.
-	 Make sure that your host does have an [appropriate amount of RAM](/memory.html) and always have
-	 at least a few gigabytes of swap space enabled. Workloads can be simulated using [PerfTest](/java-tools.html).
-   A separate guide on [reasoning about node memory usage](/memory-use.html) is available.
+	 Make sure that your host does have an [appropriate amount of RAM](./memory.html) and always have
+	 at least a few gigabytes of swap space enabled. Workloads can be simulated using [PerfTest](./java-tools.html).
+   A separate guide on [reasoning about node memory usage](./memory-use.html) is available.
  * RabbitMQ generally will take advantage of all the CPU cores
 	in the system provided the workload uses [multiple queues](queues.html).
   Other factors should be taken into account (e.g. disk and network I/O throughput).
- * [Monitoring](/monitoring.html) RabbitMQ nodes as well as applications that use it
+ * [Monitoring](./monitoring.html) RabbitMQ nodes as well as applications that use it
    on real or simulated workloads will help assess how suitable a particular instance type is.
 
 
@@ -85,7 +85,7 @@ On Linux, RabbitMQ will use the following directories for its node data director
  * <code>/var/lib/rabbitmq/</code> to store persistent data like the messages or queues
  * <code>/var/log/rabbitmq/</code> to store logs
 
-See the [File and Directory Locations](/relocate.html) for details.
+See the [File and Directory Locations](./relocate.html) for details.
 
 Those directories can be symlinks to a dedicated storage volume. The node must be stopped
 before symlinking is performed:
@@ -101,16 +101,16 @@ If an EBS volume hits the limit, disk writes will worsen. It is also possible th
 compaction (garbage collection of on-disk data) can fall behind
 disk writes, which means the disk will be filled up quicker than
 disk space can be reclaimed after messages were consumed and
-acknowledged. This will eventually lead to [resource alarms](/alarms.html) and publisher throttling. Please make sure the limit
+acknowledged. This will eventually lead to [resource alarms](./alarms.html) and publisher throttling. Please make sure the limit
 is high and set up I/O operation rate monitoring.
 
 ## <a id="related" class="anchor" href="#related">Further Reading</a>
 
 Several other guides cover topics highly relevant for running RabbitMQ clusters in public clouds:
 
- * [Clustering Fundamentals](/clustering.html)
- * [Peer Discovery](/cluster-formation.html)
+ * [Clustering Fundamentals](./clustering.html)
+ * [Peer Discovery](./cluster-formation.html)
  * [Configuration](configure.html)
- * [Monitoring](/monitoring.html)
- * [Production Checklist](/production-checklist.html)
- * [File and Directory Locations](/relocate.html)
+ * [Monitoring](./monitoring.html)
+ * [Production Checklist](./production-checklist.html)
+ * [File and Directory Locations](./relocate.html)

--- a/site/erlang-client-user-guide.md
+++ b/site/erlang-client-user-guide.md
@@ -19,9 +19,9 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers an Erlang client for RabbitMQ (<a href="/tutorials/amqp-concepts.html">AMQP 0-9-1</a>).
+This guide covers an Erlang client for RabbitMQ (<a href="./tutorials/amqp-concepts.html">AMQP 0-9-1</a>).
 
-This user guide assumes that the reader is familiar with <a href="/tutorials/amqp-concepts.html">basic concepts of AMQP 0-9-1</a>.
+This user guide assumes that the reader is familiar with <a href="./tutorials/amqp-concepts.html">basic concepts of AMQP 0-9-1</a>.
 
 Refer to guides on [connections](connections.html), [channels](channels.html), [queues](queues.html),
 [publishers](./publishers.html), and [consumers](./consumers.html) to learn about those
@@ -73,7 +73,7 @@ The basic usage of the client follows these broad steps:
 1. Make sure the `amqp_client` Erlang application is started
 2. Establish a [connection](connections.html) to a RabbitMQ node
 3. Open a new channel on the connection
-4. Execute <a href="/amqp-0-9-1-quickref.html">AMQP 0-9-1 commands</a> with a channel such as
+4. Execute <a href="./amqp-0-9-1-quickref.html">AMQP 0-9-1 commands</a> with a channel such as
    declaring exchanges and queues, defining bindings between them, publishing messages,
    registering consumers (subscribing), and so on
 5. Register optional event handlers such as [returned message handler](#returns)
@@ -219,11 +219,11 @@ The `#amqp_params_network` record sets the following default values:
       <td>0</td>
     </tr>
     <tr>
-      <td><a href="/heartbeats.html">heartbeat</a></td>
+      <td><a href="./heartbeats.html">heartbeat</a></td>
       <td>0</td>
     </tr>
     <tr>
-      <td><a href="/ssl.html">ssl_options</a></td>
+      <td><a href="./ssl.html">ssl_options</a></td>
       <td>none</td>
     </tr>
     <tr>
@@ -308,7 +308,7 @@ The `#amqp_params_direct` record sets the following default values:
 ### <a id="amqp-uris" class="anchor" href="#amqp-uris">Connecting to RabbitMQ Using an AMQP URI</a>
 
 Instead of working with records such `#amqp_params_network` directly,
-<a href="/uri-spec.html">AMQP URIs</a> may be used.
+<a href="./uri-spec.html">AMQP URIs</a> may be used.
 
 The `amqp_uri:parse/1` function is provided for this purpose.
 It parses an URI and returns the equivalent `#amqp_params_network` or `#amqp_params_direct` record.

--- a/site/erlang-client-user-guide.md
+++ b/site/erlang-client-user-guide.md
@@ -24,7 +24,7 @@ This guide covers an Erlang client for RabbitMQ (<a href="/tutorials/amqp-concep
 This user guide assumes that the reader is familiar with <a href="/tutorials/amqp-concepts.html">basic concepts of AMQP 0-9-1</a>.
 
 Refer to guides on [connections](connections.html), [channels](channels.html), [queues](queues.html),
-[publishers](/publishers.html), and [consumers](/consumers.html) to learn about those
+[publishers](./publishers.html), and [consumers](./consumers.html) to learn about those
 key RabbitMQ concepts in more details.
 
 Some topics covered in this guide include
@@ -100,7 +100,7 @@ The main two modules in the client library are:
  * `amqp_channel`, which exposes most AMQP 0-9-1 operations such as queue declaration
    or consumer registration
 
-Once a connection has been established and successfully [authenticated](/access-control.html),
+Once a connection has been established and successfully [authenticated](./access-control.html),
 and a channel has been opened, an application will typically use the
 `amqp_channel:call/{2,3}` and `amqp_channel:cast/{2,3}` functions
 together with AMQP 0-9-1 protocol method records to perform most operations.
@@ -135,7 +135,7 @@ connections. This communication method assumes that the application that uses
 the client runs on the same Erlang cluster as RabbitMQ nodes.
 
 The use of direct client should be limited to applications that are deployed
-side by side with RabbitMQ. [Shovel](shovel.html) and [Federation](/federation.html)
+side by side with RabbitMQ. [Shovel](shovel.html) and [Federation](./federation.html)
 plugins are two examples of such applications.
 
 In most other cases, developers should prefer the more traditional network client covered above.
@@ -271,7 +271,7 @@ unconditionally.
 
 If neither username nor password are provided, then the connection will be considered
 to be from a fully trusted user which can connect to any virtual host and has
-full [permissions](/access-control.html).
+full [permissions](./access-control.html).
 
 The `#amqp_params_direct` record sets the following default values:
 
@@ -317,7 +317,7 @@ Diverging from the spec, if the hostname is omitted, the
 connection is assumed to be direct and an `#amqp_params_direct{}`
 record is returned.  In addition to the standard host, port, user,
 password and vhost parameters, extra parameters may be specified
-via the query string (e.g. "?heartbeat=5" to configure a [heartbeat timeout](/heartbeats.html)).
+via the query string (e.g. "?heartbeat=5" to configure a [heartbeat timeout](./heartbeats.html)).
 
 
 ## <a id="channels" class="anchor" href="#channels">Creating Channels</a>
@@ -338,7 +338,7 @@ a channel and will be used to execute protocol commands.
 ## <a id="methods" class="anchor" href="#methods">Using AMQP 0-9-1 Methods (Protocol Operations)</a>
 
 The client library's primary way of interacting with RabbitMQ nodes is by
-sending and handling [AMQP 0-9-1 methods](/specification.html)
+sending and handling [AMQP 0-9-1 methods](./specification.html)
 (also referred to as "commands" in this guide) that are represented by records.
 
 The client tries to use sensible default values for each record.
@@ -375,7 +375,7 @@ Declare = #'exchange.declare'{exchange = &lt;&lt;"my_exchange"&gt;&gt;},
 #'exchange.declare_ok'{} = amqp_channel:call(Channel, Declare)
 </pre>
 
-Similarly, a [transient](/queues.html#durability) queue called `my_queue` is created by this code:
+Similarly, a [transient](./queues.html#durability) queue called `my_queue` is created by this code:
 
 <pre class="lang-erlang">
 Declare = #'queue.declare'{queue = &lt;&lt;"my_queue"&gt;&gt;},
@@ -476,7 +476,7 @@ amqp_channel:cast(Channel, Publish, #amqp_msg{payload = Payload})
 </pre>
 
 By default, the properties field of the `#amqp_msg{}` record contains
-a minimal set of [message properties](/publishers.html#message-properties) as a `#'P_basic'{}` properties record.
+a minimal set of [message properties](./publishers.html#message-properties) as a `#'P_basic'{}` properties record.
 
 If an application needs to override any of the defaults, for example,
 to send persistent messages, the `#amqp_msg{}` needs to
@@ -490,15 +490,15 @@ Msg = #amqp_msg{props = Props, payload = Payload},
 amqp_channel:cast(Channel, Publish, Msg)
 </pre>
 
-Full list of [message properties](/publishers.html#message-properties) can be found
+Full list of [message properties](./publishers.html#message-properties) can be found
 in the Publishers guide.
 
 The AMQP 0-9-1 `#'basic.publish'` method is [asynchronous](#call-or-cast):
 the server will not send a response to it. However, clients can opt in
-to have [unroutable messages](/publishers.html#unroutable) returned to them.
+to have [unroutable messages](./publishers.html#unroutable) returned to them.
 This is described in the section on [return message handlers](#returns).
 
-The above example does not use [Publisher Confirms](/confirms.html).
+The above example does not use [Publisher Confirms](./confirms.html).
 To await for all outstanding publishes to be confirmed after publishing
 a batch of messages, use `amqp_channel:wait_for_confirms/2` function.
 It will return a `true` if all outstanding publishes were successfully confirmed
@@ -577,7 +577,7 @@ notification and then proceeds to wait for delivery messages to
 arrive in its process mailbox.
 
 When messages are received, the loop does something useful with the message and
-sends an [acknowledgement](/confirms.html) back to the server.
+sends an [acknowledgement](./confirms.html) back to the server.
 If the consumer is cancelled, a cancellation notification will be sent to the
 consumer process. In this scenario, the receive loop just
 exits. If the application does not wish to explicitly acknowledge
@@ -668,7 +668,7 @@ amqp_channel:call(Channel, #'basic.qos'{prefetch_count = Prefetch})
 </pre>
 
 Applications are recommended to use a prefetch. Learn more in the
-[Publisher Confirms and Consumer Acknowledgements guide](/confirms.html).
+[Publisher Confirms and Consumer Acknowledgements guide](./confirms.html).
 
 
 ## <a id="blocked" class="anchor" href="#blocked">Blocked Connections</a>
@@ -762,8 +762,8 @@ will not produce a response for them.
 ## <a id="example" class="anchor" href="#example">A Basic Example</a>
 
 Below is a complete example of basic usage of the library. For the sake of simplicity
-it does not use [publisher confirms](/confirms.html) and uses a [polling consumer](#polling) which performs
-[manual acknowledgements](/confirms.html).
+it does not use [publisher confirms](./confirms.html) and uses a [polling consumer](#polling) which performs
+[manual acknowledgements](./confirms.html).
 
 <pre class="lang-erlang">
 -module(amqp_example).

--- a/site/erlang-client.md
+++ b/site/erlang-client.md
@@ -24,7 +24,7 @@ to connect to and interact with RabbitMQ nodes.
 
 The library is [open-source](https://github.com/rabbitmq/rabbitmq-erlang-client/),
 and is dual-licensed under [the Apache License v2](https://www.apache.org/licenses/LICENSE-2.0)
-and [the Mozilla Public License v2.0](/mpl.html).
+and [the Mozilla Public License v2.0](./mpl.html).
 
 
 ## <a id="releases" class="anchor" href="#releases">Releases</a>
@@ -55,7 +55,7 @@ dep_rabbit_common = hex &version-erlang-client;
 
 RabbitMQ Erlang client connects to RabbitMQ server nodes.
 
-You will need a running [RabbitMQ node](/download.html) to use with the client
+You will need a running [RabbitMQ node](./download.html) to use with the client
 library.
 
 ## Download the Library and Documentation
@@ -66,7 +66,7 @@ The library is distributed [via hex.pm](https://hex.pm/packages/amqp_client).
 
 ### Documentation
 
-Please refer to the [Erlang RabbitMQ user guide](/erlang-client-user-guide.html).
+Please refer to the [Erlang RabbitMQ user guide](./erlang-client-user-guide.html).
 
 <a href="https://hexdocs.pm/amqp_client/3.8.6/">RabbitMQ Erlang client edoc</a> is available on hexdocs.pm.
 

--- a/site/erlang-client.md
+++ b/site/erlang-client.md
@@ -81,7 +81,7 @@ to download a version of the RabbitMQ Erlang Client library other than the above
 The RabbitMQ Erlang client depends on the RabbitMQ server repository,
 a shared library and a code generation library.
 
-Please see the <a href="/build-erlang-client.html">Erlang client build guide</a> for instructions on
+Please see the <a href="./build-erlang-client.html">Erlang client build guide</a> for instructions on
 compiling from source code.
 
 <table>

--- a/site/extensions.md
+++ b/site/extensions.md
@@ -24,49 +24,49 @@ The RabbitMQ implements a number of extensions of the
 document here.
 
 Some extensions introduce new protocol methods (operations); others rely on existing
-extension points such as [optional queue arguments](/queues.html#optional-arguments).
+extension points such as [optional queue arguments](./queues.html#optional-arguments).
 
 ## Publishing
 
- * [Publisher Confirms](/confirms.html) (aka Publisher Acknowledgements) are a lightweight way to know when
+ * [Publisher Confirms](./confirms.html) (aka Publisher Acknowledgements) are a lightweight way to know when
    RabbitMQ has taken responsibility for messages.
- * [Blocked Connection Notifications](/connection-blocked.html)
+ * [Blocked Connection Notifications](./connection-blocked.html)
    allows clients to be notified when a connection is blocked and unblocked.
 
 ## Consuming
 
- * [Consumer Cancellation Notifications](/consumer-cancel.html) let a consumer know if it has been cancelled by the server.
- * [`basic.nack`](/nack.html) extends `basic.reject` to support rejecting multiple messages at once.
- * [Consumer Priorities](/consumer-priority.html) allow you to send messages to higher priority consumers first.
- * [Direct reply-to](/direct-reply-to.html) allows RPC clients to receive replies to their queries without needing
+ * [Consumer Cancellation Notifications](./consumer-cancel.html) let a consumer know if it has been cancelled by the server.
+ * [`basic.nack`](./nack.html) extends `basic.reject` to support rejecting multiple messages at once.
+ * [Consumer Priorities](./consumer-priority.html) allow you to send messages to higher priority consumers first.
+ * [Direct reply-to](./direct-reply-to.html) allows RPC clients to receive replies to their queries without needing
    to declare a temporary queue.
 
 ## Message Routing
 
- * [Exchange to Exchange Bindings](/e2e.html) allow
+ * [Exchange to Exchange Bindings](./e2e.html) allow
    messages to pass through multiple exchanges for more flexible routing.
- * [Alternate Exchanges](/ae.html) route messages that were otherwise unroutable.
- * [Sender-selected Distribution](/sender-selected.html) allows a publisher to decide where messages
+ * [Alternate Exchanges](./ae.html) route messages that were otherwise unroutable.
+ * [Sender-selected Distribution](./sender-selected.html) allows a publisher to decide where messages
    are routed directly.
 
 ## Message Lifecycle
 
- * [Per-Queue Message TTL](/ttl.html#per-queue-message-ttl)
+ * [Per-Queue Message TTL](./ttl.html#per-queue-message-ttl)
    determines how long an unconsumed message can live in a queue before
    it is automatically deleted.
- * [Per-Message TTL](/ttl.html#per-message-ttl) determines the TTL on a per-message basis.
- * [Queue TTL](/ttl.html#queue-ttl) determines how
+ * [Per-Message TTL](./ttl.html#per-message-ttl) determines the TTL on a per-message basis.
+ * [Queue TTL](./ttl.html#queue-ttl) determines how
    long an unused queue can live before it is automatically deleted.
- * [Dead Letter Exchanges](/dlx.html) ensure messages get re-routed when they are rejected or expire.
+ * [Dead Letter Exchanges](./dlx.html) ensure messages get re-routed when they are rejected or expire.
  * [Queue Length Limit](maxlength.html) allows the maximum length of a queue to be set.
- * [Priority Queues](/priority.html) support the message priority field (in a slightly different way).
+ * [Priority Queues](./priority.html) support the message priority field (in a slightly different way).
 
 ## Authentication and Identity
 
- * The [User-ID](/validated-user-id.html) message property is validated by the server.
+ * The [User-ID](./validated-user-id.html) message property is validated by the server.
  * Clients that advertise the appropriate capability may receive
-   explicit [authentication failure notifications](/auth-notification.html) from the broker.
- * [`update-secret`](/amqp-0-9-1-reference.html#connection.update-secret)
+   explicit [authentication failure notifications](./auth-notification.html) from the broker.
+ * [`update-secret`](./amqp-0-9-1-reference.html#connection.update-secret)
    to be able to renew credentials for an active connection, when those credentials can expire.
 
 
@@ -75,6 +75,6 @@ extension points such as [optional queue arguments](/queues.html#optional-argume
 Some features that were in AMQP 0-8 were deprecated in AMQP
 0-9-1. We have undeprecated some of them and introduced a
 couple of tiny behaviour changes that improve usability of
-the product. Please refer to the [spec differences](/spec-differences.html) page.
+the product. Please refer to the [spec differences](./spec-differences.html) page.
 
-There's also an [AMQP 0-9-1 Errata page](/amqp-0-9-1-errata.html) which explains how various
+There's also an [AMQP 0-9-1 Errata page](./amqp-0-9-1-errata.html) which explains how various

--- a/site/feature-flags.md
+++ b/site/feature-flags.md
@@ -17,7 +17,7 @@ to determine if they are compatible and then communicate together,
 regardless of their version.
 
 This subsystem was introduced in RabbitMQ 3.8.0 to allow **[rolling
-upgrades](/upgrade.html#rolling-upgrades) of cluster members without
+upgrades](./upgrade.html#rolling-upgrades) of cluster members without
 shutting down the entire cluster**.
 
 <p class="box-warning">
@@ -51,14 +51,14 @@ feature flags are enabled.
     <pre class="lang-bash">rabbitmqctl enable_feature_flag &lt;all | name&gt;</pre>
 
 It is also possible to list and enable feature flags from the
-[Management plugin UI](/management.html), in "*Admin > Feature flags*".
+[Management plugin UI](./management.html), in "*Admin > Feature flags*".
 
 ### The Two Examples
 
 #### Example 1: Compatible Nodes
 
 <div style="text-align: center;">
-<img src="/img/feature-flags/compatible-nodes.svg" style="width: 100%; max-width: 400px;"/>
+<img src="./img/feature-flags/compatible-nodes.svg" style="width: 100%; max-width: 400px;"/>
 </div>
 
  * If nodes A and B are not clustered, they can be clustered.
@@ -69,7 +69,7 @@ It is also possible to list and enable feature flags from the
 #### Example 2: Incompatible Nodes
 
 <div style="text-align: center;">
-<img src="/img/feature-flags/incompatible-nodes.svg" style="width: 100%; max-width: 400px;"/>
+<img src="./img/feature-flags/incompatible-nodes.svg" style="width: 100%; max-width: 400px;"/>
 </div>
 
  * If nodes A and B are not clustered, they cannot be clustered because
@@ -88,7 +88,7 @@ in the release notes. Indeed, there are some changes which cannot be
 implemented as feature flags.
 
 <div style="text-align: center;">
-<img src="/img/feature-flags/feature-flags-and-rabbitmq-versions.svg" style="width: 100%; max-width: 647px;"/>
+<img src="./img/feature-flags/feature-flags-and-rabbitmq-versions.svg" style="width: 100%; max-width: 647px;"/>
 </div>
 
 It is also possible to upgrade from RabbitMQ 3.7.x to 3.8.x. Indeed,
@@ -207,10 +207,10 @@ rabbitmqctl -q --formatter pretty_table list_feature_flags
 </pre>
 
 It is also possible to list and enable feature flags from the
-[Management plugin UI](/management.html), in "*Admin > Feature flags*":
+[Management plugin UI](./management.html), in "*Admin > Feature flags*":
 
 <div style="text-align: center;">
-<img src="/img/feature-flags/management-ui-ff-panel.png" style="width: 100%; border: solid 1px #75757f;"/>
+<img src="./img/feature-flags/management-ui-ff-panel.png" style="width: 100%; border: solid 1px #75757f;"/>
 </div>
 
 ## <a id="how-to-disable-feature-flags" class="anchor" href="#how-to-disable-feature-flags">How to Disable Feature Flags</a>
@@ -353,11 +353,11 @@ one of the tier-1 plugins bundled with RabbitMQ.
 
 There are two times when an operator has to consider feature flags:
 
- * When [extending an existing cluster](/clustering.html) by adding
+ * When [extending an existing cluster](./clustering.html) by adding
    nodes using a different version of RabbitMQ (older or newer), the
    operator needs to pay attention to feature flags: they might prevent
    clustering.
- * After [upgrading a cluster](/upgrade.html), the operator should take
+ * After [upgrading a cluster](./upgrade.html), the operator should take
    a look at the new feature flags and perhaps enable them.
 
 A node compares its own list of feature flags with remote nodes' list
@@ -395,14 +395,14 @@ Controlling a remote node with `rabbitmqctl` is only supported if the
 remote node is running the same version of RabbitMQ than `rabbitmqctl`
 comes from.
 
-If [CLI tools](/cli.html) from a different minor/major version of RabbitMQ is
+If [CLI tools](./cli.html) from a different minor/major version of RabbitMQ is
 used on a remote node, they may fail to work as expected or even have unexpected
 side effects on the node.
 
 ##### Load-balancing Requests to the HTTP API
 
 If a request sent to the HTTP API exposed by the [Management
-plugin](/management.html) goes through a load balancer, including one
+plugin](./management.html) goes through a load balancer, including one
 from the management plugin UI, the API's behavior and its response may
 be different, depending on the version of the node which handled the
 request. This is exactly the same if the domain name of the HTTP API

--- a/site/feature-flags.md
+++ b/site/feature-flags.md
@@ -27,7 +27,7 @@ compatible with older release series. Therefore, <strong>a future
 version of RabbitMQ might still require a cluster-wide shutdown for
 upgrading</strong>.
 
-Please always read <a href="/changelog.html">release notes</a> to see if a rolling
+Please always read <a href="./changelog.html">release notes</a> to see if a rolling
 upgrade to the next minor or major RabbitMQ version is possible.
 </p>
 
@@ -269,7 +269,7 @@ one of the tier-1 plugins bundled with RabbitMQ.
   <tr>
     <td><a id="ff-quorum_queue" class="anchor" href="#ff-quorum_queue">quorum_queue</a></td>
     <td>
-      Enables <a href="/quorum-queues.html">quorum queue</a> type.
+      Enables <a href="./quorum-queues.html">quorum queue</a> type.
     </td>
     <td>
       <table class="feature-flag-lifecycle">
@@ -282,7 +282,7 @@ one of the tier-1 plugins bundled with RabbitMQ.
   <tr>
     <td><a id="ff-stream_queue" class="anchor" href="#ff-stream_queue">stream_queue</a></td>
     <td>
-      Enables <a href="/streams.html">streams</a>.
+      Enables <a href="./streams.html">streams</a>.
     </td>
     <td>
       <table class="feature-flag-lifecycle">
@@ -295,7 +295,7 @@ one of the tier-1 plugins bundled with RabbitMQ.
   <tr>
     <td><a id="ff-drop_unroutable_metric" class="anchor" href="#ff-drop_unroutable_metric">drop_unroutable_metric</a></td>
     <td>
-      Dropped <a href="/publishers.html#unroutable">unroutable message</a> metrics.
+      Dropped <a href="./publishers.html#unroutable">unroutable message</a> metrics.
     </td>
     <td>
     <table class="feature-flag-lifecycle">
@@ -308,7 +308,7 @@ one of the tier-1 plugins bundled with RabbitMQ.
   <tr>
     <td><a id="ff-maintenance_mode_status" class="anchor" href="#ff-maintenance_mode_status">maintenance_mode_status</a></td>
     <td>
-      Enable <a href="/upgrade.html#maintenance-mode">maintenance mode</a>, so nodes can be drained for maintenance or upgrade operations.
+      Enable <a href="./upgrade.html#maintenance-mode">maintenance mode</a>, so nodes can be drained for maintenance or upgrade operations.
     </td>
     <td>
     <table class="feature-flag-lifecycle">

--- a/site/federated-exchanges.md
+++ b/site/federated-exchanges.md
@@ -30,7 +30,7 @@ Some covered topics include:
 * [Example topologies](#topology-diagrams)
 * [Implementation details](#details)
 
-A separate [Federation plugin reference](/federation-reference.html) guide is available.
+A separate [Federation plugin reference](./federation-reference.html) guide is available.
 
 Exchange federation is a mechanism that allows a flow of messages through an exchange
 in one location (called the _upstream_ or the source) be replicated to exchanges in other
@@ -45,18 +45,18 @@ The upstream exchanges do not need to be reconfigured. They are assumed
 to be located on a separate node or in a separate cluster.
 
 An upstream definition is a URI with certain recognised query parameters that
-control link connection parameters. Upstreams can be managed using [CLI tools](/cli.html)
+control link connection parameters. Upstreams can be managed using [CLI tools](./cli.html)
 or the HTTP API with [an additional plugin](https://github.com/rabbitmq/rabbitmq-federation-management).
 
 Here is a diagram showing a single upstream exchange (the source exchange) in one
 node linking to a set of two downstream exchanges in two other nodes:
 
-<img src="img/federation/federated-exchange.svg" alt="Basic federated exchange" title="Basic federated exchange"/>
+<img src="./img/federation/federated-exchange.svg" alt="Basic federated exchange" title="Basic federated exchange"/>
 
 When exchange federation is used, usually only a subset of exchanges in a cluster is federated.
 Some exchanges can be inherently local to the "site" (cluster) and its uses.
 
-Exchange federation will propagate [bindings](/tutorials/amqp-concepts.html)
+Exchange federation will propagate [bindings](./tutorials/amqp-concepts.html)
 from the downstream to the upstreams when possible. It will also apply optimizations and propagate messages selectively if needed.
 This is covered in [future sections](#details).
 
@@ -64,8 +64,8 @@ This is covered in [future sections](#details).
 ## <a id="use-cases" class="anchor" href="#use-cases">Use Cases</a>
 
 Federated exchanges can be used to replicate a flow of certain message types to remote locations.
-Combined with continuous [schema synchronisation](/backup.html#definitions-backup) and
-[queue and message TTL](/ttl.html), this can be used to maintain a hot standby
+Combined with continuous [schema synchronisation](./backup.html#definitions-backup) and
+[queue and message TTL](./ttl.html), this can be used to maintain a hot standby
 with reasonably up-to-date data within a controlled time window.
 
 Another use would be to implement massive fanout with a single "source"
@@ -91,7 +91,7 @@ by RabbitMQ and cannot be federated.
 
 ## <a id="usage" class="anchor" href="#usage">Usage and Configuration</a>
 
-Federation configuration uses [runtime parameters and policies](/parameters.html), which means it can be configured
+Federation configuration uses [runtime parameters and policies](./parameters.html), which means it can be configured
 and reconfigured on the fly as system topology changes. There are two key pieces of configuration involved:
 
 * Upstreams: these are remote endpoints in a federated system
@@ -119,10 +119,10 @@ On Windows, use `rabbitmqctl.bat` and suitable PowerShell quoting:
 rabbitmqctl.bat set_parameter federation-upstream origin "{""uri"":""amqp://localhost:5672""}"
 </pre>
 
-More upstream definition parameters are covered in the [Federation Reference guide](/federation-reference.html).
+More upstream definition parameters are covered in the [Federation Reference guide](./federation-reference.html).
 
 Once an upstream has been specified, a policy that controls federation can be added. It is added just like
-any other [policy](/parameters.html#policies), using <code></code>:
+any other [policy](./parameters.html#policies), using <code></code>:
 
 <pre class="lang-bash">
 # Adds a policy named "exchange-federation"
@@ -151,7 +151,7 @@ the one with the highest priority will be used. Multiple policy definitions will
 priorities are equal.
 
 Once configured, a federation link (connection) will be opened for every matching exchange and upstream pair.
-By "matching exchange" here we mean an exchange that is matched by the [federation policy pattern](/parameters.html#policies).
+By "matching exchange" here we mean an exchange that is matched by the [federation policy pattern](./parameters.html#policies).
 If no exchanges matched, no links will be started.
 
 To disable federation for the matching exchanges, delete the policy using its name:
@@ -179,7 +179,7 @@ same type. Mixing types can and likely will lead to confusing routing behaviours
 ## <a id="details" class="anchor" href="#details">Implementation</a>
 
 Inter-broker communication is implemented using AMQP 0-9-1 (optionally
-[secured with TLS](/ssl.html)). Bindings are grouped together and binding operations such as
+[secured with TLS](./ssl.html)). Bindings are grouped together and binding operations such as
 `queue.bind` and `queue.unbind` commands are sent to the upstream side of
 the link when bindings change in the downstream.
 
@@ -191,7 +191,7 @@ The messages are buffered in an internally declared queue created in the upstrea
 exchange's cluster. This is called the _upstream queue_.
 It is the upstream queue which is bound to the upstream
 exchange with the grouped bindings. It is possible to tailor
-some of the properties of this queue in the [upstream configuration](/federation-reference.html#upstreams).
+some of the properties of this queue in the [upstream configuration](./federation-reference.html#upstreams).
 
 
 Here is a detailed diagram showing a single federated
@@ -202,7 +202,7 @@ messages republished by the federated exchange. Some
 potential publisher clients are shown publishing to both
 exchanges.
 
-<img src="img/federation/federation01.png" height="180" alt="Simple federation" title="Simple federation" />
+<img src="./img/federation/federation01.png" height="180" alt="Simple federation" title="Simple federation" />
 
 Publications to either exchange may be received by queues bound to
 the federated exchange, but publications directly to the federated
@@ -215,7 +215,7 @@ exchange.
 We illustrate some example federation topologies. Where RabbitMQ
 brokers are shown in these diagrams indicated by
 
-(indicated by a <img src="img/rabbitmq_logo_30x30.png" height="15"/>)
+(indicated by a <img src="./img/rabbitmq_logo_30x30.png" height="15"/>)
 
 it can be a cluster of nodes or a standalone node.
 
@@ -237,7 +237,7 @@ it can be a cluster of nodes or a standalone node.
           Both consumers can receive messages published by either publisher.
         </p>
 
-        <img src="img/federation/federation02.png" height="215" alt="Symmetric pair" title="Symmetric pair" />
+        <img src="./img/federation/federation02.png" height="215" alt="Symmetric pair" title="Symmetric pair" />
 
         <p>
           Both links are declared with `max-hops=1` so that
@@ -255,7 +255,7 @@ it can be a cluster of nodes or a standalone node.
           but for three exchanges. Each exchange links to both the others.
         </p>
 
-        <img src="img/federation/federation03.png" height="250" alt="Three-way federation" title="Three-way federation" />
+        <img src="./img/federation/federation03.png" height="250" alt="Three-way federation" title="Three-way federation" />
 
         <p>
           Again `max-hops=1` because the "hop distance" to any
@@ -275,7 +275,7 @@ it can be a cluster of nodes or a standalone node.
           received by any consumer connected to any broker in the tree.
         </p>
 
-        <img src="img/federation/federation04.png" height="500" alt="Fan-out" title="Fan-out" />
+        <img src="./img/federation/federation04.png" height="500" alt="Fan-out" title="Fan-out" />
 
         <p>
           Because there are no loops it is not as crucial to get the
@@ -296,7 +296,7 @@ it can be a cluster of nodes or a standalone node.
           once.
         </p>
 
-        <img src="img/federation/federation05.png" height="300" alt="Ring" title="Ring" />
+        <img src="./img/federation/federation05.png" height="300" alt="Ring" title="Ring" />
 
         <p>
           This topology, though relatively cheap in queues and connections, is

--- a/site/federated-queues.md
+++ b/site/federated-queues.md
@@ -29,7 +29,7 @@ Some covered topics include:
 * [Limitations](#limitations) and [pitfalls](#pitfalls) of queue federation
 * [Implementation details](#details)
 
-A separate [Federation plugin reference](/federation-reference.html) guide is available.
+A separate [Federation plugin reference](./federation-reference.html) guide is available.
 
 In addition to [federated exchanges](federated-exchanges.html), RabbitMQ supports federated queues.
 This feature provides a way of balancing the load of a single logical queue
@@ -54,7 +54,7 @@ or the HTTP API with [an additional plugin](https://github.com/rabbitmq/rabbitmq
 The following diagram demonstrates several federated and unfederated
 queues in two RabbitMQ nodes connected using queue federation:
 
-<img src="/img/federation/federated_queues00.png" width="700" alt="Overview of federated queues" />
+<img src="./img/federation/federated_queues00.png" width="700" alt="Overview of federated queues" />
 
 When queue federation is used, usually only a subset of queues in a cluster is federated.
 Some queues can be inherently local to the "site" (cluster) and its uses.
@@ -81,7 +81,7 @@ around in order to perform load balancing.
 Federated queues include a number of limitations or differences compared to their non-federated peers
 as well as federated exchanges.
 
-Queue federation will not propagate [bindings](/tutorials/amqp-concepts.html) from the downstream to the upstreams.
+Queue federation will not propagate [bindings](./tutorials/amqp-concepts.html) from the downstream to the upstreams.
 
 Applications that use <code>basic.get</code> (consume via polling, a highly discouraged practice)
 cannot retrieve messages over federation if there aren't any in a local queue (on the node the client is connected to).
@@ -103,7 +103,7 @@ In order for RabbitMQ to recognize that a queue needs to be federated,
 and what other nodes messages should be consumed from, _downstream_
 (consuming) nodes need to be configured.
 
-<img src="/img/federation/federated_queues01.png" width="700" alt="Federated queue policies" />
+<img src="./img/federation/federated_queues01.png" width="700" alt="Federated queue policies" />
 
 Federation configuration uses [runtime parameters and policies](parameters.html), which means it can be configured
 and reconfigured on the fly as system topology changes. There are two key pieces of configuration involved:

--- a/site/federation-reference.md
+++ b/site/federation-reference.md
@@ -87,7 +87,7 @@ The upstream definition object can contain the following keys:
       <td>
         The  <a href="uri-spec.html">AMQP URI(s)</a> for the upstream.
         See the <a href="uri-query-parameters.html">query parameter reference</a> for the underlying client library extensions
-        (including those for <a href="/ssl.html">TLS</a>) which are available to federation.
+        (including those for <a href="./ssl.html">TLS</a>) which are available to federation.
 
         The value can either be a string, or a list of
         strings. If more than one string is provided, the federation
@@ -102,7 +102,7 @@ The upstream definition object can contain the following keys:
     <tr>
       <td><code>prefetch-count</code></td>
       <td>
-        The <a href="/confirms.html">maximum number of deliveries pending acknowledgement</a> on a link at
+        The <a href="./confirms.html">maximum number of deliveries pending acknowledgement</a> on a link at
         any given time. Default is <code>1000</code>. Increasing this value can improve link
         throughput up to a point but will also result in higher memory usage of the link.
       </td>
@@ -158,7 +158,7 @@ The upstream definition object can contain the following keys:
 
 #### Applying to Federated Exchanges Only
 
-The following upstream parameters are only applicable to <a href="/federated-exchanges.html">federated exchanges</a>.
+The following upstream parameters are only applicable to <a href="./federated-exchanges.html">federated exchanges</a>.
 
 <table>
   <thead>
@@ -202,7 +202,7 @@ The following upstream parameters are only applicable to <a href="/federated-exc
         This setting controls how long the upstream queue will
         last before it is eligible for deletion if the connection is lost.
 
-        This value controls <a href="/ttl.html">TTL settings</a> for the upstream queue.
+        This value controls <a href="./ttl.html">TTL settings</a> for the upstream queue.
       </td>
     </tr>
 
@@ -214,7 +214,7 @@ The following upstream parameters are only applicable to <a href="/federated-exc
         Default is <code>'none'</code>, meaning messages should never expire.
         This does not apply to federated queues.
 
-        This value controls <a href="/ttl.html">TTL settings</a> for the messages in the upstream queue.
+        This value controls <a href="./ttl.html">TTL settings</a> for the messages in the upstream queue.
       </td>
     </tr>
   </tbody>

--- a/site/federation.md
+++ b/site/federation.md
@@ -68,10 +68,10 @@ exchanges</a> and [federated queues](federated-queues.html).
 To use federation, one needs to configure two things
 
 * One or more upstreams that define federation connections
-  to other nodes. This can be done via [runtime parameters](/parameters.html)
+  to other nodes. This can be done via [runtime parameters](./parameters.html)
   or the [federation management plugin](https://github.com/rabbitmq/rabbitmq-federation-management) which
-  adds a federation management tab to the [management UI](/management.html).
-* One or more [policies](/parameters.html#policies) that match exchanges/queues and makes them
+  adds a federation management tab to the [management UI](./management.html).
+* One or more [policies](./parameters.html#policies) that match exchanges/queues and makes them
   federated.
 
 

--- a/site/federation.md
+++ b/site/federation.md
@@ -238,10 +238,10 @@ three exchanges and two upstreams for each there will be six
 links.
 
 For simple use this should be all you need - you will probably
-want to look at the <a href="/uri-spec.html">AMQP URI
+want to look at the <a href="./uri-spec.html">AMQP URI
 reference</a>.
 
-The <a href="/federation-reference.html">federation reference</a> contains
+The <a href="./federation-reference.html">federation reference</a> contains
 more details on upstream parameters and upstream sets.
 
 

--- a/site/feed.xsl
+++ b/site/feed.xsl
@@ -88,7 +88,7 @@ limitations under the License.
                   <xsl:with-param name="date" select="substring($itemdate, 0, 11)"/>
                 </xsl:call-template>
               </span>
-              <a href="/news.html#{$itemdate}"><xsl:value-of select="title|rss1:title|atom:title"/></a>
+              <a href="./news.html#{$itemdate}"><xsl:value-of select="title|rss1:title|atom:title"/></a>
               <br/>
             </xsl:when>
 

--- a/site/flow-control.md
+++ b/site/flow-control.md
@@ -19,7 +19,7 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 This guide covers a back pressure mechanism applied by RabbitMQ nodes
-to publishing connections in order to avoid runaway [memory usage](/memory-use.html) growth.
+to publishing connections in order to avoid runaway [memory usage](./memory-use.html) growth.
 It is necessary because some components in a node can fall behind particularly fast publishers
 as they have to do significantly more work than publishing clients (e.g. replicate data to N
 peer nodes or store it on disk).
@@ -47,6 +47,6 @@ Other components than connections can be in the
 `flow` state. Channels, queues and other parts of the system
 can apply flow control that eventually propagates back to publishing connections.
 
-To find out if consumers and [prefetch settings](/confirms.html)
+To find out if consumers and [prefetch settings](./confirms.html)
 can be key limiting factors, [take a look at relevant metrics](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
-See [Monitoring and Health Checks](/monitoring.html) guide to learn more.
+See [Monitoring and Health Checks](./monitoring.html) guide to learn more.

--- a/site/getstarted.md
+++ b/site/getstarted.md
@@ -33,141 +33,141 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
 <table id="tutorials">
   <tr>
   <td id="tutorial-one">
-    <h2><span class="tute-num">1</span> <a href="/tutorials/tutorial-one-python.html">"Hello World!"</a></h2>
+    <h2><span class="tute-num">1</span> <a href="./tutorials/tutorial-one-python.html">"Hello World!"</a></h2>
     <p>
       The simplest thing that does <em>something</em>
     </p>
     <p><img src="./img/tutorials/python-one.png" width="180"  /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-one-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-one-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-one-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-one-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-one-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-one-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-one-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-one-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-one-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-one-swift.html">Swift</a></li>
-      <li><a href="/tutorials/tutorial-one-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorials/tutorial-one-python.html">Python</a></li>
+      <li><a href="./tutorials/tutorial-one-java.html">Java</a></li>
+      <li><a href="./tutorials/tutorial-one-ruby.html">Ruby</a></li>
+      <li><a href="./tutorials/tutorial-one-php.html">PHP</a></li>
+      <li><a href="./tutorials/tutorial-one-dotnet.html">C#</a></li>
+      <li><a href="./tutorials/tutorial-one-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorials/tutorial-one-go.html">Go</a></li>
+      <li><a href="./tutorials/tutorial-one-elixir.html">Elixir</a></li>
+      <li><a href="./tutorials/tutorial-one-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorials/tutorial-one-swift.html">Swift</a></li>
+      <li><a href="./tutorials/tutorial-one-spring-amqp.html">Spring AMQP</a></li>
     </ul>
   </td>
 
   <td id="tutorial-two">
-    <h2><span class="tute-num">2</span> <a href="/tutorials/tutorial-two-python.html">Work queues</a></h2>
+    <h2><span class="tute-num">2</span> <a href="./tutorials/tutorial-two-python.html">Work queues</a></h2>
     <p>
       Distributing tasks among workers (the <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html">competing consumers pattern</a>)
     </p>
     <p><img src="./img/tutorials/python-two.png" width="180" /></p>
     <ul>
-        <li><a href="/tutorials/tutorial-two-python.html">Python</a></li>
-        <li><a href="/tutorials/tutorial-two-java.html">Java</a></li>
-        <li><a href="/tutorials/tutorial-two-ruby.html">Ruby</a></li>
-        <li><a href="/tutorials/tutorial-two-php.html">PHP</a></li>
-        <li><a href="/tutorials/tutorial-two-dotnet.html">C#</a></li>
-        <li><a href="/tutorials/tutorial-two-javascript.html">JavaScript</a></li>
-        <li><a href="/tutorials/tutorial-two-go.html">Go</a></li>
-        <li><a href="/tutorials/tutorial-two-elixir.html">Elixir</a></li>
-        <li><a href="/tutorials/tutorial-two-objectivec.html">Objective-C</a></li>
-        <li><a href="/tutorials/tutorial-two-swift.html">Swift</a></li>
-        <li><a href="/tutorials/tutorial-two-spring-amqp.html">Spring AMQP</a></li>
+        <li><a href="./tutorials/tutorial-two-python.html">Python</a></li>
+        <li><a href="./tutorials/tutorial-two-java.html">Java</a></li>
+        <li><a href="./tutorials/tutorial-two-ruby.html">Ruby</a></li>
+        <li><a href="./tutorials/tutorial-two-php.html">PHP</a></li>
+        <li><a href="./tutorials/tutorial-two-dotnet.html">C#</a></li>
+        <li><a href="./tutorials/tutorial-two-javascript.html">JavaScript</a></li>
+        <li><a href="./tutorials/tutorial-two-go.html">Go</a></li>
+        <li><a href="./tutorials/tutorial-two-elixir.html">Elixir</a></li>
+        <li><a href="./tutorials/tutorial-two-objectivec.html">Objective-C</a></li>
+        <li><a href="./tutorials/tutorial-two-swift.html">Swift</a></li>
+        <li><a href="./tutorials/tutorial-two-spring-amqp.html">Spring AMQP</a></li>
     </ul>
   </td>
 
   <td id="tutorial-three">
-    <h2><span class="tute-num">3</span> <a href="/tutorials/tutorial-three-python.html">Publish/Subscribe</a></h2>
+    <h2><span class="tute-num">3</span> <a href="./tutorials/tutorial-three-python.html">Publish/Subscribe</a></h2>
     <p>
       Sending messages to many consumers at once
     </p>
     <p><img src="./img/tutorials/python-three.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-three-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-three-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-three-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-three-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-three-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-three-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-three-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-three-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-three-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-three-swift.html">Swift</a></li>
-      <li><a href="/tutorials/tutorial-three-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorials/tutorial-three-python.html">Python</a></li>
+      <li><a href="./tutorials/tutorial-three-java.html">Java</a></li>
+      <li><a href="./tutorials/tutorial-three-ruby.html">Ruby</a></li>
+      <li><a href="./tutorials/tutorial-three-php.html">PHP</a></li>
+      <li><a href="./tutorials/tutorial-three-dotnet.html">C#</a></li>
+      <li><a href="./tutorials/tutorial-three-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorials/tutorial-three-go.html">Go</a></li>
+      <li><a href="./tutorials/tutorial-three-elixir.html">Elixir</a></li>
+      <li><a href="./tutorials/tutorial-three-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorials/tutorial-three-swift.html">Swift</a></li>
+      <li><a href="./tutorials/tutorial-three-spring-amqp.html">Spring AMQP</a></li>
     </ul>
   </td>
   </tr>
 
   <tr>
   <td id="tutorial-four">
-    <h2><span class="tute-num">4</span> <a href="/tutorials/tutorial-four-python.html">Routing</a></h2>
+    <h2><span class="tute-num">4</span> <a href="./tutorials/tutorial-four-python.html">Routing</a></h2>
     <p>
       Receiving messages selectively
     </p>
     <p><img src="./img/tutorials/python-four.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-four-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-four-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-four-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-four-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-four-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-four-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-four-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-four-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-four-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-four-swift.html">Swift</a></li>
-      <li><a href="/tutorials/tutorial-four-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorials/tutorial-four-python.html">Python</a></li>
+      <li><a href="./tutorials/tutorial-four-java.html">Java</a></li>
+      <li><a href="./tutorials/tutorial-four-ruby.html">Ruby</a></li>
+      <li><a href="./tutorials/tutorial-four-php.html">PHP</a></li>
+      <li><a href="./tutorials/tutorial-four-dotnet.html">C#</a></li>
+      <li><a href="./tutorials/tutorial-four-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorials/tutorial-four-go.html">Go</a></li>
+      <li><a href="./tutorials/tutorial-four-elixir.html">Elixir</a></li>
+      <li><a href="./tutorials/tutorial-four-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorials/tutorial-four-swift.html">Swift</a></li>
+      <li><a href="./tutorials/tutorial-four-spring-amqp.html">Spring AMQP</a></li>
     </ul>
   </td>
 
   <td id="tutorial-five">
-    <h2><span class="tute-num">5</span> <a href="/tutorials/tutorial-five-python.html">Topics</a></h2>
+    <h2><span class="tute-num">5</span> <a href="./tutorials/tutorial-five-python.html">Topics</a></h2>
     <p>
       Receiving messages based on a pattern (topics)
     </p>
     <p><img src="./img/tutorials/python-five.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-five-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-five-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-five-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-five-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-five-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-five-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-five-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-five-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-five-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-five-swift.html">Swift</a></li>
-      <li><a href="/tutorials/tutorial-five-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorials/tutorial-five-python.html">Python</a></li>
+      <li><a href="./tutorials/tutorial-five-java.html">Java</a></li>
+      <li><a href="./tutorials/tutorial-five-ruby.html">Ruby</a></li>
+      <li><a href="./tutorials/tutorial-five-php.html">PHP</a></li>
+      <li><a href="./tutorials/tutorial-five-dotnet.html">C#</a></li>
+      <li><a href="./tutorials/tutorial-five-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorials/tutorial-five-go.html">Go</a></li>
+      <li><a href="./tutorials/tutorial-five-elixir.html">Elixir</a></li>
+      <li><a href="./tutorials/tutorial-five-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorials/tutorial-five-swift.html">Swift</a></li>
+      <li><a href="./tutorials/tutorial-five-spring-amqp.html">Spring AMQP</a></li>
     </ul>
   </td>
 
   <td id="tutorial-six">
-    <h2><span class="tute-num">6</span> <a href="/tutorials/tutorial-six-python.html">RPC</a></h2>
+    <h2><span class="tute-num">6</span> <a href="./tutorials/tutorial-six-python.html">RPC</a></h2>
     <p>
       <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html">Request/reply pattern</a> example
     </p>
     <p><img src="./img/tutorials/python-six.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-six-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-six-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-six-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-six-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-six-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-six-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-six-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-six-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-six-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorials/tutorial-six-python.html">Python</a></li>
+      <li><a href="./tutorials/tutorial-six-java.html">Java</a></li>
+      <li><a href="./tutorials/tutorial-six-ruby.html">Ruby</a></li>
+      <li><a href="./tutorials/tutorial-six-php.html">PHP</a></li>
+      <li><a href="./tutorials/tutorial-six-dotnet.html">C#</a></li>
+      <li><a href="./tutorials/tutorial-six-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorials/tutorial-six-go.html">Go</a></li>
+      <li><a href="./tutorials/tutorial-six-elixir.html">Elixir</a></li>
+      <li><a href="./tutorials/tutorial-six-spring-amqp.html">Spring AMQP</a></li>
     </ul>
   </td>
   </tr>
   <tr>
   <td id="tutorial-seven">
-    <h2><span class="tute-num">7</span> <a href="/tutorials/tutorial-seven-java.html">Publisher Confirms</a></h2>
+    <h2><span class="tute-num">7</span> <a href="./tutorials/tutorial-seven-java.html">Publisher Confirms</a></h2>
     <p>
       Reliable publishing with publisher confirms
     </p>
     <ul>
-      <li><a href="/tutorials/tutorial-seven-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-seven-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-seven-php.html">PHP</a></li>
+      <li><a href="./tutorials/tutorial-seven-java.html">Java</a></li>
+      <li><a href="./tutorials/tutorial-seven-dotnet.html">C#</a></li>
+      <li><a href="./tutorials/tutorial-seven-php.html">PHP</a></li>
     </ul>
   </td>
   <td class="tutorial-empty"></td>

--- a/site/getstarted.md
+++ b/site/getstarted.md
@@ -37,7 +37,7 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
     <p>
       The simplest thing that does <em>something</em>
     </p>
-    <p><img src="/img/tutorials/python-one.png" width="180"  /></p>
+    <p><img src="./img/tutorials/python-one.png" width="180"  /></p>
     <ul>
       <li><a href="/tutorials/tutorial-one-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-one-java.html">Java</a></li>
@@ -58,7 +58,7 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
     <p>
       Distributing tasks among workers (the <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html">competing consumers pattern</a>)
     </p>
-    <p><img src="/img/tutorials/python-two.png" width="180" /></p>
+    <p><img src="./img/tutorials/python-two.png" width="180" /></p>
     <ul>
         <li><a href="/tutorials/tutorial-two-python.html">Python</a></li>
         <li><a href="/tutorials/tutorial-two-java.html">Java</a></li>
@@ -79,7 +79,7 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
     <p>
       Sending messages to many consumers at once
     </p>
-    <p><img src="/img/tutorials/python-three.png" height="50" width="180" /></p>
+    <p><img src="./img/tutorials/python-three.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-three-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-three-java.html">Java</a></li>
@@ -102,7 +102,7 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
     <p>
       Receiving messages selectively
     </p>
-    <p><img src="/img/tutorials/python-four.png" height="50" width="180" /></p>
+    <p><img src="./img/tutorials/python-four.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-four-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-four-java.html">Java</a></li>
@@ -123,7 +123,7 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
     <p>
       Receiving messages based on a pattern (topics)
     </p>
-    <p><img src="/img/tutorials/python-five.png" height="50" width="180" /></p>
+    <p><img src="./img/tutorials/python-five.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-five-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-five-java.html">Java</a></li>
@@ -144,7 +144,7 @@ Examples for [RabbitMQ streams](streams.html) on the [RabbitMQ blog](https://blo
     <p>
       <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html">Request/reply pattern</a> example
     </p>
-    <p><img src="/img/tutorials/python-six.png" height="50" width="180" /></p>
+    <p><img src="./img/tutorials/python-six.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-six-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-six-java.html">Java</a></li>
@@ -187,7 +187,7 @@ or the public [RabbitMQ community Slack](https://rabbitmq-slack.herokuapp.com/).
 
 Once you have been through the tutorials (or if you want to
 skip ahead), you may wish to read an
-[Introduction to RabbitMQ Concepts](/tutorials/amqp-concepts.html)
+[Introduction to RabbitMQ Concepts](./tutorials/amqp-concepts.html)
 and browse our
 [AMQP 0-9-1 Quick Reference Guide](amqp-0-9-1-quickref.html).
 
@@ -205,5 +205,5 @@ many more languages and client libraries, for example:
  * [Perl](https://github.com/oylenshpeegul/RabbitMQ-Tutorial-Perl) (using [Net::AMQP::RabbitMQ](http://p3rl.org/Net::AMQP::RabbitMQ))
  * [Scala](https://github.com/rabbitmq/rabbitmq-tutorials/tree/master/scala) (using [RabbitMQ Java client](https://www.rabbitmq.com/api-guide.html))
 
-We also maintain a list of community-developed [clients and developer tools](/devtools.html)
+We also maintain a list of community-developed [clients and developer tools](./devtools.html)
 for a range of platforms.

--- a/site/ha.md
+++ b/site/ha.md
@@ -46,7 +46,7 @@ Topics covered in this guide include
 
 and more.
 
-This guide assumes general familiarity with [RabbitMQ clustering](/clustering.html).
+This guide assumes general familiarity with [RabbitMQ clustering](./clustering.html).
 
 
 ## <a id="what-is-mirroring" class="anchor" href="#what-is-mirroring">What is Queue Mirroring</a>
@@ -66,9 +66,9 @@ node commonly referred as the leader node for that queue. Each queue has
 its own leader node. All operations for a given queue are first applied
 on the queue's leader node and then propagated to mirrors. This
 involves enqueueing publishes, delivering messages to consumers, tracking
-[acknowledgements from consumers](/confirms.html) and so on.
+[acknowledgements from consumers](./confirms.html) and so on.
 
-Queue mirroring implies [a cluster of nodes](/clustering.html).
+Queue mirroring implies [a cluster of nodes](./clustering.html).
 It is therefore not recommended for use
 across a WAN (though of course, clients can still connect
 from as near and as far as needed).
@@ -98,12 +98,12 @@ replaced or removed in a future version.
 
 ## <a id="ways-to-configure" class="anchor" href="#ways-to-configure">How Mirroring is Configured</a>
 
-Mirroring parameters are configured using [policies](/parameters.html#policies). A policy matches
+Mirroring parameters are configured using [policies](./parameters.html#policies). A policy matches
 one or more queues by name (using a regular expression pattern) and
 contains a definition (a map of optional arguments) that are added to the total set of
 properties of the matching queues.
 
-Please see [Runtime Parameters and Policies](/parameters.html#policies) for more information on policies.
+Please see [Runtime Parameters and Policies](./parameters.html#policies) for more information on policies.
 
 
 ## <a id="mirroring-arguments" class="anchor" href="#mirroring-arguments">Queue Arguments that Control Mirroring</a>
@@ -211,7 +211,7 @@ for some queues (or even not use any mirroring).
 ## <a id="how-to-check-i-a-queue-is-mirrored" class="anchor" href="#how-to-check-i-a-queue-is-mirrored">How to Check if a Queue is Mirrored?</a>
 
 Mirrored queues will have a policy name and the number of additional replicas (mirrors)
-next to it on the queue page in the [management UI](/management.html).
+next to it on the queue page in the [management UI](./management.html).
 
 Below is an example of a queue named `two.replicas` which has a leader
 and a mirror:
@@ -247,7 +247,7 @@ rabbitmqctl list_queues name policy pid slave_pids
 If a queue that's expected to be mirroring is not, this usually means that its name
 doesn't match that specified in the policy that controls mirroring or that another
 policy takes priority (and does not enable mirroring).
-See [Runtime Parameters and Policies](/parameters.html#policies) to learn more.
+See [Runtime Parameters and Policies](./parameters.html#policies) to learn more.
 
 
 ## <a id="leader-migration-data-locality" class="anchor" href="#leader-migration-data-locality">Queue Leader Replicas, Leader Migration, Data Locality</a>
@@ -562,7 +562,7 @@ leader as follows:
    by the publisher. From the point of view of the publisher,
    publishing to a mirrored queue is no different from publishing to a non-mirrored one.
 
-If consumers use [automatic acknowledgement mode](/confirms.html), then messages can be lost. This is no different
+If consumers use [automatic acknowledgement mode](./confirms.html), then messages can be lost. This is no different
 from non-mirrored queues, of course: the broker considers a message
 _acknowledged_ as soon as it has been sent to a consumer in automatic acknowledgement mode.
 
@@ -723,7 +723,7 @@ which means permanent loss of a leader with this promotion strategy equates to l
 queue contents.
 
 Systems that use the `when-synced` promotion strategy must use
-[publisher confirms](/confirms.html) in order to detect queue unavailability
+[publisher confirms](./confirms.html) in order to detect queue unavailability
 and broker's inability to enqueue messages.
 
 ### <a id="start-stop" class="anchor" href="#start-stop">Stopping Nodes and Synchronisation</a>

--- a/site/heartbeats.md
+++ b/site/heartbeats.md
@@ -78,7 +78,7 @@ RabbitMQ [configuration](configure.html) exposes the timeout value,
 so do the officially supported client libraries. However some clients might expose
 the interval, potentially causing confusion.
 
-Any traffic (e.g. protocol operations, published messages, [acknowledgements](/confirms.html)) counts for a valid
+Any traffic (e.g. protocol operations, published messages, [acknowledgements](./confirms.html)) counts for a valid
 heartbeat. Clients may choose to send heartbeat frames
 regardless of whether there was any other traffic on the
 connection but some only do it when necessary.
@@ -97,7 +97,7 @@ as frame delivery will be too infrequent to make a practical difference.
 
 Unless [TCP keepalives](#tcp-keepalives) are used instead with an adequately low inactivity detection period,
 *disabling heartbeats is highly discouraged*. If heartbeats are disabled, it will make timely peer unavailability
-detection much less likely. That *would pose a significant risk to data safety*, in particular for [publishers](/publishers.html).
+detection much less likely. That *would pose a significant risk to data safety*, in particular for [publishers](./publishers.html).
 
 
 ## <a id="using-heartbeats-in-java" class="anchor" href="#using-heartbeats-in-java">Enabling Heartbeats with Java Client</a>
@@ -175,7 +175,7 @@ consult your MQTT client's documentation for examples.
 connections to RabbitMQ nodes under the hood. As such, they can be configured
 to use a desired heartbeat value.
 
-Please refer to the [AMQP 0-9-1 URI query parameters reference](/uri-query-parameters.html)
+Please refer to the [AMQP 0-9-1 URI query parameters reference](./uri-query-parameters.html)
 for details.
 
 ## <a id="tcp-keepalives" class="anchor" href="#tcp-keepalives">TCP Keepalives</a>
@@ -225,11 +225,11 @@ Also see the section on low timeouts and false positives above.
 
 ## <a id="troubleshooting" class="anchor" href="#troubleshooting">Troubleshooting Active and Defunct Connections</a>
 
-RabbitMQ nodes will [log connections](/logging.html#connection-lifecycle-events) closed due to missed heartbeats. So will all
+RabbitMQ nodes will [log connections](./logging.html#connection-lifecycle-events) closed due to missed heartbeats. So will all
 officially supported client libraries. Inspecting server and client logs will provide
 valuable information and should be the first troubleshooting step.
 
 It may be necessary to inspect the connections open to or from a node,
 their state, origin, username and effective heartbeat timeout value.
-[Network Troubleshooting](/troubleshooting-networking.html) guide
+[Network Troubleshooting](./troubleshooting-networking.html) guide
 provides an overview of the tools available to help with that.

--- a/site/how.xml
+++ b/site/how.xml
@@ -163,7 +163,7 @@ limitations under the License.
         <li><a href="http://skillsmatter.com/podcast/cloud-grid/use-cases-for-cloud-messaging/rl-311">Cloud Messaging Use Cases</a><br/>
           Alexis' presentation on use cases for cloud messaging at the Cloud and Grid Exchange 2010. The talk discusses what is messaging
           and why it is useful for cloud computing by way of illustrating use cases from RabbitMQ customers. (Download a
-          <a href="/resources/SkillsMatterCloudAndGridExchange2010RabbitMQCloudMessagingUseCases.pdf">PDF of the slides</a>, 3.2MB).
+          <a href="./resources/SkillsMatterCloudAndGridExchange2010RabbitMQCloudMessagingUseCases.pdf">PDF of the slides</a>, 3.2MB).
     </li>
     <li>
     <a href="https://web.archive.org/web/20170115215106/http://helenaedelson.com/?p=685">Why RabbitMQ for Cloud?</a><br/>
@@ -395,7 +395,7 @@ limitations under the License.
       An excellent presentation describing how scale social network activity streams with RabbitMQ, Redis and NoSQL in general.
     </li>
     <li>
-      <a href="/resources/RabbitMQ_usecase_StefanNorberg_Unibet_10xScalabilityAtHalfTheCost.pdf">Unibet</a> [PDF 10.3 MB]<br />
+      <a href="./resources/RabbitMQ_usecase_StefanNorberg_Unibet_10xScalabilityAtHalfTheCost.pdf">Unibet</a> [PDF 10.3 MB]<br />
       Stefan Norberg's presentation on use of RabbitMQ and Kaazing and Terracotta for European scale real time betting at Unibet.
     </li>
     <li>
@@ -464,7 +464,7 @@ limitations under the License.
       Walk through of how you might build a RabbitMQ management tool.
     </li>
     <li>
-      <a href="/resources/ErlangFactorySFBay2010-TonyGarnock-Jones.pdf">HOWTO: Extend RabbitMQ with custom exchange types</a> [PDF 7MB]<br />
+      <a href="./resources/ErlangFactorySFBay2010-TonyGarnock-Jones.pdf">HOWTO: Extend RabbitMQ with custom exchange types</a> [PDF 7MB]<br />
       Tony Garnock-Jones' slides from Erlang Factory SF 2010 that explain how you can build your own
       custom exchange implementations to extend the functionality of RabbitMQ.
     </li>
@@ -553,7 +553,7 @@ limitations under the License.
       A short presentation from Bob Pasker on what messaging systems are for.
     </li>
     <li>
-      <a href="/resources/Queuevol5no4_May2007.pdf">Toward a commodity enterprise middleware</a><br />
+      <a href="./resources/Queuevol5no4_May2007.pdf">Toward a commodity enterprise middleware</a><br />
       Article in ACM Queue from June 2007 by John O'Hara, one of the original creators
       of AMQP. John discusses the origins of AMQP, how it came to be, and how you
       might go about integrating AMQP messaging with legacy middleware. The article entitled 'Toward a

--- a/site/index.xml
+++ b/site/index.xml
@@ -97,7 +97,7 @@ limitations under the License.
           <div class='features'>
             <div class='feature column onethird'>
               <div class='inner'>
-                <img src="img/messaging.svg" height="62" width="71" alt="Asynchronous Messaging" title="Asynchronous Messaging" />
+                <img src="./img/messaging.svg" height="62" width="71" alt="Asynchronous Messaging" title="Asynchronous Messaging" />
                 <h2>Asynchronous Messaging</h2>
                 <p>
                   Supports <a href='/protocols.html'>multiple messaging protocols</a>, <a href='/tutorials/tutorial-two-python.html'>message queuing</a>, <a href='/reliability.html'>delivery acknowledgement</a>, <a href='/tutorials/tutorial-four-python.html'>flexible routing to queues</a>, <a href='/tutorials/amqp-concepts.html'>multiple exchange type</a>.
@@ -106,7 +106,7 @@ limitations under the License.
             </div>
             <div class='feature column onethird'>
               <div class='inner'>
-                <img src="img/monitor.svg" height="62" width="71" alt="Developer Experience" title="Developer Experience" />
+                <img src="./img/monitor.svg" height="62" width="71" alt="Developer Experience" title="Developer Experience" />
                 <h2>Developer Experience</h2>
                 <p>
                   Deploy with <a href='/download.html'>BOSH, Chef, Docker and Puppet</a>. Develop cross-language messaging with favorite programming languages such as: Java, .NET, PHP, Python, JavaScript, Ruby, Go, <a href='/devtools.html'>and many others</a>.
@@ -115,7 +115,7 @@ limitations under the License.
             </div>
             <div class='feature column onethird'>
               <div class='inner'>
-                <img src="img/network.svg" height="62" width="71" alt="Distributed Deployment" title="Distributed Deployment" />
+                <img src="./img/network.svg" height="62" width="71" alt="Distributed Deployment" title="Distributed Deployment" />
                 <h2>Distributed Deployment</h2>
                 <p>
                   Deploy as <a href='/clustering.html'>clusters</a> for high availability and throughput; <a href='/federation.html'>federate</a> across multiple availability zones and regions.
@@ -124,7 +124,7 @@ limitations under the License.
             </div>
             <div class='feature column onethird'>
               <div class='inner'>
-                <img src="img/clouds.svg" height="62" width="71" alt="Enterprise &amp; Cloud Ready" title="Enterprise &amp; Cloud Ready" />
+                <img src="./img/clouds.svg" height="62" width="71" alt="Enterprise &amp; Cloud Ready" title="Enterprise &amp; Cloud Ready" />
                 <h2>Enterprise &amp; Cloud Ready</h2>
                 <p>
                   Pluggable <a href='/authentication.html'>authentication</a>, <a href='/access-control.html'>authorisation</a>, supports <a href='/ssl.html'>TLS</a> and <a href='/ldap.html'>LDAP</a>. Lightweight and easy to deploy in public and private clouds.
@@ -133,7 +133,7 @@ limitations under the License.
             </div>
             <div class='feature column onethird'>
               <div class='inner'>
-                <img src="img/tools.svg" height="62" width="71" alt="Tools &amp; Plugins" title="Tools &amp; Plugins" />
+                <img src="./img/tools.svg" height="62" width="71" alt="Tools &amp; Plugins" title="Tools &amp; Plugins" />
                 <h2>Tools &amp; Plugins</h2>
                 <p>
                   Diverse array of <a href='/devtools.html'>tools and plugins</a> supporting continuous integration, operational metrics, and integration to other enterprise systems. Flexible <a href='/plugins.html'>plug-in approach</a> for extending RabbitMQ functionality.
@@ -142,7 +142,7 @@ limitations under the License.
             </div>
             <div class='feature column onethird'>
               <div class='inner'>
-                <img src="img/gauge.svg" height="62" width="71" alt="Management &amp; Monitoring" title="Management &amp; Monitoring" />
+                <img src="./img/gauge.svg" height="62" width="71" alt="Management &amp; Monitoring" title="Management &amp; Monitoring" />
                 <h2>Management &amp; Monitoring</h2>
                 <p>
                   HTTP-API, command line tool, and UI for <a href='/management.html'>managing and monitoring</a> RabbitMQ.
@@ -183,7 +183,7 @@ limitations under the License.
               <div id='commercialservicesillustration'></div>
             </div>
             <div class='column threequarters'>
-              <img src="img/commercial-distribution-phone.svg" height="111" width="88" />
+              <img src="./img/commercial-distribution-phone.svg" height="111" width="88" />
               <h2>Commercial Distribution</h2>
               <p>
                 VMware offers a <a href="https://tanzu.vmware.com/rabbitmq">range of commercial offerings for RabbitMQ</a>.
@@ -192,7 +192,7 @@ limitations under the License.
                 and a forthcoming <a href="https://tanzu.vmware.com/content/blog/introducing-rabbitmq-for-kubernetes">version for Kubernetes</a>.
                 These distributions include all of the features of the open source version, with some additional management features. Support agreements are part of the commercial licensing.
               </p>
-              <img src="img/support-and-hosting-phone.svg" height="94" width="109" />
+              <img src="./img/support-and-hosting-phone.svg" height="94" width="109" />
               <h2>Support + Hosting</h2>
               <p>
                 VMware provides <a href="https://pivotal.io/rabbitmq">support for open source RabbitMQ</a>,
@@ -205,7 +205,7 @@ limitations under the License.
                 <a href="https://northflank.com/changelog/introducing-managed-rabbit-mq-build-and-scale-with-queues-and-message-brokers">Northflank</a>.
                 RabbitMQ can also be deployed in AWS and Microsoft Azure.
               </p>
-              <img src="img/testing-phone.svg" height="109" width="94" />
+              <img src="./img/testing-phone.svg" height="109" width="94" />
               <h2>Training</h2>
               <p>The following companies provide free, virtual, or instructor-led courses for RabbitMQ:
                 <a href="https://mylearn.vmware.com/mgrReg/courses.cfm?ui=www_edu&amp;a=one&amp;id_subject=94112" target="_blank">VMware</a>,

--- a/site/index.xml
+++ b/site/index.xml
@@ -57,7 +57,7 @@ limitations under the License.
               </p>
               <p>
                 RabbitMQ runs on many operating systems and cloud
-                environments, and provides a <a href="/devtools.html">wide range of developer
+                environments, and provides a <a href="./devtools.html">wide range of developer
                 tools for most popular languages</a>.
               </p>
               <p>
@@ -240,7 +240,7 @@ limitations under the License.
                 <h2>Commercial inquiries</h2>
                 <p><a href='mailto:rabbitmq-sales@pivotal.io'>VMware Sales</a> | <a href='https://support.pivotal.io' target="_blank">VMware Support</a></p>
                 <h2>Other inquiries</h2>
-                <p><a href="/contact.html">Contact us</a></p>
+                <p><a href="./contact.html">Contact us</a></p>
                 <h2>Report a security vulnerability</h2>
                 <p><a href="mailto:security@rabbitmq.com">security@rabbitmq.com</a></p>
                 <h2>Social media</h2>

--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -119,7 +119,7 @@ apt repositories:
      </td>
      <td>
        <strong>Supported <a href="https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/">starting with 3.8.16</a></strong>.
-       See <a href="/which-erlang.html">Erlang compatibility guide</a>.
+       See <a href="./which-erlang.html">Erlang compatibility guide</a>.
      </td>
    </tr>
 
@@ -134,7 +134,7 @@ apt repositories:
      </td>
      <td>
        <strong>Supported <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/wlPIWz3UYHQ">starting with 3.8.4</a></strong>.
-       See <a href="/which-erlang.html">Erlang compatibility guide</a>.
+       See <a href="./which-erlang.html">Erlang compatibility guide</a>.
      </td>
    </tr>
  </tbody>

--- a/site/install-generic-unix.md
+++ b/site/install-generic-unix.md
@@ -22,10 +22,10 @@ limitations under the License.
 RabbitMQ releases include a binary package for Linux, MacOS, and *BSD systems.
 It is minimalistic and not opinionated in how it is installed, configured and managed.
 This package is recommended in environments where more opinionated installation options
-(the [Debian](/install-debian.html) or [RPM packages](/install-rpm.html), [Homebrew](/install-homebrew.html), BSD ports) cannot be used.
+(the [Debian](./install-debian.html) or [RPM packages](./install-rpm.html), [Homebrew](./install-homebrew.html), BSD ports) cannot be used.
 It is also the most convenient option for running multiple versions on the same machine
-in development environments, e.g. [preview release](/snapshots.html) testing.
-There's a separate [binary package for Windows](/install-windows-manual.html).
+in development environments, e.g. [preview release](./snapshots.html) testing.
+There's a separate [binary package for Windows](./install-windows-manual.html).
 
 
 ## <a id="downloads" class="anchor" href="#downloads">Downloads</a>
@@ -55,7 +55,7 @@ There's a separate [binary package for Windows](/install-windows-manual.html).
 
 ### <a id="install-erlang" class="anchor" href="#install-erlang">Make Sure Erlang/OTP is Installed</a>
 
-This package requires a [supported version of Erlang](/which-erlang.html) to be installed
+This package requires a [supported version of Erlang](./which-erlang.html) to be installed
 in order to run.
 
 ### <a id="install" class="anchor" href="#install">Install the Server</a>
@@ -64,7 +64,7 @@ in order to run.
 
 Contained in the tarball is a directory named `rabbitmq_server-&version-server;`. This directory is the node base directory. It should be
 moved to a suitable application directory on the system, such as `/usr/local`.
-The `sbin` directory in that directory contains server and [CLI tool](/cli.html) scripts.
+The `sbin` directory in that directory contains server and [CLI tool](./cli.html) scripts.
 It is a good candidate for including into `PATH`.
 
 
@@ -72,10 +72,10 @@ It is a good candidate for including into `PATH`.
 
 ### <a id="running-generic-unix" class="anchor" href="#running-generic-unix">Running and Managing the Node</a>
 
-Unlike some other installation methods, namely the [Debian](/install-debian.html) and [RPM packages](/install-rpm.html), RabbitMQ
+Unlike some other installation methods, namely the [Debian](./install-debian.html) and [RPM packages](./install-rpm.html), RabbitMQ
 generic UNIX binary build does not require `sudo`. It can be uncompressed
-into any location and started and managed using the scripts and [CLI tools](/cli.html) under `sbin`.
-Default [data directory location](/relocate.html) will be under `./var`,
+into any location and started and managed using the scripts and [CLI tools](./cli.html) under `sbin`.
+Default [data directory location](./relocate.html) will be under `./var`,
 that is, in the installation directory.
 
 #### Starting the Server
@@ -109,14 +109,14 @@ See RabbitMQ [configuration guide](configure.html) to learn more.
 ### <a id="file-locations" class="anchor" href="#file-locations">File Locations</a>
 
 The generic binary build is designed to run without granted
-permissions to directories outside of its base one. The [directories and files](/relocate.html) used by default are
+permissions to directories outside of its base one. The [directories and files](./relocate.html) used by default are
 all held under the installation directory `rabbitmq_server-&version-server;`
 which is in the <span class="envvar">$RABBITMQ_HOME</span>
 variable in the scripts.
 
-The node can be [instructed](/relocate.html) to use more
+The node can be [instructed](./relocate.html) to use more
 conventional system directories for [configuration](configure.html),
-node data directory, [log](/logging.html) files, [plugins](/plugins.html) and so on.
+node data directory, [log](./logging.html) files, [plugins](./plugins.html) and so on.
 In order to make the node use operating system defaults, locate the following line
 
 <pre class="lang-bash">
@@ -138,8 +138,8 @@ node user won't have permissions for.
 
 In particular `RABBITMQ_MNESIA_BASE` and
 `RABBITMQ_LOG_BASE` may need to be created (the server will attempt to create them at startup), and the
-[enabled plugins file](/plugins.html) (`RABBITMQ_ENABLED_PLUGINS_FILE`) will need
-to be writable by [rabbitmq-plugins](/cli.html).
+[enabled plugins file](./plugins.html) (`RABBITMQ_ENABLED_PLUGINS_FILE`) will need
+to be writable by [rabbitmq-plugins](./cli.html).
 
 The configuration files will be looked for in `/etc/rabbitmq/`.
 
@@ -164,13 +164,13 @@ Make sure the following ports are accessible:
  * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
    and is allocated from a dynamic range (computed as server distribution port + 10000 through
    server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672: [HTTP API](/management.html) clients, [management UI](/management.html) and [rabbitmqadmin](/management-cli.html)
-   (only if the [management plugin](/management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](/stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](/mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](/web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](/web-mqtt.html) is enabled)
- * 15692: Prometheus metrics (only if the [Prometheus plugin](/prometheus.html) is enabled)
+ * 15672: [HTTP API](./management.html) clients, [management UI](./management.html) and [rabbitmqadmin](./management-cli.html)
+   (only if the [management plugin](./management.html) is enabled)
+ * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](./stomp.html) is enabled)
+ * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](./mqtt.html) is enabled
+ * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](./web-stomp.html) is enabled)
+ * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](./web-mqtt.html) is enabled)
+ * 15692: Prometheus metrics (only if the [Prometheus plugin](./prometheus.html) is enabled)
 
 It is possible to [configure RabbitMQ](configure.html)
 to use [different ports and specific network interfaces](networking.html).
@@ -197,7 +197,7 @@ commands will report the node absence if no broker is running.
  * Invoke `rabbitmqctl stop` or `rabbitmqctl shutdown` to stop the server
  * Invoke `rabbitmq-diagnostics status` to check whether it is running
 
-See [CLI tools guide](/cli.html) to learn more.
+See [CLI tools guide](./cli.html) to learn more.
 
 
 ## <a id="kernel-resource-limits" class="anchor" href="#kernel-resource-limits">Controlling System Limits on Linux</a>

--- a/site/install-homebrew.md
+++ b/site/install-homebrew.md
@@ -23,7 +23,7 @@ limitations under the License.
 [RabbitMQ formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/rabbitmq.rb) is available from
 [Homebrew](https://brew.sh/)'s core tap (out of the box).
 
-The formula will also install a reasonably recent [supported Erlang/OTP version](/which-erlang.html)
+The formula will also install a reasonably recent [supported Erlang/OTP version](./which-erlang.html)
 as a dependency.
 
 
@@ -41,11 +41,11 @@ Then, install RabbitMQ server with:
 brew install rabbitmq
 </pre>
 
-Installing the RabbitMQ formula will install key dependencies such as a [supported Erlang/OTP version](/which-erlang.html).
+Installing the RabbitMQ formula will install key dependencies such as a [supported Erlang/OTP version](./which-erlang.html).
 
 ## <a id="operations" class="anchor" href="#operations">Operations</a>
 
-The RabbitMQ server scripts and [CLI tools](/cli.html) are installed into the `sbin` directory under `/usr/local/Cellar/rabbitmq/<version>/`,
+The RabbitMQ server scripts and [CLI tools](./cli.html) are installed into the `sbin` directory under `/usr/local/Cellar/rabbitmq/<version>/`,
 which is accessible from `/usr/local/opt/rabbitmq/sbin`. Links to binaries have been created under `/usr/local/sbin`.
 In case that directory is not in `PATH` it's recommended to append it:
 

--- a/site/install-solaris.md
+++ b/site/install-solaris.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Installing on Solaris
 
-The [Generic binary build](/install-generic-unix.html) installation instructions may be used to install
+The [Generic binary build](./install-generic-unix.html) installation instructions may be used to install
 RabbitMQ on Solaris, with two modifications.
 
 

--- a/site/install-standalone-mac.md
+++ b/site/install-standalone-mac.md
@@ -23,6 +23,6 @@ RabbitMQ releases used to include a special binary package for macOS that bundle
 a supported version of Erlang/OTP. As of September 2019, this package has been discontinued.
 It will no longer be produced for new RabbitMQ releases.
 
-macOS users should use the [Homebrew formula](/install-homebrew.html)
-or the [generic binary build](/install-generic-unix.html) (requires a [supported version of Erlang](/which-erlang.html)
+macOS users should use the [Homebrew formula](./install-homebrew.html)
+or the [generic binary build](./install-generic-unix.html) (requires a [supported version of Erlang](./which-erlang.html)
 to be installed separately) to provision RabbitMQ.

--- a/site/install-windows-manual.md
+++ b/site/install-windows-manual.md
@@ -20,12 +20,12 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 This guide describes how RabbitMQ can be installed and configured manually on Windows. In general
-we recommend using one the [more automation-friendly options for Windows](/install-windows.html) when possible.
+we recommend using one the [more automation-friendly options for Windows](./install-windows.html) when possible.
 
 
 ## <a id="install-erlang" class="anchor" href="#install-erlang">Install Erlang/OTP</a>
 
-RabbitMQ requires a 64-bit [supported version of Erlang](/which-erlang.html) for Windows to be installed.
+RabbitMQ requires a 64-bit [supported version of Erlang](./which-erlang.html) for Windows to be installed.
 Latest binary builds for Windows can be obtained from the [Erlang/OTP Version Tree](https://erlang.org/download/otp_versions_tree.html) page.
 
 Erlang will appear in the Start Menu,
@@ -83,7 +83,7 @@ into `&dir-server-windows;`
 
 ## <a id="erlang-cookie" class="anchor" href="#erlang-cookie">Synchronise the Erlang Cookie</a>
 
-The Erlang cookie is a shared secret used for authentication between [RabbitMQ nodes](/clustering.html) and [CLI tools](/cli.html).
+The Erlang cookie is a shared secret used for authentication between [RabbitMQ nodes](./clustering.html) and [CLI tools](./cli.html).
 The value is stored in a file commonly referred to as the Erlang cookie file.
 
 The cookie file used by the service account and the user
@@ -91,7 +91,7 @@ running `rabbitmqctl.bat` must be synchronised for
 CLI tools such as `rabbitmqctl.bat` to function. All nodes in a cluster must have the same
 cookie value (cookie file contents).
 
-Please see [How CLI Tools Authenticate to Nodes (and Nodes to Each Other): the Erlang Cookie](/cli.html#erlang-cookie) for details.
+Please see [How CLI Tools Authenticate to Nodes (and Nodes to Each Other): the Erlang Cookie](./cli.html#erlang-cookie) for details.
 
 
 ## <a id="locating-binaries-and-data" class="anchor" href="#locating-binaries-and-data">Locating CLI Tools and App Data</a>
@@ -140,9 +140,9 @@ e.g. <code>C:\Documents and Settings\<span class="envvar">%USERNAME%</span>\Appl
 Execute `echo %APPDATA%` at a Command Prompt
 to find this directory. Alternatively, Start&#xA0;>&#xA0;Run&#xA0;`%APPDATA%` will open this folder.
 
-A node can be [configured](configure.html) to use a [different data directory](/relocate.html)
+A node can be [configured](configure.html) to use a [different data directory](./relocate.html)
 using one of these environment variables: `RABBITMQ_BASE`, `RABBITMQ_MNESIA_BASE` or
-`RABBITMQ_MNESIA_DIR`. Please read [the relocation guide](/relocate.html) for a description
+`RABBITMQ_MNESIA_DIR`. Please read [the relocation guide](./relocate.html) for a description
 of how each of these variables works.
 
 
@@ -153,8 +153,8 @@ script in `sbin`.
 
 ### Customise RabbitMQ Environment Variables
 
-The service will run fine using its default settings. It is possible to [customise the RabbitMQ environment](/configure.html#customise-windows-environment)
-or edit [configuration](/configure.html#configuration-files).
+The service will run fine using its default settings. It is possible to [customise the RabbitMQ environment](./configure.html#customise-windows-environment)
+or edit [configuration](./configure.html#configuration-files).
 
 **Important**: after setting environment variables, it is necessary to restart the node.
 
@@ -193,8 +193,8 @@ The service runs using the `rabbitmq-service.bat` script in `sbin`.
 
 ### Customise RabbitMQ Environment Variables
 
-The service will run fine using its default settings. It is possible to [customise the RabbitMQ environment](/configure.html#customise-windows-environment)
-or edit [configuration](/configure.html#configuration-files).
+The service will run fine using its default settings. It is possible to [customise the RabbitMQ environment](./configure.html#customise-windows-environment)
+or edit [configuration](./configure.html#configuration-files).
 
 **Important**: after setting environment variables, it is necessary to reinstall the service.
 
@@ -248,8 +248,8 @@ Links to RabbitMQ directories can be found in the Start Menu.
 
 There is also a link to a command prompt window that
 will start in the sbin dir, in the Start Menu. This is
-the most convenient way to run the [command line tools](/cli.html).
-Note that CLI tools will have to [authenticate to the RabbitMQ node](/cli.html#erlang-cookie) running locally. That involves a shared secret file
+the most convenient way to run the [command line tools](./cli.html).
+Note that CLI tools will have to [authenticate to the RabbitMQ node](./cli.html#erlang-cookie) running locally. That involves a shared secret file
 which has to be placed into the correct location for the user.
 
 ### Stopping a Node
@@ -271,12 +271,12 @@ the node if it is running:
 rabbitmqctl.bat status
 </pre>
 
-See [RabbitMQ CLI tools guide](/cli.html) and the [Monitoring and Health Checks guide](/monitoring.html) for details.
+See [RabbitMQ CLI tools guide](./cli.html) and the [Monitoring and Health Checks guide](./monitoring.html) for details.
 
 ### <a id="server-logs" class="anchor" href="#server-logs">Log Files and Management</a>
 
 Server logs are critically important in troubleshooting and root cause analysis.
-See [Logging](/logging.html) and [File and Directory Location](/relocate.html) guides
+See [Logging](./logging.html) and [File and Directory Location](./relocate.html) guides
 to learn about log file location, log rotation and more.
 
 ### Troubleshooting When Running as a Service
@@ -324,12 +324,12 @@ Make sure the following ports are accessible:
  * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
    and is allocated from a dynamic range (computed as server distribution port + 10000 through
    server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672: [HTTP API](/management.html) clients, [management UI](/management.html) and [rabbitmqadmin](/management-cli.html)
-   (only if the [management plugin](/management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](/stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](/mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](/web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](/web-mqtt.html) is enabled)
+ * 15672: [HTTP API](./management.html) clients, [management UI](./management.html) and [rabbitmqadmin](./management-cli.html)
+   (only if the [management plugin](./management.html) is enabled)
+ * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](./stomp.html) is enabled)
+ * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](./mqtt.html) is enabled
+ * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](./web-stomp.html) is enabled)
+ * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](./web-mqtt.html) is enabled)
 
 It is possible to [configure RabbitMQ](configure.html)
 to use [different ports and specific network interfaces](networking.html).

--- a/site/install-windows.md
+++ b/site/install-windows.md
@@ -35,9 +35,9 @@ The guide also covers a few post-installation topics in the context of Windows:
  * [Log file location](#server-logs)
  * [Default user limitations](#default-user-access)
 
- and more. These topics are covered in more details in the [rest of documentation guides](/documentation.html).
+ and more. These topics are covered in more details in the [rest of documentation guides](./documentation.html).
 
-A separate companion guide covers known [Windows-specific issues](/windows-quirks.html)
+A separate companion guide covers known [Windows-specific issues](./windows-quirks.html)
 and ways to mitigate them.
 
 
@@ -61,7 +61,7 @@ The Chocolatey RabbitMQ package is open source and can be [found on GitHub](http
 
 ## <a id="installer" class="anchor" href="#installer">Using the Installer</a>
 
-The official RabbitMQ installer is produced for [every RabbitMQ release](/changelog.html).
+The official RabbitMQ installer is produced for [every RabbitMQ release](./changelog.html).
 
 Compared to [installation via Chocolatey](#chocolatey), this option gives Windows users
 the most flexibility but also requires them to be
@@ -77,11 +77,11 @@ aware of certain assumptions and requirements in the installer:
 When these conditions are not met, Windows service and CLI tools may require
 reinstallation or other manual steps to get them to function as expected.
 
-This is covered in more detail in the [Windows-specific Issues](/windows-quirks.html) guide.
+This is covered in more detail in the [Windows-specific Issues](./windows-quirks.html) guide.
 
 ### Dependencies
 
-RabbitMQ requires a 64-bit [supported version of Erlang](/which-erlang.html) for Windows to be installed.
+RabbitMQ requires a 64-bit [supported version of Erlang](./which-erlang.html) for Windows to be installed.
 Latest binary builds for Windows can be obtained from the [Erlang/OTP Version Tree](https://erlang.org/download/otp_versions_tree.html) page.
 
 Note that Erlang must be installed **using an administrative account** or it won't be
@@ -122,16 +122,16 @@ can be managed from the Start menu.
 
 ## <a id="cli" class="anchor" href="#cli">CLI Tools</a>
 
-RabbitMQ nodes are often managed, inspected and operated using [CLI Tools](/cli.html)
+RabbitMQ nodes are often managed, inspected and operated using [CLI Tools](./cli.html)
 in [PowerShell](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/powershell).
 
 On Windows, CLI tools have a `.bat` suffix compared to other platforms. For example,
 `rabbitmqctl` on Windows is invoked as `rabbitmqctl.bat`.
 
-In order for these tools to work they must be able to [authenticate with RabbitMQ nodes](/cli.html#erlang-cookie)
+In order for these tools to work they must be able to [authenticate with RabbitMQ nodes](./cli.html#erlang-cookie)
 using a shared secret file called the Erlang cookie.
 
-The main [CLI tools guide](/cli.html) covers most topics related to command line tool usage.
+The main [CLI tools guide](./cli.html) covers most topics related to command line tool usage.
 
 In order to explore what commands various RabbitMQ CLI tools provide, use the `help` command:
 
@@ -155,12 +155,12 @@ rabbitmqctl.bat help add_user
 
 ## <a id="cli-cookie-file-location" class="anchor" href="#cli-cookie-file-location">Cookie File Location</a>
 
-On Windows, the [cookie file location](/cli.html#cookie-file-locations) depends on
+On Windows, the [cookie file location](./cli.html#cookie-file-locations) depends on
 whether the `HOMEDRIVE` and `HOMEPATH` environment variables are set.
 
-If RabbitMQ is installed using a non-administrative account, a [shared secret](/cli.html#erlang-cookie) file
+If RabbitMQ is installed using a non-administrative account, a [shared secret](./cli.html#erlang-cookie) file
 used by nodes and CLI tools will not be placed into a correct location,
-leading to [authentication failures](/cli.html#cli-authentication-failures) when `rabbitmqctl.bat`
+leading to [authentication failures](./cli.html#cli-authentication-failures) when `rabbitmqctl.bat`
 and other CLI tools are used.
 
 One of these options can be used to mitigate:
@@ -173,17 +173,17 @@ One of these options can be used to mitigate:
 ## <a id="configure" class="anchor" href="#configure">Node Configuration</a>
 
 The service starts using its default [settings](configure.html), listening
-for connections on [default interfaces](/networking.html#interfaces) and [ports](#ports).
+for connections on [default interfaces](./networking.html#interfaces) and [ports](#ports).
 
-Node configuration is primarily done using a [configuration file](/configure.html#configuration-files).
-A number of available [environment variables](/configure.html#customise-windows-environment) can be used
-to control node's [data location](/relocate.html), configuration file path and so on.
+Node configuration is primarily done using a [configuration file](./configure.html#configuration-files).
+A number of available [environment variables](./configure.html#customise-windows-environment) can be used
+to control node's [data location](./relocate.html), configuration file path and so on.
 
 This is covered in more detail in the [Configuration guide](configure.html)
 
 ### Environment Variable Changes on Windows
 
-**Important**: after setting environment variables, it is necessary to [**re-install** the Windows service](/configure.html#rabbitmq-env-file-windows). Restarting the service will not be sufficient.
+**Important**: after setting environment variables, it is necessary to [**re-install** the Windows service](./configure.html#rabbitmq-env-file-windows). Restarting the service will not be sufficient.
 
 
 ## <a id="managing" class="anchor" href="#managing">Managing a RabbitMQ Node</a>
@@ -209,7 +209,7 @@ rabbitmqctl.bat stop
 
 ### <a id="status" class="anchor" href="#status">Checking Node Status</a>
 
-The following [CLI command](#cli) runs a basic [health check](/monitoring.html#health-checks)
+The following [CLI command](#cli) runs a basic [health check](./monitoring.html#health-checks)
 and displays some information about the node if it is running.
 
 <pre class="lang-powershell">
@@ -223,13 +223,13 @@ two conditions must be true:
  * The node must be running
  * `rabbitmqctl.bat` must be able to authenticate with the node
 
-See the [CLI tools section](#cli) and the [Monitoring and Health Checks guide](/monitoring.html)
+See the [CLI tools section](#cli) and the [Monitoring and Health Checks guide](./monitoring.html)
 to learn more.
 
 ### <a id="server-logs" class="anchor" href="#server-logs">Log Files and Management</a>
 
 Server logs are critically important in troubleshooting and root cause analysis.
-See [Logging](/logging.html) and [File and Directory Location](/relocate.html) guides
+See [Logging](./logging.html) and [File and Directory Location](./relocate.html) guides
 to learn about log file location, log rotation and more.
 
 
@@ -274,12 +274,12 @@ Make sure the following ports are accessible:
  * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
    and is allocated from a dynamic range (computed as server distribution port + 10000 through
    server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672: [HTTP API](/management.html) clients, [management UI](/management.html) and [rabbitmqadmin](/management-cli.html)
-   (only if the [management plugin](/management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](/stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](/mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](/web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](/web-mqtt.html) is enabled)
+ * 15672: [HTTP API](./management.html) clients, [management UI](./management.html) and [rabbitmqadmin](./management-cli.html)
+   (only if the [management plugin](./management.html) is enabled)
+ * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](./stomp.html) is enabled)
+ * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](./mqtt.html) is enabled
+ * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](./web-stomp.html) is enabled)
+ * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](./web-mqtt.html) is enabled)
 
 It is possible to [configure RabbitMQ](configure.html)
 to use [different ports and specific network interfaces](networking.html).
@@ -298,5 +298,5 @@ architecture.
 In the event that the Erlang VM terminates when RabbitMQ is running
 as a service, rather than writing the crash dump to the current
 directory (which doesn't make sense for a service) it is written
-to an `erl_crash.dump` file in the [base directory](/relocate.html) of
+to an `erl_crash.dump` file in the [base directory](./relocate.html) of
 the RabbitMQ server, defaulting to `%APPDATA%\%RABBITMQ_SERVICENAME%` - typically `%APPDATA%\RabbitMQ` otherwise.

--- a/site/installing-plugins.md
+++ b/site/installing-plugins.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 This guide describes installation of 3rd party plugins.
 For an overview of the plugin mechanism, plugin activation and
-the list of tier 1 (core) plugins, see the [main Plugins guide](/plugins.html).
+the list of tier 1 (core) plugins, see the [main Plugins guide](./plugins.html).
 
 
 ## <a id="installing-custom-plugins" class="anchor" href="#installing-custom-plugins">Installing 3rd Party Plugins</a>
@@ -34,10 +34,10 @@ directories specified by <span class="envvar">$RABBITMQ_PLUGINS_DIR</span>.
 Assuming that plugins correctly specify a dependency on the core RabbitMQ server
 and their files were copied to the correct directory, they will show up in
 `rabbitmq-plugins list` and can be enabled with
-`rabbitmq-plugins enable`. This is covered the [Plugins guide](/plugins.html).
+`rabbitmq-plugins enable`. This is covered the [Plugins guide](./plugins.html).
 
 The plugins directory location is determined by the `RABBITMQ_PLUGINS_DIR`> environment variable.
-Its [default location](/relocate.html) depends on how RabbitMQ was installed. Some common values are:
+Its [default location](./relocate.html) depends on how RabbitMQ was installed. Some common values are:
 
 <table>
   <tr>

--- a/site/java-client.md
+++ b/site/java-client.md
@@ -167,7 +167,7 @@ This means it is no longer necessary to <i>bundleise</i> or
 ## GitHub Repositories
 
 The RabbitMQ Java client depends on the code generation library module.
-Please see the <a href="/build-java-client.html">build page</a> for instructions on
+Please see the <a href="./build-java-client.html">build page</a> for instructions on
 compiling from source code.
 
 <table>

--- a/site/java-client.md
+++ b/site/java-client.md
@@ -22,12 +22,12 @@ limitations under the License.
 The RabbitMQ Java client library allows Java and JVM-based applications
 to connect to and interact with RabbitMQ nodes.
 
-5.x release series of this library [require JDK 8](/java-versions.html), both for compilation and at runtime. On Android,
+5.x release series of this library [require JDK 8](./java-versions.html), both for compilation and at runtime. On Android,
 this means only [Android 7.0 or later](https://developer.android.com/guide/platform/j8-jack.html) versions are supported.
 
-4.x release series [support JDK 6](/java-versions.html) and Android versions prior to 7.0.
+4.x release series [support JDK 6](./java-versions.html) and Android versions prior to 7.0.
 
-See the [RabbitMQ Java libraries support page](/java-versions.html) for the support timeline.
+See the [RabbitMQ Java libraries support page](./java-versions.html) for the support timeline.
 
 ### <a id="licensing" class="anchor" href="#licensing">Licensing</a>
 
@@ -45,7 +45,7 @@ a commercial product. Codebases that are licensed under the GPLv2 may choose GPL
 
 RabbitMQ Java client connects to RabbitMQ server nodes.
 
-You will need a running [RabbitMQ node](/download.html) to use with the client
+You will need a running [RabbitMQ node](./download.html) to use with the client
 library.
 
 ### Latest Version
@@ -118,8 +118,8 @@ source.
 </table>
 
 
-See the [Signatures guide](/signatures.html) for details on how to verify package signatures, and the
-[Java client build guide](/build-java-client.html) for instructions on compiling from source-code.
+See the [Signatures guide](./signatures.html) for details on how to verify package signatures, and the
+[Java client build guide](./build-java-client.html) for instructions on compiling from source-code.
 
 ### The Documentation
 

--- a/site/java-tools.md
+++ b/site/java-tools.md
@@ -33,7 +33,7 @@ PerfTest documentation is hosted on GitHub Pages:
 ## <a id="tracer" class="anchor" href="#tracer">Tracer</a>
 
 The tracer is a very basic, very simple AMQP 0-9-1 protocol analyzer, similar in
-purpose to [Wireshark](/amqp-wireshark.html).
+purpose to [Wireshark](./amqp-wireshark.html).
 Use it with the `runtracer` or `runtracer.bat` script:
 
 <pre class="lang-bash">

--- a/site/jms-client-compliance.md
+++ b/site/jms-client-compliance.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # JMS Client Reference
 
-This page annotates the [RabbitMQ JMS Client](/jms-client.html) implementation
+This page annotates the [RabbitMQ JMS Client](./jms-client.html) implementation
 of the JMS 1.1 API.
 
 You can download the JMS 1.1 specification and API documentation

--- a/site/jms-client.md
+++ b/site/jms-client.md
@@ -22,12 +22,12 @@ limitations under the License.
 RabbitMQ is not a JMS provider but includes [a plugin](https://github.com/rabbitmq/rabbitmq-server/tree/v3.9.x/deps/rabbitmq_jms_topic_exchange)
 needed to support the JMS Queue and Topic messaging models. JMS Client
 for RabbitMQ implements the JMS 1.1 specification on top of the
-[RabbitMQ Java client](/api-guide.html), thus allowing new and
+[RabbitMQ Java client](./api-guide.html), thus allowing new and
 existing JMS applications to connect to RabbitMQ.
 
 The plugin and the JMS client are meant to work and be used together.
 
-See the [RabbitMQ Java libraries support page](/java-versions.html) for the support timeline
+See the [RabbitMQ Java libraries support page](./java-versions.html) for the support timeline
 of the RabbitMQ JMS Client library.
 
 ## <a id="components" class="anchor" href="#components">Components</a>
@@ -190,11 +190,11 @@ The following table lists all of the attributes/properties that are available.
 | `factory`                           |    Yes     | JMS Client for RabbitMQ `ObjectFactory` class, always `com.rabbitmq.jms.admin.RMQObjectFactory`.                                                                                                                                                                                                                                                             |
 | `username`                          |    No      | Name to use to authenticate a connection with the RabbitMQ broker. The default is "guest".                                                                                                                                                                                                                                                              |
 | `password`                          |    No      | Password to use to authenticate a connection with the RabbitMQ broker. The default is "guest".                                                                                                                                                                                                                                                          |
-| `virtualHost`                       |    No      | RabbitMQ [virtual host](/vhosts.html) within which the application will operate. The default is "/".                                                                                                                                                                                                                                                                    |
+| `virtualHost`                       |    No      | RabbitMQ [virtual host](./vhosts.html) within which the application will operate. The default is "/".                                                                                                                                                                                                                                                                    |
 | `host`                              |    No      | Host on which RabbitMQ is running. The default is "localhost".                                                                                                                                                                                                                                                                                          |
-| `port`                              |    No      | RabbitMQ port used for connections. The default is "5672" unless this is a [TLS connection](/ssl.html), in which case the default is "5671".                                                                                                                                                                                                                        |
+| `port`                              |    No      | RabbitMQ port used for connections. The default is "5672" unless this is a [TLS connection](./ssl.html), in which case the default is "5671".                                                                                                                                                                                                                        |
 | `ssl`                               |    No      | Whether to use an SSL connection to RabbitMQ. The default is "false". See the `useSslProtocol` methods for more information.                                                                                                                                                                                                                                                                                 |
-| `uri`                               |    No      | The [AMQP 0-9-1 URI](/uri-spec.html) string used to establish a RabbitMQ connection. The value can encode the `host`, `port`, `username`, `password` and `virtualHost` in a single string. Both 'amqp' and 'amqps' schemes are accepted. Note: this property sets other properties and the set order is unspecified. |                                                                                                                                                                                                                                                                                                                                                      |
+| `uri`                               |    No      | The [AMQP 0-9-1 URI](./uri-spec.html) string used to establish a RabbitMQ connection. The value can encode the `host`, `port`, `username`, `password` and `virtualHost` in a single string. Both 'amqp' and 'amqps' schemes are accepted. Note: this property sets other properties and the set order is unspecified. |                                                                                                                                                                                                                                                                                                                                                      |
 | `onMessageTimeoutMs`                |    No      | How long to wait for `MessageListener#onMessage()` to return, in milliseconds. Default is 2000 ms. |
 | `preferProducerMessageProperty`     |    No      | Whether `MessageProducer` properties (delivery mode, priority, TTL) take precedence over respective `Message` properties or not. Default is true (which is compliant to the JMS specification). |
 | `requeueOnMessageListenerException` |    No      | Whether requeuing messages on a `RuntimeException` in the `MessageListener` or not. Default is false. |
@@ -381,7 +381,7 @@ for configuration details.
 
 ## <a id="publisher-confirms" class="anchor" href="#publisher-confirms">Publisher Confirms</a>
 
-[Publisher confirms](/confirms.html#publisher-confirms) are a RabbitMQ extension to implement reliable
+[Publisher confirms](./confirms.html#publisher-confirms) are a RabbitMQ extension to implement reliable
 publishing. This feature builds on top of the AMQP protocol, but the JMS client
 provides an API to use it. This allows to benefit from a reliability feature without
 diverging too much from the JMS API.
@@ -401,7 +401,7 @@ Note the `ConfirmListener` is not a good place to execute long-running
 tasks. Those should be executed in a dedicated thread, using e.g. an `ExecutorService`.
 
 Typical operations in a `ConfirmListener` are logging or message re-publishing (in case
-of nacks). The [publish confirms tutorial](/tutorials/tutorial-seven-java.html) provides more guidance. It aims for the
+of nacks). The [publish confirms tutorial](./tutorials/tutorial-seven-java.html) provides more guidance. It aims for the
 AMQP Java client, but principles remain the same for the JMS client.
 
 ## <a id="rpc-support" class="anchor" href="#rpc-support">Support for Request/Reply (a.k.a. RPC)</a>
@@ -580,7 +580,7 @@ acknowledgement behaviours.
 
 ## <a id="jms_topic_support"></a>JMS Topic Support
 
-JMS topics are implemented using an AMQP [topic exchange](/tutorials/amqp-concepts.html#exchange-topic)
+JMS topics are implemented using an AMQP [topic exchange](./tutorials/amqp-concepts.html#exchange-topic)
 and a dedicated AMQP queue for each JMS topic subscriber. The AMQP
 topic exchange is `jms.temp.topic` or `jms.durable.topic`, depending
 on whether the JMS topic is temporary or not, respectively. Let's
@@ -767,6 +767,6 @@ normal case, when the message is an instance of
 
 To gain better understanding of AMQP 0-9-1 concepts and interoperability of
 the RabbitMQ JMS client with AMQP 0-9-1 clients, you may wish to read an
-[Introduction to RabbitMQ Concepts](/tutorials/amqp-concepts.html)
+[Introduction to RabbitMQ Concepts](./tutorials/amqp-concepts.html)
 and browse our
 [AMQP 0-9-1 Quick Reference Guide](amqp-0-9-1-quickref.html).

--- a/site/kubernetes/operator/configure-operator-defaults.md
+++ b/site/kubernetes/operator/configure-operator-defaults.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers how to modify the default configuration of the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html) in a Kubernetes cluster.
+This guide covers how to modify the default configuration of the [RabbitMQ Cluster Kubernetes Operator](./operator-overview.html) in a Kubernetes cluster.
 
 Environment variables used by the operator can be overridden in order to influence how the operator configures created RabbitmqClusters.
 This can be useful when configuring the operator to automatically use RabbitMQ container images stored in a private registry.

--- a/site/kubernetes/operator/install-operator.md
+++ b/site/kubernetes/operator/install-operator.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-This guide covers the installation of the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html) in a Kubernetes cluster.
+This guide covers the installation of the [RabbitMQ Cluster Kubernetes Operator](./operator-overview.html) in a Kubernetes cluster.
 
 ## <a id='compatibility' class='anchor' href='#compatibility'>Compatibility</a>
 
@@ -47,7 +47,7 @@ kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/latest/d
 </pre>
 
 At this point, the RabbitMQ Cluster Kubernetes Operator is successfully installed.
-Once the RabbitMQ Cluster Kubernetes Operator pod is running, head over to [Using Kubernetes RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/using-operator.html) for instructions on how to deploy RabbitMQ using a Kubernetes Custom Resource.
+Once the RabbitMQ Cluster Kubernetes Operator pod is running, head over to [Using Kubernetes RabbitMQ Cluster Kubernetes Operator](./using-operator.html) for instructions on how to deploy RabbitMQ using a Kubernetes Custom Resource.
 
 If you want to install a specific version of the Operator, you will have to obtain the manifest link from the
 [Operator Releases](https://github.com/rabbitmq/cluster-operator/releases). Please note that releases prior to 0.46.0

--- a/site/kubernetes/operator/kubectl-plugin.md
+++ b/site/kubernetes/operator/kubectl-plugin.md
@@ -1,7 +1,7 @@
 # RabbitMQ Cluster Operator Plugin for kubectl
 
 This guide covers the RabbitMQ Cluster Operator plugin for kubectl.
-This plugin makes it easy to install the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html).
+This plugin makes it easy to install the [RabbitMQ Cluster Kubernetes Operator](./operator-overview.html).
 into any Kubernetes instance and offers several commands for common workflows with RabbitMQ clusters.
 
 The only prerequisites to using the plugin are a working installation of kubectl and krew.
@@ -11,7 +11,7 @@ The only prerequisites to using the plugin are a working installation of kubectl
 
 Each plugin command automates many interactions with the kubernetes API and the RabbitMQ cluster operator.
 For a more detailed guide on using the operator and how to deploy Custom Resource objects it manages, see the
-[Using RabbitMQ Cluster Operator](/kubernetes/operator/using-operator.html) page.
+[Using RabbitMQ Cluster Operator](./using-operator.html) page.
 ---
 ## <a id='install' class='anchor' href='#install'>Install the plugin</a>
 
@@ -118,7 +118,7 @@ Displays the default user secrets for the named RabbitMQ cluster
 kubectl rabbitmq manage INSTANCE
 </pre>
 
-Opens the RabbitMQ [Management UI](/management.html) in a browser.
+Opens the RabbitMQ [Management UI](../../management.html) in a browser.
 
 ### <a id='debug' class='anchor' href='#debug'>Set Log Level to debug</a>
 
@@ -127,7 +127,7 @@ kubectl rabbitmq debug INSTANCE
 </pre>
 
 Sets the log level on all nodes to debug. For a detailed breakdown on RabbitMQ logging
-see the [Logging guide](/logging.html).
+see the [Logging guide](../../logging.html).
 
 ### <a id='tail' class='anchor' href='#tail'>Tail Logs</a>
 
@@ -148,7 +148,7 @@ kubectl krew install tail
 kubectl rabbitmq observe INSTANCE INDEX
 </pre>
 
-Opens the [`rabbitmq-diagnostics`](/rabbitmq-diagnostics.8.html) observer interface for a given node.
+Opens the [`rabbitmq-diagnostics`](../../rabbitmq-diagnostics.8.html) observer interface for a given node.
 
 ### <a id='feature-flags' class='anchor' href='#feature-flags'>Enable All Feature Flags</a>
 
@@ -156,7 +156,7 @@ Opens the [`rabbitmq-diagnostics`](/rabbitmq-diagnostics.8.html) observer interf
 kubectl rabbitmq enable-all-feature-flags INSTANCE 
 </pre>
 
-This command uses [`rabbitmqctl`](/cli.html) to enable all possible [feature flags](/feature-flags.html).
+This command uses [`rabbitmqctl`](../../cli.html) to enable all possible [feature flags](../../feature-flags.html).
 
 ### <a id='pause-reconciliation' class='anchor' href='#pause-reconciliation'>Pause Reconciliation</a>
 

--- a/site/kubernetes/operator/operator-monitoring.md
+++ b/site/kubernetes/operator/operator-monitoring.md
@@ -1,13 +1,13 @@
 # Monitoring RabbitMQ in Kubernetes
 
-This guide describes how to [monitor](/monitoring.html) RabbitMQ instances deployed by the [Kubernetes Cluster Operator](/kubernetes/operator/operator-overview.html).
+This guide describes how to [monitor](../../monitoring.html) RabbitMQ instances deployed by the [Kubernetes Cluster Operator](./operator-overview.html).
 
 ## <a id='overview' class='anchor' href='#overview'>Overview</a>
 
-Cluster Operator deploys RabbitMQ clusters with the [rabbitmq_prometheus plugin](/prometheus.html) enabled.
+Cluster Operator deploys RabbitMQ clusters with the [rabbitmq_prometheus plugin](../../prometheus.html) enabled.
 The plugin exposes a Prometheus-compatible metrics endpoint.
 
-For a detailed guide on RabbitMQ Prometheus configuration, check the [Prometheus guide](/prometheus.html).
+For a detailed guide on RabbitMQ Prometheus configuration, check the [Prometheus guide](../../prometheus.html).
 
 The following sections assume Prometheus is deployed and functional.
 How to configure Prometheus to monitor RabbitMQ depends on whether Prometheus is installed by Prometheus Operator or by other means.
@@ -131,7 +131,7 @@ for the [Alertmanager configuration file](https://prometheus.io/docs/alerting/la
 
 RabbitMQ provides Grafana dashboards to visualize the metrics scraped by Prometheus.
 
-Follow the instructions in the [Prometheus guide](/prometheus.html#grafana-configuration) to import dashboards to Grafana.
+Follow the instructions in the [Prometheus guide](../../prometheus.html#grafana-configuration) to import dashboards to Grafana.
 
 Alternatively, if Grafana is deployed by the [Grafana Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana), `kubectl apply` the `ConfigMaps` in directory [grafana/dashboards](https://github.com/rabbitmq/cluster-operator/tree/main/observability/grafana/dashboards)
 to import RabbitMQ Grafana dashboards [using a sidecar container](https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards).

--- a/site/kubernetes/operator/operator-overview.md
+++ b/site/kubernetes/operator/operator-overview.md
@@ -81,10 +81,10 @@ RabbitMQ Messaging Topology Operator supports managing RabbitMQ messaging topolo
 
 Documentation of Messaging Topology Operator structured as following:
 
- * [Installing RabbitMQ Messaging Topology Operator](/kubernetes/operator/install-topology-operator.html)
- * [Using RabbitMQ Messaging Topology Operator](/kubernetes/operator/using-topology-operator.html)
- * [TLS for Messaging Topology Operator](/kubernetes/operator/tls-topology-operator.html)
- * [Troubleshooting Messaging Topology Operator](/kubernetes/operator/troubleshooting-topology-operator.html)
+ * [Installing RabbitMQ Messaging Topology Operator](./install-topology-operator.html)
+ * [Using RabbitMQ Messaging Topology Operator](./using-topology-operator.html)
+ * [TLS for Messaging Topology Operator](./tls-topology-operator.html)
+ * [Troubleshooting Messaging Topology Operator](./troubleshooting-topology-operator.html)
 
 ## <a id='source' class='anchor' href='#source'>Source Code</a>
 

--- a/site/kubernetes/operator/quickstart-operator.md
+++ b/site/kubernetes/operator/quickstart-operator.md
@@ -1,6 +1,6 @@
 # RabbitMQ Cluster Kubernetes Operator Quickstart
 
-This is the fastest way to get up and running with a RabbitMQ cluster deployed by the Cluster Operator. More detailed resources are available for [installation](/kubernetes/operator/install-operator.html), [usage](/kubernetes/operator/using-operator.html) and [API reference](/kubernetes/operator/using-operator.html).
+This is the fastest way to get up and running with a RabbitMQ cluster deployed by the Cluster Operator. More detailed resources are available for [installation](./install-operator.html), [usage](./using-operator.html) and [API reference](./using-operator.html).
 
 ## Prerequisites
 
@@ -20,9 +20,9 @@ This guide goes through the following steps:
 
 ## The `kubectl rabbitmq` Plugin
 
-Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at its [installation instructions](/kubernetes/operator/install-operator.html).
+Many steps in the quickstart - installing the operator, accessing the Management UI, fetching credentials for the RabbitMQ Cluster, are made easier by the `kubectl rabbitmq` plugin. While there are instructions to follow along without using the plugin, getting the plugin will make these commands simpler. To install the plugin, look at its [installation instructions](./install-operator.html).
 
-For extensive documentation on the plugin see the [`kubectl` Plugin guide](/kubernetes/operator/kubectl-plugin.html).
+For extensive documentation on the plugin see the [`kubectl` Plugin guide](./kubectl-plugin.html).
 
 ## Install the RabbitMQ Cluster Operator
 
@@ -257,5 +257,5 @@ Now that you are up and running with the basics, you can explore what the Cluste
 You can do so by:
 
 1. Looking at [more examples](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/) such as [monitoring the deployed RabbitMQ Cluster using Prometheus](https://www.rabbitmq.com/prometheus.html), [enabling TLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/tls), etc.
-2. Looking at the [API reference documentation](/kubernetes/operator/using-operator.html).
+2. Looking at the [API reference documentation](./using-operator.html).
 3. Checking out our [GitHub repository](https://github.com/rabbitmq/cluster-operator/) and contributing to this guide, other docs, and the codebase!

--- a/site/kubernetes/operator/troubleshooting-operator.md
+++ b/site/kubernetes/operator/troubleshooting-operator.md
@@ -29,9 +29,9 @@ Potential solution to resolve this issue:
 
  * Run `kubectl describe pod POD-NAME` to see if there are any warnings (eg. `0/1 nodes are available: 1 Insufficient memory.`)
  * Correct the <code>imagePullSecrets</code> and <code>storageClassName</code>
-   configurations. See [imagePullSecrets](/kubernetes/operator/using-operator.html#image-pull-secrets),
-   [Persistence](/kubernetes/operator/using-operator.html#persistence), and
-   [Update a RabbitMQ Instance](/kubernetes/operator/using-operator.html#update).
+   configurations. See [imagePullSecrets](./using-operator.html#image-pull-secrets),
+   [Persistence](./using-operator.html#persistence), and
+   [Update a RabbitMQ Instance](./using-operator.html#update).
  * If the issue persists after updating the above configurations, view the status
    of your RabbitMQ cluster resources by following in the procedure in
    [Check the Status of an Instance](#check-instance-status)
@@ -55,7 +55,7 @@ Kubernetes cluster, but you have not created the necessary `PodSecurityPolicy` a
 corresponding role-based access control (RBAC) resources.
 
 Potential solution is to create the PodSecurityPolicy and RBAC resources by following the procedure in
-[Pod Security Policies](/kubernetes/operator/using-operator.html#psp).
+[Pod Security Policies](./using-operator.html#psp).
 
 ### <a id="pods-stuck-in-terminating-state" class="anchor" href="#pods-stuck-in-terminating-state">Pods Are Stuck in the Terminating State</a>
 

--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -975,7 +975,7 @@ For more information about concepts mentioned above, see:
 
 ## <a id='tls' class='anchor' href='#tls'>(Optional) Configure TLS</a>
 
-Transport Layer Security (TLS) is a protocol for encrypting network traffic. <a href="/ssl.html">RabbitMQ supports TLS</a>, and the cluster operator simplifies the process of configuring a RabbitMQ cluster with [TLS](#one-way-tls) or
+Transport Layer Security (TLS) is a protocol for encrypting network traffic. <a href="../../ssl.html">RabbitMQ supports TLS</a>, and the cluster operator simplifies the process of configuring a RabbitMQ cluster with [TLS](#one-way-tls) or
 [mutual TLS (mTLS)](#mutual-tls) encrypted traffic between clients and the cluster, as well
 as supporting [encrypting RabbitMQ inter-node traffic with mTLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/mtls-inter-node).
 A [basic overview of TLS](../../ssl.html#certificates-and-keys) is helpful for understanding this guide.

--- a/site/kubernetes/operator/using-operator.md
+++ b/site/kubernetes/operator/using-operator.md
@@ -3,9 +3,9 @@
 ## <a id='overview' class='anchor' href='#overview'>Overview</a>
 
 This guide covers how to deploy Custom Resource objects that will
-be managed by the [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/operator-overview.html).
+be managed by the [RabbitMQ Cluster Kubernetes Operator](./operator-overview.html).
 If RabbitMQ Cluster Kubernetes Operator is not installed,
-see the [installation guide](/kubernetes/operator/install-operator.html). For instructions on getting started quickly, see the [quickstart guide](/kubernetes/operator/quickstart-operator.html).
+see the [installation guide](./install-operator.html). For instructions on getting started quickly, see the [quickstart guide](./quickstart-operator.html).
 This guide is structured in the following sections:
 
 * [Confirm Service Availability](#service-availability)
@@ -48,7 +48,7 @@ kubectl get customresourcedefinitions.apiextensions.k8s.io
 # rabbitmqclusters.rabbitmq.com   2019-10-23T10:11:06Z
 </pre>
 
-If it is not, install it by following the steps in the [installation guide](/kubernetes/operator/install-operator.html).
+If it is not, install it by following the steps in the [installation guide](./install-operator.html).
 
 
 ## <a id='psp' class='anchor' href='#psp'>(Optional) Apply Pod Security Policies</a>
@@ -201,7 +201,7 @@ metadata:
 
 **Description:** Specify the number of replicas for the RabbitmqCluster. [An even number of replicas
 is highly discouraged](../../clustering.html#node-count). Odd numbers (1, 3, 5, 7, and so on)
-[must be used](/clustering.html#node-count).
+[must be used](../../clustering.html#node-count).
 
 **Default Value:** 1
 
@@ -573,10 +573,10 @@ If community plugins need to be provisioned, they should be included into a cust
 already exist in the same Namespace as the `RabbitmqCluster` object. It is expected that the Secret contains `tls.key`
 and `tls.crt` for the private key and public certificate respectively.
 
-By default, enabling [TLS for client connections](/ssl.html) does not disable non-TLS listeners. Therefore, unencrypted connections will still be accepted.
+By default, enabling [TLS for client connections](../../ssl.html) does not disable non-TLS listeners. Therefore, unencrypted connections will still be accepted.
 To disable non-TLS listeners and only accept TLS connections, set `spec.tls.disableNonTLSListeners: true`.
 
-It is also possible to make RabbitMQ [verify peer certificates](/ssl.html#peer-verification) against a provided CA certificate.
+It is also possible to make RabbitMQ [verify peer certificates](../../ssl.html#peer-verification) against a provided CA certificate.
 The same can be done by clients, so peer verification can be mutual ("mTLS").
 This certificate must be stored in a Secret of name `spec.tls.caSecretName`, in the same Namespace as the `RabbitmqCluster`
 object. Note that this can be the same Secret as `spec.tls.secretName`. This Secret **must** have a key `ca.crt` containing
@@ -978,7 +978,7 @@ For more information about concepts mentioned above, see:
 Transport Layer Security (TLS) is a protocol for encrypting network traffic. <a href="/ssl.html">RabbitMQ supports TLS</a>, and the cluster operator simplifies the process of configuring a RabbitMQ cluster with [TLS](#one-way-tls) or
 [mutual TLS (mTLS)](#mutual-tls) encrypted traffic between clients and the cluster, as well
 as supporting [encrypting RabbitMQ inter-node traffic with mTLS](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/mtls-inter-node).
-A [basic overview of TLS](/ssl.html#certificates-and-keys) is helpful for understanding this guide.
+A [basic overview of TLS](../../ssl.html#certificates-and-keys) is helpful for understanding this guide.
 
 ### <a id='one-way-tls' class='anchor' href='#one-way-tls'>TLS encrypting traffic between clients and RabbitMQ</a>
 
@@ -1024,7 +1024,7 @@ spec:
 
 Mutual TLS (mTLS) enhances TLS by requiring that the server verify the identity of the client, in addition to the client verifying the server, which already occurs in TLS encryption. In order for this mutual verification to occur, both the client and server must be configured with certificate and key pairs, with the client pair signed by a CA trusted by the server and the server pair signed by a CA trusted by the client. The mutual verification process is shown in the following diagram:
 
-<img src="/img/mTLS.png"/>
+<img src="../../img/mTLS.png"/>
 
 In addition to the [configuration required to support TLS](#one-way-tls), configuring mutual TLS requires the RabbitMQ cluster to be configured with the CA certificate
 used to sign the client certificate and key pair, `ca.pem`. Create a Kubernetes secret with key `ca.crt` containing this secret
@@ -1049,7 +1049,7 @@ spec:
     caSecretName: ca-secret
 </pre>
 
-In order to enforce client verification, RabbitMQ must be configured to reject clients that do not present certificates. This can be done by enabling [TLS peer verification](/ssl.html#peer-verification) using
+In order to enforce client verification, RabbitMQ must be configured to reject clients that do not present certificates. This can be done by enabling [TLS peer verification](../../ssl.html#peer-verification) using
 the `ssl_options.fail_if_no_peer_cert` option in the additional config:
 
 <pre class="lang-yaml">
@@ -1205,14 +1205,14 @@ kubectl delete pod perf-test
 
 For information about how to start using your apps, see
 [RabbitMQ tutorials](../../getstarted.html)
-and guides on [Connections](/consumers.html), [Publishers](/publishers.html), and [Consumers](/consumers.html).
+and guides on [Connections](../../consumers.html), [Publishers](../../publishers.html), and [Consumers](../../consumers.html).
 
 
 ## <a id='monitoring' class='anchor' href='#monitoring'>Monitor RabbitMQ Clusters</a>
 
-For production systems, it is critically important to enable RabbitMQ cluster [monitoring](/monitoring.html).
+For production systems, it is critically important to enable RabbitMQ cluster [monitoring](../../monitoring.html).
 
-See [Monitoring RabbitMQ in Kubernetes](/kubernetes/operator/operator-monitoring.html) to learn about
+See [Monitoring RabbitMQ in Kubernetes](./operator-monitoring.html) to learn about
 the recommended monitoring options for Kubernetes-deployed clusters.
 
 

--- a/site/kubernetes/operator/using-topology-operator.md
+++ b/site/kubernetes/operator/using-topology-operator.md
@@ -25,7 +25,7 @@ This guide has the following sections:
 
 <p class="note">
   <strong>Note:</strong> Additional information about using the operator on Openshift can be found at
-  [Using the RabbitMQ Kubernetes Operators on Openshift](using-on-openshift.html).
+  [Using the RabbitMQ Kubernetes Operators on Openshift](./using-on-openshift.html).
 </p>
 
 ## <a id='requirements' class='anchor' href='#requirements'> Cluster Operator Requirements</a>
@@ -383,12 +383,12 @@ user credentials set in the definitions.
 ## <a id='tls' class='anchor' href='#tls'>TLS</a>
 
 If the RabbitmqClusters managed by the Messaging Topology Operator are configured to serve the Management over HTTPS, there are some additional
-steps required to configure Messaging Topology Operator. Follow this [TLS dedicated guide](/kubernetes/operator/tls-topology-operator.html) to configure
+steps required to configure Messaging Topology Operator. Follow this [TLS dedicated guide](./tls-topology-operator.html) to configure
 the Operator.
 
 ## <a id='vault' class='anchor' href='#vault'>(Optional) Use HashiCorp Vault</a>
 
-If the RabbitmqClusters managed by the Messaging Topology Operator are configured to store their default user credentials in Vault, there are some additional steps requires to configure Messaging Topology Operator. Follow this [Vault dedicated guide](/kubernetes/operator/vault-topology-operator.html) to configure the operator.
+If the RabbitmqClusters managed by the Messaging Topology Operator are configured to store their default user credentials in Vault, there are some additional steps requires to configure Messaging Topology Operator. Follow this [Vault dedicated guide](./vault-topology-operator.html) to configure the operator.
 
 ## <a id='operator-log' class='anchor' href='#operator-log'>Configure Log Level for the Operator</a>
 

--- a/site/kubernetes/operator/vault-topology-operator.md
+++ b/site/kubernetes/operator/vault-topology-operator.md
@@ -7,7 +7,7 @@ stored in Vault, it may be necessary to configure the Topology Operator with som
 
 This guide assumes you have the following:
 
-1. The [RabbitMQ Cluster Operator](operator-overview.html) and [Messaging Topology Operator](install-topology-operator.html) are installed on the Kubernetes cluster
+1. The [RabbitMQ Cluster Operator](./operator-overview.html) and [Messaging Topology Operator](./install-topology-operator.html) are installed on the Kubernetes cluster
 2. A Vault server is installed on the Kubernetes cluster
 3. A *Vault role* must be declared in Vault for the topology operator to use. By default, the topology operator will use a vault role with the name `messaging-topology-operator`. Should we declared a *Vault role* with a different name, we have to configure the operator by overriding the environment variable `OPERATOR_VAULT_ROLE`
 

--- a/site/lazy-queues.md
+++ b/site/lazy-queues.md
@@ -251,7 +251,7 @@ All messages in the message store are stored in 16MB files called segment files 
 Each queue has its own file descriptor for each segment file it has to access.
 For example, if 100 queues store 10GB worth of messages, there will
 be 640 files in the message store and up to 64000 file descriptors.
-Make sure the nodes have a high enough [open file limit](/production-checklist.html#resource-limits-file-handle-limit)
+Make sure the nodes have a high enough [open file limit](./production-checklist.html#resource-limits-file-handle-limit)
 and overprovision it when in doubt (e.g. to 300K or 500K).
 For new installations it is possible to increase file size used by the message store using
 `msg_store_file_size_limit` configuration key. **Never change segment file size for existing installations**
@@ -286,7 +286,7 @@ The total system memory required for the queue process to finish starting is **5
 
 ### Mirroring of Lazy Queues
 
-When enabling [automatic queue mirroring](/ha.html#unsynchronised-mirrors), consider the expected on disk
+When enabling [automatic queue mirroring](./ha.html#unsynchronised-mirrors), consider the expected on disk
 data set of the queues involved. Queues with a sizeable data set
 (say, tens of gigabytes or more) will have to replicate it to
 the newly added mirror(s), which can put a significant load on

--- a/site/ldap.md
+++ b/site/ldap.md
@@ -74,7 +74,7 @@ After enabling the plugin it is necessary to configure the node to use it.
 
 This involves
 
- * Listing LDAP as an [authentication (authN) and/or authorization (authZ) backend](/access-control.html)
+ * Listing LDAP as an [authentication (authN) and/or authorization (authZ) backend](./access-control.html)
  * Configuring [LDAP server endpoints](#connectivity)
  * Specifying what [LDAP queries](#query-types) will be used for various authZ permission checks
 
@@ -86,7 +86,7 @@ and ignore the internal database:
 auth_backends.1 = ldap
 </pre>
 
-In [`advanced.config` file](/configure.html#erlang-term-config-file), the same settings would look like this:
+In [`advanced.config` file](./configure.html#erlang-term-config-file), the same settings would look like this:
 
 <pre class="lang-erlang">
 {rabbit, [
@@ -104,7 +104,7 @@ auth_backends.1 = ldap
 auth_backends.2 = internal
 </pre>
 
-Same example in the [`advanced.config` format](/configure.html#erlang-term-config-file):
+Same example in the [`advanced.config` format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 {rabbit,[
@@ -128,7 +128,7 @@ auth_backends.1.authz = internal
 auth_backends.2 = internal
 </pre>
 
-In the [advanced config format](/configure.html#erlang-term-config-file):
+In the [advanced config format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 {rabbit,[{auth_backends, [{rabbit_auth_backend_ldap, rabbit_auth_backend_internal},
@@ -238,7 +238,7 @@ Note that those settings are mutually exclusive (cannot be combined).
 Both values default to `false`.
 
 Client side TLS settings are configured using `ssl_options`, which
-are very similar to [TLS settings elsewhere in RabbitMQ](/ssl.html).
+are very similar to [TLS settings elsewhere in RabbitMQ](./ssl.html).
 TLS settings for LDAP connections can only be configured via the advanced config file:
 
 <pre class="lang-ini">
@@ -367,7 +367,7 @@ It should be possible to open a channel on it, for example. All further operatio
 performed on the connection will execute one of the authorisation queries. For example,
 declaring a queue will execute a resource access query (covered below). Publishing a
 message to a topic exchange will additionally execute a topic access query. Please refer
-to the [Access Control guide](/access-control.html) to learn more.
+to the [Access Control guide](./access-control.html) to learn more.
 
 ### <a id="usernames-and-dns" class="anchor" href="#usernames-and-dns">Usernames and Distinguished Names</a>
 
@@ -493,7 +493,7 @@ For authentication this plugin binds to the LDAP server as the
 user it is trying to authenticate. The `other_bind` setting controls how to
 bind for authorisation queries, and to retrieve the details of a
 user who is logging in without presenting a password (e.g. using the
-[EXTERNAL authentication mechanism](/authentication.html)).
+[EXTERNAL authentication mechanism](./authentication.html)).
 
 The accepted values are `as_user` (to bind as the authenticated
 user) or `anon` (to bind anonymously), or be presented by two
@@ -547,7 +547,7 @@ Default value is `'none'`.
 
 ### <a id="authorisation-overview" class="anchor" href="#authorisation-overview">How RabbitMQ Permission Model Maps to LDAP</a>
 
-RabbitMQ [permission model](/access-control.html)
+RabbitMQ [permission model](./access-control.html)
 is different from that of LDAP. In addition, the way LDAP
 schemas are used will vary from company to
 company. Therefore a mechanism that defines what LDAP
@@ -568,8 +568,8 @@ have.
 Note the longer `rabbitmq_auth_backend_ldap` prefix.
 Queries are expressed using a domain-specific language expressed in Erlang terms (data structures),
 so they can be defined only using the
-[classic config format](/configure.html#erlang-term-config-file). Starting with RabbitMQ 3.7
-query definitions are commonly placed into the [advanced.config file](/configure.html#advanced-config-file).
+[classic config format](./configure.html#erlang-term-config-file). Starting with RabbitMQ 3.7
+query definitions are commonly placed into the [advanced.config file](./configure.html#advanced-config-file).
 
 ### <a id="query-types" class="anchor" href="#query-types">Queries and Their Types</a>
 
@@ -664,7 +664,7 @@ two <i>additional</i> variables will be made available for each of the above que
 The terms configure, write and read for resource access have the
 same meanings that they do for the built-in RabbitMQ permissions
 system, see https://www.rabbitmq.com/access-control.html. See
-also [topic authorisation](/access-control.html#topic-authorisation)
+also [topic authorisation](./access-control.html#topic-authorisation)
 for `topic_access_query`.
 
 When first getting familiar with the query DSL, it can be
@@ -914,8 +914,8 @@ above for example.
 
 ## <a id="example" class="anchor" href="#example">Example Configuration</a>
 
-Bringing it all together, here's a sample configuration. It uses both the [standard config](/configure.html#config-file) and
-[advanced config](/configure.html#advanced-config-file) files together. This
+Bringing it all together, here's a sample configuration. It uses both the [standard config](./configure.html#config-file) and
+[advanced config](./configure.html#advanced-config-file) files together. This
 makes all users able to access the management plugin, but
 makes none of them administrators. Access to virtual hosts is
 controlled by membership of a group per virtual host. Only
@@ -925,7 +925,7 @@ exchanges and declare from queues. Publishing to topic-typed
 exchanges is restricted to messages with a routing key
 beginning with "a" and consuming from topics isn't restricted (topic authorisation).
 
-The [standard config](/configure.html#config-file)
+The [standard config](./configure.html#config-file)
 (rabbitmq.conf) is used to configure authentication backends and
 several LDAP plugin parameters:
 
@@ -939,7 +939,7 @@ auth_ldap.port       = 389
 auth_ldap.log        = false
 </pre>
 
-[Advanced config](/configure.html#advanced-config-file) is used to define LDAP queries:
+[Advanced config](./configure.html#advanced-config-file) is used to define LDAP queries:
 
 <pre class="lang-erlang">
 [{rabbitmq_auth_backend_ldap,[
@@ -965,7 +965,7 @@ auth_ldap.log        = false
 ]}].
 </pre>
 
-Alternatively, you can use the [classic config format](/configure.html#erlang-term-config-file)
+Alternatively, you can use the [classic config format](./configure.html#erlang-term-config-file)
 to configure everything in a single file:
 
 <pre class="lang-erlang">
@@ -1005,8 +1005,8 @@ to configure everything in a single file:
 
 Using LDAP for authentication and/or authorisation introduces another moving
 part into the system. Since LDAP servers are accessed over the network,
-some topics covered in the [Network Troubleshooting](/troubleshooting-networking.html)
-and [TLS Troubleshooting](/troubleshooting-ssl.html) guides apply to LDAP.
+some topics covered in the [Network Troubleshooting](./troubleshooting-networking.html)
+and [TLS Troubleshooting](./troubleshooting-ssl.html) guides apply to LDAP.
 
 In order to troubleshoot LDAP operations performed during the authentication and authorisation
 stages, [enabling LDAP traffic logging](#logging) is highly recommended.

--- a/site/logging.md
+++ b/site/logging.md
@@ -311,7 +311,7 @@ log.syslog.formatter = json
 </pre>
 
 Less commonly used [Syslog client](https://github.com/schlagert/syslog) options can
-be configured using the <a href="/configure.html#configuration-files">advanced config file</a>.
+be configured using the <a href="./configure.html#configuration-files">advanced config file</a>.
 
 
 ## <a id="json" class="anchor" href="#json">JSON Logging</a>

--- a/site/logging.md
+++ b/site/logging.md
@@ -167,7 +167,7 @@ log.file.rotation.count = 5
 On Linux, BSD and other UNIX-like systems, [logrotate](https://linux.die.net/man/8/logrotate) is an alternative
 way of log file rotation and compression.
 
-RabbitMQ [Debian](/install-debian.html) and [RPM](/install-rpm.html) packages will set up `logrotate` to run weekly on files
+RabbitMQ [Debian](./install-debian.html) and [RPM](./install-rpm.html) packages will set up `logrotate` to run weekly on files
 located in default `/var/log/rabbitmq` directory. Rotation configuration can be found in `/etc/logrotate.d/rabbitmq-server`.
 
 
@@ -437,7 +437,7 @@ There are two ways of changing effective log levels:
 
  * Via [configuration file(s)](configure.html): this is more flexible but requires
    a node restart between changes
- * Using [CLI tools](/cli.html), `rabbitmqctl set_log_level &lt;level&gt;`: the changes are transient (will not survive node restart) but can be used to
+ * Using [CLI tools](./cli.html), `rabbitmqctl set_log_level &lt;level&gt;`: the changes are transient (will not survive node restart) but can be used to
    enable and disable e.g. [debug logging](#debug-logging) at runtime for a period of time.
 
 To set log level to `debug` on a running node:
@@ -455,7 +455,7 @@ rabbitmqctl -n rabbit@target-host set_log_level info
 
 ## <a id="log-tail" class="anchor" href="#log-tail">Tailing Logs Using CLI Tools</a>
 
-Modern releases support tailing logs of a node using [CLI tools](/cli.html). This is convenient
+Modern releases support tailing logs of a node using [CLI tools](./cli.html). This is convenient
 when log file location is not known or is not easily accessible but CLI tool connectivity
 is allowed.
 
@@ -576,7 +576,7 @@ The entry includes client IP address and port (<code>127.0.0.1:52771</code>) as 
 IP address and port of the server (<code>127.0.0.1:5672</code>). This information can be useful
 when troubleshooting client connections.
 
-Once a connection successfully authenticates and is granted access to a [virtual host](/vhosts.html),
+Once a connection successfully authenticates and is granted access to a [virtual host](./vhosts.html),
 that is also logged:
 
 <pre class="lang-plaintext">
@@ -585,7 +585,7 @@ that is also logged:
 
 The examples above include two values that can be used as connection identifiers
 in various scenarios: connection name (`127.0.0.1:57919 -> 127.0.0.1:5672`) and an Erlang process ID of the connection (`&lt;0.620.0&gt;`).
-The latter is used by [rabbitmqctl](./cli.html) and the former is used by the [HTTP API](/management.html).
+The latter is used by [rabbitmqctl](./cli.html) and the former is used by the [HTTP API](./management.html).
 
 A [client connection](connections.html) can be closed cleanly or abnormally. In the
 former case the client closes AMQP 0-9-1 (or 1.0, or STOMP, or
@@ -651,7 +651,7 @@ When used interactively, results can be piped to a command line JSON processor s
 rabbitmq-diagnostics consume_event_stream | jq
 </pre>
 
-The events can also be exposed to applications for [consumption](/consumers.html)
+The events can also be exposed to applications for [consumption](./consumers.html)
 with a plugin, [rabbitmq-event-exchange](https://github.com/rabbitmq/rabbitmq-event-exchange/).
 
 Events are published as messages with blank bodies. All event metadata is stored in
@@ -677,19 +677,19 @@ Below is a list of published events.
  * `channel.created`
  * `channel.closed`
 
-[Consumer](/consumers.html) events:
+[Consumer](./consumers.html) events:
 
  * `consumer.created`
  * `consumer.deleted`
 
-[Policy and Parameter](/parameters.html) events:
+[Policy and Parameter](./parameters.html) events:
 
  * `policy.set`
  * `policy.cleared`
  * `parameter.set`
  * `parameter.cleared`
 
-[Virtual host](/vhosts.html) events:
+[Virtual host](./vhosts.html) events:
 
  * `vhost.created`
  * `vhost.deleted`
@@ -706,14 +706,14 @@ User management events:
  * `user.password.cleared`
  * `user.tags.set`
 
-[Permission](/access-control.html) events:
+[Permission](./access-control.html) events:
 
  * `permission.created`
  * `permission.deleted`
  * `topic.permission.created`
  * `topic.permission.deleted`
 
-[Alarm](/alarms.html) events:
+[Alarm](./alarms.html) events:
 
  * `alarm.set`
  * `alarm.cleared`

--- a/site/management-cli.md
+++ b/site/management-cli.md
@@ -17,15 +17,15 @@ limitations under the License.
 
 # Management Command Line Tool NOSYNTAX
 
-The [management plugin](/management.html) ships with a command line
+The [management plugin](./management.html) ships with a command line
 tool **rabbitmqadmin** which can perform some of the same actions as the
 Web-based UI, and which may be more convenient for automation tasks.
 Note that rabbitmqadmin is just a specialised HTTP client;
 if you are contemplating invoking rabbitmqadmin from your own program
 you may want to consider using an HTTP API client library instead.
 
-Note that `rabbitmqadmin` is not a replacement for [rabbitmqctl](/man/rabbitmqctl.8.html) or
-[rabbitmq-plugins](/man/rabbitmq-plugins.8.html).
+Note that `rabbitmqadmin` is not a replacement for [rabbitmqctl](./man/rabbitmqctl.8.html) or
+[rabbitmq-plugins](./man/rabbitmq-plugins.8.html).
 HTTP API intentionally doesn't expose certain operations.
 
 
@@ -56,8 +56,8 @@ Invoke `rabbitmqadmin --help` for usage instructions. You can:
 * close connections and purge queues
 * import and export configuration
 
-For other tasks, see [rabbitmqctl](/man/rabbitmqctl.8.html) and
-[rabbitmq-plugins](/man/rabbitmq-plugins.8.html).
+For other tasks, see [rabbitmqctl](./man/rabbitmqctl.8.html) and
+[rabbitmq-plugins](./man/rabbitmq-plugins.8.html).
 
 
 ## rabbitmqadmin and RabbitMQ HTTP API Compatibility

--- a/site/management.md
+++ b/site/management.md
@@ -126,27 +126,27 @@ Some of the features include:
 
 <ul>
   <li>
-    Declare, list and delete exchanges, <a href="/queues.html">queues</a>, bindings,
-    users, <a href="/vhosts.html">virtual hosts</a> and <a href="/access-control.html">user permissions</a>.
+    Declare, list and delete exchanges, <a href="./queues.html">queues</a>, bindings,
+    users, <a href="./vhosts.html">virtual hosts</a> and <a href="./access-control.html">user permissions</a>.
   </li>
   <li>
     Monitor queue length, message rates (globally and per queue, exchange or channel), resource usage of queue,
     node GC activity, data rates of client connections, and more.
   </li>
   <li>
-    Monitor node resource use: <a href="/networking.html#open-file-handle-limit">sockets and file descriptors</a>,
-    <a href="/memory-use.html">memory usage breakdown</a>, available disk space and bandwidth usage on inter-node communication
+    Monitor node resource use: <a href="./networking.html#open-file-handle-limit">sockets and file descriptors</a>,
+    <a href="./memory-use.html">memory usage breakdown</a>, available disk space and bandwidth usage on inter-node communication
     links.
   </li>
   <li>
     Manage users (provided administrative permissions of the current user).
   </li>
   <li>
-    Manage <a href="/parameters.html">policies and runtime parameters</a> (provided sufficient permissions of the current user).
+    Manage <a href="./parameters.html">policies and runtime parameters</a> (provided sufficient permissions of the current user).
   </li>
   <li>
-    <a href="/backup.html">Export schema</a> (vhosts, users, permissions, queues, exchanges, bindings, parameters,
-    policies) and <a href="/definitions.html">import it on node start</a>. This can be used for <a href="/backup.html">recovery purposes</a>
+    <a href="./backup.html">Export schema</a> (vhosts, users, permissions, queues, exchanges, bindings, parameters,
+    policies) and <a href="./definitions.html">import it on node start</a>. This can be used for <a href="./backup.html">recovery purposes</a>
     or setup automation of new nodes and clusters.
   </li>
   <li>

--- a/site/management.md
+++ b/site/management.md
@@ -58,7 +58,7 @@ use to extend the UI.
 
 ## <a id="external-monitoring" class="anchor" href="#external-monitoring">Management UI and External Monitoring Systems</a>
 
-The management UI and its [HTTP API](#http-api) is a built-in [monitoring option](/monitoring.html) for RabbitMQ.
+The management UI and its [HTTP API](#http-api) is a built-in [monitoring option](./monitoring.html) for RabbitMQ.
 This is a convenient option for development and in environments where
 external monitoring is difficult or impossible to introduce.
 
@@ -68,30 +68,30 @@ However, the management UI has a number of limitations:
  * A certain amount of overhead
  * It only stores recent data (think hours, not days or months)
  * It has a basic user interface
- * Its design [emphasizes ease of use over best possible availability](/management.html#clustering).
- * Management UI access is controlled via the [RabbitMQ permission tags system](/access-control.html)
+ * Its design [emphasizes ease of use over best possible availability](./management.html#clustering).
+ * Management UI access is controlled via the [RabbitMQ permission tags system](./access-control.html)
    (or a convention on JWT token scopes)
 
-Long term metric storage and visualisation services such as [Prometheus and Grafana](/prometheus.html)
+Long term metric storage and visualisation services such as [Prometheus and Grafana](./prometheus.html)
 or the [ELK stack](https://www.elastic.co/what-is/elk-stack) are more suitable options for production systems. They offer:
 
  * Decoupling of the monitoring system from the system being monitored
  * Lower overhead
  * Long term metric storage
- * Access to additional related metrics such as those of the [Erlang runtime](/runtime.html) ones
+ * Access to additional related metrics such as those of the [Erlang runtime](./runtime.html) ones
  * More powerful and customizable user interface
  * Ease of metric data sharing: both metric state and dashboards
  * Metric access permissions are not specific to RabbitMQ
  * Collection and aggregation of node-specific metrics which is more resilient to individual node failures
 
-RabbitMQ provides first class support for [Prometheus and Grafana](/prometheus.html) as of 3.8.
+RabbitMQ provides first class support for [Prometheus and Grafana](./prometheus.html) as of 3.8.
 It is recommended for production environments.
 
 
 ## <a id="getting-started" class="anchor" href="#getting-started">Getting Started</a>
 
 The management plugin is included in the RabbitMQ
-distribution. Like any other [plugin](/plugins.html), it must
+distribution. Like any other [plugin](./plugins.html), it must
 be enabled before it can be used. That's done using [rabbitmq-plugins](man/rabbitmq-plugins.8.html):
 
 <pre class="lang-bash">
@@ -101,7 +101,7 @@ rabbitmq-plugins enable rabbitmq_management
 Node restart is not required after plugin activation.
 
 During automated deployments, the plugin can be enabled via
-[enabled plugin file](/plugins.html#enabled-plugins-file).
+[enabled plugin file](./plugins.html#enabled-plugins-file).
 
 
 ## <a id="usage" class="anchor" href="#usage">Usage</a>
@@ -115,7 +115,7 @@ it can be accessed by users with [sufficient privileges](#permissions) at either
 or `http://localhost:15672/` (provided that `localhost` resolves correctly).
 
 Note that the UI and HTTP API port — typically 15672 — does not support AMQP 0-9-1, AMQP 1.0, STOMP or MQTT connections.
-[Separate ports](/networking.html#ports) should be used by those clients.
+[Separate ports](./networking.html#ports) should be used by those clients.
 
 Users must be [granted permissions](#permissions) for management UI access.
 
@@ -175,10 +175,10 @@ This is covered in the [following section](#permissions).
 
 The management UI requires [authentication and authorisation](access-control.html), much like RabbitMQ requires
 it from connecting clients. In addition to successful authentication, management UI access is controlled by user tags.
-The tags are managed using [rabbitmqctl](/rabbitmqctl.8.html#set_user_tags).
+The tags are managed using [rabbitmqctl](./rabbitmqctl.8.html#set_user_tags).
 Newly created users do not have any tags set on them by default.
 
-See [Production Checklist](/production-checklist.html) for general recommendations on user and credential
+See [Production Checklist](./production-checklist.html) for general recommendations on user and credential
 management.
 
 <table>
@@ -268,7 +268,7 @@ with sufficient permissions or forgotten/incorrect permissions, [CLI tools](cli.
 be used to manage the users and their credentials. [rabbitmqctl add_user](man/rabbitmqctl.8.html#)
 should be used to create a user, [rabbitmqctl set_permissions](man/rabbitmqctl.8.html#) to grant the
 user the desired permissions and finally, [rabbitmqctl
-set_user_tags](/man/rabbitmqctl.8.html#set_user_tags) should be used to give the user management UI access permissions.
+set_user_tags](./man/rabbitmqctl.8.html#set_user_tags) should be used to give the user management UI access permissions.
 
 ### <a id="cli-examples" class="anchor" href="#cli-examples">Command Line Examples</a>
 
@@ -366,7 +366,7 @@ that interacts with the HTTP API. It can be downloaded from any RabbitMQ node th
 has the management plugin enabled at <code>http://<i>{node-hostname}</i>:15672/cli/</code>.
 
 For HTTP API clients in several languages,
-see [Developer Tools](/devtools.html).
+see [Developer Tools](./devtools.html).
 
 Some API endpoints return a lot of information. The volume can be reduced
 by filtering what columns are returned by `HTTP GET` requests. See
@@ -394,7 +394,7 @@ management.tcp.port = 15672
 </pre>
 
 It is possible to configure what interface the API endpoint will use, similarly
-to [messaging protocol listeners](/networking.html#interfaces), using
+to [messaging protocol listeners](./networking.html#interfaces), using
 the `management.tcp.ip` key:
 
 <pre class="lang-ini">
@@ -464,7 +464,7 @@ management.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
 # management.ssl.fail_if_no_peer_cert = true
 </pre>
 
-The above example in the [classic config format](/configure.html#erlang-term-config-file):
+The above example in the [classic config format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 [
@@ -516,7 +516,7 @@ management.ssl.keyfile    = /path/to/server_key.pem
 </pre>
 
 The same configuration keys can be used to configure a single listener (just HTTP or HTTPS)
-and match those used by the [Web STOMP](/web-stomp.html) and [Web MQTT](/web-mqtt.html).
+and match those used by the [Web STOMP](./web-stomp.html) and [Web MQTT](./web-mqtt.html).
 
 ### <a id="advanced-options" class="anchor" href="#advanced-options">Advanced HTTP Options</a>
 
@@ -684,10 +684,10 @@ at least one retention setting (period).
 
 ### <a id="disable-stats" class="anchor" href="#disable-stats">Disable Statistics and Metric Collection</a>
 
-It is possible to disable the statistics in the UI and [HTTP API](#http-api) in order for these to be used only for operations. This can be a useful feature if external monitoring solutions such as [Prometheus and Grafana](/prometheus.html) are being used. If statistics are disabled in any of the following ways, all charts and detailed statistics will be hidden in the UI.
+It is possible to disable the statistics in the UI and [HTTP API](#http-api) in order for these to be used only for operations. This can be a useful feature if external monitoring solutions such as [Prometheus and Grafana](./prometheus.html) are being used. If statistics are disabled in any of the following ways, all charts and detailed statistics will be hidden in the UI.
 
 In order to completely disable the internal metrics collection, the `disable_metrics_collector` flag must be set in the `rabbitmq_management_agent` plugin.
-The [Prometheus plugin](/prometheus.html) will still work even if collection is disabled.
+The [Prometheus plugin](./prometheus.html) will still work even if collection is disabled.
 
 <pre class="lang-ini">
 management_agent.disable_metrics_collector = true
@@ -695,7 +695,7 @@ management_agent.disable_metrics_collector = true
 
 Disabling the metrics collection is the preferred option if it is being used with an external monitoring system, as this reduced the overhead that statistics collection and aggregation causes in the broker. If the statistics are only temporary disabled, or are not required in some [HTTP API](#http-api) queries, the aggregation of the stats can be disabled in the `rabbitmq_management` plugin. The disable flag can be also passed as part of the query string in the URI.
 
-As at the moment the [Prometheus plugin](/prometheus.html) cannot report individual queue totals, there is a configuration option that allows to list `messages`, `messages_ready` and `messages_unacknowledged` in the `queues` endpoint.
+As at the moment the [Prometheus plugin](./prometheus.html) cannot report individual queue totals, there is a configuration option that allows to list `messages`, `messages_ready` and `messages_unacknowledged` in the `queues` endpoint.
 
 Below is a configuration example that disables the statistics but returns individual queue totals in the `queues` page:
 
@@ -855,10 +855,10 @@ management.sample_retention_policies.detailed.10 = 5
 Nodes and clusters store information that can be thought of schema, metadata or topology.
 Users, vhosts, queues, exchanges, bindings, runtime parameters all fall into this category.
 
-Definitions can be exported and imported via the [`rabbitmqctl`](/cli.html) or the HTTP API
+Definitions can be exported and imported via the [`rabbitmqctl`](./cli.html) or the HTTP API
 provided by this plugin, including `rabbitmqadmin`.
 
-Please refer to the [Definitions guide](/definitions.html).
+Please refer to the [Definitions guide](./definitions.html).
 
 
 ## <a id="clustering" class="anchor" href="#clustering">Metrics Collection and HTTP API in Clusters</a>
@@ -960,7 +960,7 @@ collect_statistics_interval = 30000
 Increasing the interval value to 30-60s will reduce CPU footprint and peak memory
 consumption for systems with large amounts of connections, channels and queues.
 This comes with a downside: metrics of said entities will refresh every 30-60 seconds.
-This can be perfectly reasonable in an [externally monitored](/monitoring.html#monitoring-frequency) production system
+This can be perfectly reasonable in an [externally monitored](./monitoring.html#monitoring-frequency) production system
 but will make management UI less convenient to use for operators.
 
 The memory usage of the channel and stats collector processes can be limited
@@ -986,7 +986,7 @@ all nodes in the cluster.
 It is possible to publish and consume messages using the [HTTP API](#http-api).
 This way of messaging is discouraged: prefer one of the binary messaging protocols supported
 by RabbitMQ. Publishing and consuming that way will be significantly more efficient and will
-provide access to various messaging protocol features such as [confirmations](/confirms.html).
+provide access to various messaging protocol features such as [confirmations](./confirms.html).
 
 Publishing over HTTP API can be useful in environments where
 [long lived messaging protocol connections](connections.html) is not an option.

--- a/site/manpages.md
+++ b/site/manpages.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Manual Pages
 
-This page lists the available manual pages taken from the [latest stable release](/changelog.html).
+This page lists the available manual pages taken from the [latest stable release](./changelog.html).
 
 ## <a id="section5" class="anchor" href="#section5">Section 5: File formats</a>
 
@@ -26,10 +26,10 @@ This page lists the available manual pages taken from the [latest stable release
 
 ## <a id="section8" class="anchor" href="#section8">Section 8: System Management Commands</a>
 
- * [rabbitmqctl](rabbitmqctl.8.html): service management and [general operator commands](/cli.html)
- * [rabbitmq-diagnostics](rabbitmq-diagnostics.8.html): commands useful for diagnostics, [health checking](/monitoring.html),
+ * [rabbitmqctl](rabbitmqctl.8.html): service management and [general operator commands](./cli.html)
+ * [rabbitmq-diagnostics](rabbitmq-diagnostics.8.html): commands useful for diagnostics, [health checking](./monitoring.html),
    and observing system state
- * [rabbitmq-plugins](rabbitmq-plugins.8.html): [plugin management](/plugins.html)
+ * [rabbitmq-plugins](rabbitmq-plugins.8.html): [plugin management](./plugins.html)
  * [rabbitmq-upgrade](rabbitmq-upgrade.8.html): operational tasks related to upgrades
  * [rabbitmq-queues](rabbitmq-queues.8.html): operational tasks for queues
  * [rabbitmq-server](rabbitmq-server.8.html): starts a RabbitMQ server node

--- a/site/maxlength.md
+++ b/site/maxlength.md
@@ -25,14 +25,14 @@ body lengths, ignoring message properties and any overheads), or
 both.
 
 For any given queue, the maximum length (of either type) can be
-defined using a [policy](/parameters.html#policies) (this option is highly recommended)
-or by clients using the [queue's optional arguments](/queues.html#optional-arguments).
+defined using a [policy](./parameters.html#policies) (this option is highly recommended)
+or by clients using the [queue's optional arguments](./queues.html#optional-arguments).
 In the case where both the effective queue policy and arguments specify a maximum length,
 the minimum of the two values will be used.
 
-Queue length settings also can be enforced by [operator policies](/parameters.html#operator-policies).
+Queue length settings also can be enforced by [operator policies](./parameters.html#operator-policies).
 
-In all cases the number of messages in the **ready** state is used; [messages unacknowledged by consumers](/confirms.html)
+In all cases the number of messages in the **ready** state is used; [messages unacknowledged by consumers](./confirms.html)
 do not count towards the limit.
 
 The number of **ready** messages and their footprint in bytes can be observed
@@ -164,8 +164,8 @@ channel.queueDeclare("myqueue", false, false, false, args);
 
 ## <a id="inspecting" class="anchor" href="#inspecting">Inspecting Queue Length Limits</a>
 
-To inspect effective limits for a queue, inspect its [optional arguments](/queues.html#optional-arguments) and
-[effective policy](/parameters.html#policies).
+To inspect effective limits for a queue, inspect its [optional arguments](./queues.html#optional-arguments) and
+[effective policy](./parameters.html#policies).
 
 This can be done using CLI tools or the management UI.
 

--- a/site/memory-use.md
+++ b/site/memory-use.md
@@ -21,15 +21,15 @@ limitations under the License.
 
 Operators need to be able to reason about node's memory use,
 both absolute and relative ("what uses most memory"). This is an
-important aspect of [system monitoring](/monitoring.html).
+important aspect of [system monitoring](./monitoring.html).
 
 RabbitMQ provides tools that report and help analyse node memory use:
 
- * [`rabbitmq-diagnostics memory_breakdown`](/cli.html)
- * [`rabbitmq-diagnostics status`](/cli.html) includes the above breakdown as a section
- * [Prometheus and Grafana](/prometheus.html)-based monitoring makes it possible to observe memory breakdown over time
- * [Management UI](/management.html) provides the same breakdown on the node page as `rabbitmq-diagnostics status`
- * [HTTP API](/management.html#http-api) provides the same information as the management UI, useful [for monitoring](/monitoring.html)
+ * [`rabbitmq-diagnostics memory_breakdown`](./cli.html)
+ * [`rabbitmq-diagnostics status`](./cli.html) includes the above breakdown as a section
+ * [Prometheus and Grafana](./prometheus.html)-based monitoring makes it possible to observe memory breakdown over time
+ * [Management UI](./management.html) provides the same breakdown on the node page as `rabbitmq-diagnostics status`
+ * [HTTP API](./management.html#http-api) provides the same information as the management UI, useful [for monitoring](./monitoring.html)
  * [rabbitmq-top](https://github.com/rabbitmq/rabbitmq-top) and `rabbitmq-diagnostics observer` provide a more fine-grained [top](https://en.wikipedia.org/wiki/Top_(software))-like per Erlang process view
 
 Obtaining a node memory breakdown should be the first step when reasoning about node memory use.
@@ -92,7 +92,7 @@ and so on.
 Memory use breakdown reports allocated memory distribution on the target node, by category:
 
  * [Connections](#breakdown-connections) (further split into four categories: readers, writers, channels, other)
- * [Quorum queue](/quorum-queues.html) replicas
+ * [Quorum queue](./quorum-queues.html) replicas
  * Classic mirrored queue [leader replicas](ha.html)
  * Classic mirrored queue mirror (follower) replicas
  * Message Store and Indices
@@ -322,7 +322,7 @@ things in the system (e.g. connections, queues):
 
 ## <a id="breakdown-http-api-curl" class="anchor" href="#breakdown-http-api-curl">Producing Memory Use Breakdown Using HTTP API and curl</a>
 
-It is possible to produce memory use breakdown over [HTTP API](/management.html)
+It is possible to produce memory use breakdown over [HTTP API](./management.html)
 by issuing a `GET` request to the `/api/nodes/{node}/memory` endpoint.
 
 <pre class="lang-json">
@@ -414,9 +414,9 @@ a certain number of channels. Finding an optimal value is usually a matter of tr
 Memory used by queues, queue indices, queue state. Messages enqueued will
 in part contribute to this category.
 
-Queues will [swap their contents out to disc when under memory pressure](/memory.html).
+Queues will [swap their contents out to disc when under memory pressure](./memory.html).
 The exact behavior of this depends on [queue properties](queues.html),
-whether clients publish messages as persistent or transient, and [persistence configuration](/persistence-conf.html) of the node.
+whether clients publish messages as persistent or transient, and [persistence configuration](./persistence-conf.html) of the node.
 
 Message bodies do not show up here but in Binaries.
 
@@ -506,7 +506,7 @@ The plugin ships with RabbitMQ. Enable it with
 [sudo] rabbitmq-plugins enable rabbitmq_top
 </pre>
 
-The plugin adds new administrative tabs to the [management UI](/management.html). One
+The plugin adds new administrative tabs to the [management UI](./management.html). One
 tab displays top processes by one of the metrics:
 
  * Memory used
@@ -553,7 +553,7 @@ documentation.
 ## <a id="memory-breakdown-and-monitoring" class="anchor" href="#memory-breakdown-and-monitoring">Memory Use Monitoring</a>
 
 It is recommended that production systems monitor memory usage of all cluster nodes,
-ideally with a breakdown, together with [infrastructure-level metrics](/monitoring.html).
+ideally with a breakdown, together with [infrastructure-level metrics](./monitoring.html).
 By correlating breakdown categories with other metrics, e.g. the number of concurrent
 connections or enqueued messages, it becomes possible to detect problems that
 stem from an application-specific behavior (e.g. connection leaks or ever growing queues without consumers).

--- a/site/memory-use.md
+++ b/site/memory-use.md
@@ -156,7 +156,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>
       Processes responsible for connection parser and most of connection state. Most of their memory attributes
       to TCP buffers. The more client connections a node has, the more memory will be used by this category.
-      See <a href="/networking.html">Networking guide</a> for more information.
+      See <a href="./networking.html">Networking guide</a> for more information.
     </td>
   </tr>
 
@@ -166,7 +166,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>
       Processes responsible for serialisation of outgoing protocol frames and writing to client connection sockets.
       The more client connections a node has, the more memory will be used by this category.
-      See <a href="/networking.html">Networking guide</a> for more information.
+      See <a href="./networking.html">Networking guide</a> for more information.
     </td>
   </tr>
 
@@ -186,9 +186,9 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>quorum_queue_procs</td>
     <td>Queues</td>
     <td>
-      <a href="//quorum-queues.html">Quorum queue</a> processes, both currently elected leaders and followers.
+      <a href=".//quorum-queues.html">Quorum queue</a> processes, both currently elected leaders and followers.
       Memory footprint can be capped on a per-queue basis.
-      See the <a href="/quorum-queues.html">Quorum Queues</a> guide for more information.
+      See the <a href="./quorum-queues.html">Quorum Queues</a> guide for more information.
     </td>
   </tr>
 
@@ -199,7 +199,7 @@ reserved_unallocated: 0.0 gb (0.0%)
       Classic queue leaders, indices and messages kept in memory. The greater the number of messages enqueued,
       the more memory will generally be attributed to this section. However, this greatly depends on
       queue properties and whether messages were published as transient.
-      See <a href="/memory.html">Memory</a>, <a href="/queues.html">Queues</a>, and <a href="/lazy-queues.html">Lazy Queues</a> guides
+      See <a href="./memory.html">Memory</a>, <a href="./queues.html">Queues</a>, and <a href="./lazy-queues.html">Lazy Queues</a> guides
       for more information.
     </td>
   </tr>
@@ -212,17 +212,17 @@ reserved_unallocated: 0.0 gb (0.0%)
       inherently transient data can reduce the amount of RAM used by mirrors. The greater the number of messages enqueued,
       the more memory will generally be attributed to this section. However, this greatly depends on
       queue properties and whether messages were published as transient.
-      See <a href="/memory.html">Memory</a>, <a href="/queues.html">Queues</a>, <a href="/ha.html">Mirroring</a>, and <a href="/lazy-queues.html">Lazy Queues</a> guides
+      See <a href="./memory.html">Memory</a>, <a href="./queues.html">Queues</a>, <a href="./ha.html">Mirroring</a>, and <a href="./lazy-queues.html">Lazy Queues</a> guides
       for more information.
     </td>
   </tr>
 
   <tr>
     <td>metrics</td>
-    <td><a href="/management.html">Stats DB</a></td>
+    <td><a href="./management.html">Stats DB</a></td>
     <td>
       Node-local metrics. The more connections, channels, queues are node hosts, the more stats there are to collect and keep.
-      See <a href="/management.html">management plugin guide</a> for more information.
+      See <a href="./management.html">management plugin guide</a> for more information.
     </td>
   </tr>
 
@@ -231,7 +231,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>Stats DB</td>
     <td>
       Aggregated and pre-computed metrics, inter-node HTTP API request cache and everything else related to the stats DB.
-      See <a href="/management.html">management plugin guide</a> for more information.
+      See <a href="./management.html">management plugin guide</a> for more information.
     </td>
   </tr>
 
@@ -245,7 +245,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>plugins</td>
     <td>Plugins</td>
     <td>
-      Plugins such as <a href="/shovel.html">Shovel</a>, <a href="/federation.html">Federation</a>, or protocol implementations such as <a href="">STOMP</a>
+      Plugins such as <a href="./shovel.html">Shovel</a>, <a href="./federation.html">Federation</a>, or protocol implementations such as <a href="">STOMP</a>
       can accumulate messages in memory.
     </td>
   </tr>

--- a/site/memory.md
+++ b/site/memory.md
@@ -28,9 +28,9 @@ limitations under the License.
 This guide covers RabbitMQ memory threshold and paging settings, running nodes
 on 64-bit and 32-bit systems, and other related topics.
 
-A separate guide, [Reasoning About Memory Use](/memory-use.html), covers how to
+A separate guide, [Reasoning About Memory Use](./memory-use.html), covers how to
 determine what consumes memory on a running RabbitMQ node for the purpose of
-[monitoring](/monitoring.html) or troubleshooting.
+[monitoring](./monitoring.html) or troubleshooting.
 
 ## <a id="threshold" class="anchor" href="#threshold">Memory Threshold: What it is and How it Works</a>
 
@@ -39,10 +39,10 @@ RAM installed in the computer on startup and when
 
 <code>rabbitmqctl set_vm_memory_high_watermark <em>fraction</em></code> is
 executed. By default, when the RabbitMQ server uses above 40%
-of the available RAM, it raises a memory [alarm](/alarms.html) and blocks all
+of the available RAM, it raises a memory [alarm](./alarms.html) and blocks all
 connections that are publishing messages. Once the memory alarm has cleared (e.g. due
 to the server paging messages to disk or delivering them to
-clients that consume and [acknowledge the deliveries](/confirms.html)) normal service resumes.
+clients that consume and [acknowledge the deliveries](./confirms.html)) normal service resumes.
 
 The default memory threshold is set to 40% of installed
 RAM. Note that this does not prevent the RabbitMQ server
@@ -96,7 +96,7 @@ vm_memory_high_watermark.absolute = 1024MiB
 If the absolute limit is larger than the installed RAM or available virtual
 address space, the threshold is set to whichever limit is smaller.
 
-The memory limit is appended to the [log file](/logging.html) when the RabbitMQ node
+The memory limit is appended to the [log file](./logging.html) when the RabbitMQ node
 starts:
 
 <pre class="lang-ini">
@@ -174,7 +174,7 @@ space, running over the limit will cause the VM to terminate or killed
 by an out-of-memory mechanism of the operating system.
 
 It is therefore strongly recommended to run RabbitMQ on a 64 bit
-OS and a 64-bit [Erlang runtime](/which-erlang.html).
+OS and a 64-bit [Erlang runtime](./which-erlang.html).
 
 
 ## <a id="paging" class="anchor" href="#paging">Configuring the Paging Threshold</a>
@@ -212,7 +212,7 @@ to go off, then producers will be blocked as explained above.
 ## <a id="unrecognised-platforms" class="anchor" href="#unrecognised-platforms">Unrecognised Platforms</a>
 
 If the RabbitMQ server is unable to detect the operating system it is running on,
-it will append a warning to the [log file](/logging.html). It then assumes than
+it will append a warning to the [log file](./logging.html). It then assumes than
 1GB of RAM is installed:
 
 <pre class="lang-ini">
@@ -231,4 +231,4 @@ want RabbitMQ to throttle producers when the server is using
 above 3GB, set `vm_memory_high_watermark` to 3.
 
 For guidelines on recommended RAM watermark settings,
-see [Production Checklist](/production-checklist.html#resource-limits-ram).
+see [Production Checklist](./production-checklist.html#resource-limits-ram).

--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -246,7 +246,7 @@ be one example. Both types are complimentary to infrastructure and node metrics.
       <td><code>queue_totals.messages_ready</code></td>
     </tr>
     <tr>
-      <td>Number of <a href="/confirms.html">unacknowledged</a> messages</td>
+      <td>Number of <a href="./confirms.html">unacknowledged</a> messages</td>
       <td><code>queue_totals.messages_unacknowledged</code></td>
     </tr>
     <tr>
@@ -296,7 +296,7 @@ compared to their previous values and historical mean/percentile values.
   </thead>
   <tbody>
     <tr>
-      <td>Total amount of <a href="/memory-use.html">memory used</a></td>
+      <td>Total amount of <a href="./memory-use.html">memory used</a></td>
       <td><code>mem_used</code></td>
     </tr>
     <tr>
@@ -304,7 +304,7 @@ compared to their previous values and historical mean/percentile values.
       <td><code>mem_limit</code></td>
     </tr>
     <tr>
-      <td>Is a <a href="/memory.html">memory alarm</a> in effect?</td>
+      <td>Is a <a href="./memory.html">memory alarm</a> in effect?</td>
       <td><code>mem_alarm</code></td>
     </tr>
     <tr>
@@ -312,11 +312,11 @@ compared to their previous values and historical mean/percentile values.
       <td><code>disk_free_limit</code></td>
     </tr>
     <tr>
-      <td>Is a <a href="/disk-alarms.html">disk alarm</a> in effect?</td>
+      <td>Is a <a href="./disk-alarms.html">disk alarm</a> in effect?</td>
       <td><code>disk_free_alarm</code></td>
     </tr>
     <tr>
-      <td><a href="/networking.html#open-file-handle-limit">File descriptors available</a></td>
+      <td><a href="./networking.html#open-file-handle-limit">File descriptors available</a></td>
       <td><code>fd_total</code></td>
     </tr>
     <tr>
@@ -393,7 +393,7 @@ via the `GET /api/queues/{vhost}/{qname}` endpoint.
       <td><code>messages_ready</code></td>
     </tr>
     <tr>
-      <td>Number of <a href="/confirms.html">unacknowledged</a> messages</td>
+      <td>Number of <a href="./confirms.html">unacknowledged</a> messages</td>
       <td><code>messages_unacknowledged</code></td>
     </tr>
     <tr>
@@ -867,7 +867,7 @@ Note that this list is by no means complete.
     <tr>
       <td>Prometheus</td>
       <td>
-        <a href="/prometheus.html">Prometheus guide</a>,
+        <a href="./prometheus.html">Prometheus guide</a>,
         <a href="https://github.com/rabbitmq/rabbitmq-prometheus">GitHub</a>
       </td>
     </tr>

--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -46,7 +46,7 @@ categories:
 and also mentioned in this guide.
 
 A number of [popular tools](#monitoring-tools), both open source and commercial,
-can be used to monitor RabbitMQ. [Prometheus and Grafana](/prometheus.html) are one highly
+can be used to monitor RabbitMQ. [Prometheus and Grafana](./prometheus.html) are one highly
 recommended option.
 
 
@@ -82,7 +82,7 @@ parameters are "the process must be running". Finally, there is an evaluation st
 
 Of course, there are more varieties of health checks. Which ones are most appropriate depends on the
 definition of a "healthy node" used. So, it is a system- and team-specific decision. [RabbitMQ CLI
-tools](/cli.html) provide commands that can serve as useful health checks. They will be covered
+tools](./cli.html) provide commands that can serve as useful health checks. They will be covered
 [later in this guide](#health-checks).
 
 While health checks are a useful tool, they only provide so much insight into the state of the
@@ -115,8 +115,8 @@ Collect the following metrics on all hosts that run RabbitMQ nodes or applicatio
  * Memory usage (used, buffered, cached &amp; free percentages)
  * [Virtual Memory](https://www.kernel.org/doc/Documentation/sysctl/vm.txt) statistics (dirty page flushes, writeback volume)
  * Disk I/O (operations &amp; amount of data transferred per unit time, time to service operations)
- * Free disk space on the mount used for the [node data directory](/relocate.html)
- * File descriptors used by `beam.smp` vs. [max system limit](/networking.html#open-file-handle-limit)
+ * Free disk space on the mount used for the [node data directory](./relocate.html)
+ * File descriptors used by `beam.smp` vs. [max system limit](./networking.html#open-file-handle-limit)
  * TCP connections by state (`ESTABLISHED`, `CLOSE_WAIT`, `TIME_WAIT`)
  * Network throughput (bytes received, bytes sent) & maximum network throughput
  * Network latency (between all RabbitMQ nodes in a cluster as well as to/from clients)
@@ -130,7 +130,7 @@ Many monitoring systems poll their monitored services periodically. How often th
 done varies from tool to tool but usually can be configured by the operator.
 
 Very frequent polling can have negative consequences on the system under monitoring. For example,
-excessive load balancer checks that open a test TCP connection to a node can lead to a [high connection churn](/networking.html#dealing-with-high-connection-churn).
+excessive load balancer checks that open a test TCP connection to a node can lead to a [high connection churn](./networking.html#dealing-with-high-connection-churn).
 Excessive checks of channels and queues in RabbitMQ will increase its CPU consumption. When there
 are many (say, 10s of thousands) of them on a node, the difference can be significant.
 
@@ -138,13 +138,13 @@ The recommended metric collection interval is 15 second. To collect at an interv
 For rate metrics, use a time range that spans 4 metric collection intervals so that it can tolerate race-conditions and is resilient to scrape failures.
 
 For production systems a collection interval of 30 or even 60 seconds is recommended.
-[Prometheus](/prometheus.html) exporter API is designed to be scraped every 15 seconds,
+[Prometheus](./prometheus.html) exporter API is designed to be scraped every 15 seconds,
 including production systems.
 
 
 ## <a id="external-monitoring" class="anchor" href="#external-monitoring">Management UI and External Monitoring Systems</a>
 
-RabbitMQ comes with a [management UI and HTTP API](/management.html) which exposes a number of [RabbitMQ metrics](#rabbitmq-metrics)
+RabbitMQ comes with a [management UI and HTTP API](./management.html) which exposes a number of [RabbitMQ metrics](#rabbitmq-metrics)
 for nodes, connections, queues, message rates and so on. This is a convenient option for development
 and in environments where external monitoring is difficult or impossible to introduce.
 
@@ -154,22 +154,22 @@ However, the management UI has a number of limitations:
  * A certain amount of overhead
  * It only stores recent data (think hours, not days or months)
  * It has a basic user interface
- * Its design [emphasizes ease of use over best possible availability](/management.html#clustering).
- * Management UI access is controlled via the [RabbitMQ permission tags system](/access-control.html)
+ * Its design [emphasizes ease of use over best possible availability](./management.html#clustering).
+ * Management UI access is controlled via the [RabbitMQ permission tags system](./access-control.html)
    (or a convention on JWT token scopes)
 
-Long term metric storage and visualisation services such as [Prometheus and Grafana](/prometheus.html) or the [ELK stack](https://www.elastic.co/what-is/elk-stack) are more suitable options for production systems. They offer:
+Long term metric storage and visualisation services such as [Prometheus and Grafana](./prometheus.html) or the [ELK stack](https://www.elastic.co/what-is/elk-stack) are more suitable options for production systems. They offer:
 
  * Decoupling of the monitoring system from the system being monitored
  * Lower overhead
  * Long term metric storage
- * Access to additional related metrics such as [Erlang runtime](/runtime.html) ones
+ * Access to additional related metrics such as [Erlang runtime](./runtime.html) ones
  * More powerful and customizable user interface
  * Ease of metric data sharing: both metric state and dashboards
  * Metric access permissions are not specific to RabbitMQ
  * Collection and aggregation of node-specific metrics which is more resilient to individual node failures
 
-RabbitMQ provides first class support for [Prometheus and Grafana](/prometheus.html) as of 3.8.
+RabbitMQ provides first class support for [Prometheus and Grafana](./prometheus.html) as of 3.8.
 It is recommended for production environments.
 
 
@@ -185,7 +185,7 @@ This section will cover multiple RabbitMQ-specific aspects of monitoring.
 
 When monitoring clusters it is important to understand the guarantees provided by the
 HTTP API. In a clustered environment every node can serve metric endpoint requests.
-Cluster-wide metrics can be fetched from any node that [can contact its peers](/management.html#clustering). That node
+Cluster-wide metrics can be fetched from any node that [can contact its peers](./management.html#clustering). That node
 will collect and combine data from its peers as needed before producing a response.
 
 Every node also can serve requests to endpoints that provide [node-specific metrics](#node-metrics)
@@ -193,7 +193,7 @@ for itself as well as other cluster nodes. Like with [infrastructure and OS metr
 node-specific metrics must be collected for each node. Monitoring tools can execute HTTP API requests against any node.
 
 As mentioned earlier, inter-node connectivity issues
-will [affect HTTP API behaviour](/management.html#clustering). Choose a random online node for monitoring requests.
+will [affect HTTP API behaviour](./management.html#clustering). Choose a random online node for monitoring requests.
 For example, using a load balancer or [round-robin DNS](https://en.wikipedia.org/wiki/Round-robin_DNS).
 
 Some endpoints perform operations on the target node. Node-local health checks is the most common
@@ -437,7 +437,7 @@ keep up with the rate, even a downstream service that's experiencing a slowdown
 
 Some client libraries and frameworks
 provide means of registering metrics collectors or collect metrics out of the box.
-[RabbitMQ Java client](/api-guide.html) and [Spring AMQP](http://spring.io/projects/spring-amqp) are two examples.
+[RabbitMQ Java client](./api-guide.html) and [Spring AMQP](http://spring.io/projects/spring-amqp) are two examples.
 With others developers have to track metrics in their application code.
 
 What metrics applications track can be system-specific but some are relevant
@@ -488,14 +488,14 @@ and should be avoided. Use one of the checks covered in this section (or their c
 
 #### Stage 1
 
-The most basic check ensures that the [runtime](/runtime.html) is running
-and (indirectly) that CLI tools can [authenticate](/cli.html#erlang-cookie) with it.
+The most basic check ensures that the [runtime](./runtime.html) is running
+and (indirectly) that CLI tools can [authenticate](./cli.html#erlang-cookie) with it.
 
 Except for the CLI tool authentication
 part, the probability of false positives can be considered approaching `0`
 except for upgrades and maintenance windows.
 
-[`rabbitmq-diagnostics ping`](/rabbitmq-diagnostics.8.html) performs this check:
+[`rabbitmq-diagnostics ping`](./rabbitmq-diagnostics.8.html) performs this check:
 
 <pre class="lang-bash">
 rabbitmq-diagnostics -q ping
@@ -504,7 +504,7 @@ rabbitmq-diagnostics -q ping
 
 #### Stage 2
 
-A slightly more comprehensive check is executing [`rabbitmq-diagnostics status`](/rabbitmq-diagnostics.8.html) status:
+A slightly more comprehensive check is executing [`rabbitmq-diagnostics status`](./rabbitmq-diagnostics.8.html) status:
 
 This includes the stage 1 check plus retrieves some essential
 system information which is useful for other checks and should always be
@@ -522,8 +522,8 @@ except for upgrades and maintenance windows.
 #### Stage 3
 
 Includes previous checks and also verifies that the RabbitMQ application is running
-(not stopped with [`rabbitmqctl stop_app`](/rabbitmqctl.8.html#stop_app)
-or the [Pause Minority partition handling strategy](/partitions.html))
+(not stopped with [`rabbitmqctl stop_app`](./rabbitmqctl.8.html#stop_app)
+or the [Pause Minority partition handling strategy](./partitions.html))
 and there are no resource alarms.
 
 <pre class="lang-bash">
@@ -531,10 +531,10 @@ and there are no resource alarms.
 rabbitmq-diagnostics -q alarms
 </pre>
 
-[`rabbitmq-diagnostics check_running`](/rabbitmq-diagnostics.8.html) is a check that makes sure that the runtime is running
+[`rabbitmq-diagnostics check_running`](./rabbitmq-diagnostics.8.html) is a check that makes sure that the runtime is running
 and the RabbitMQ application on it is not stopped or paused.
 
-[`rabbitmq-diagnostics check_local_alarms`](/rabbitmq-diagnostics.8.html) checks that there are no local alarms in effect
+[`rabbitmq-diagnostics check_local_alarms`](./rabbitmq-diagnostics.8.html) checks that there are no local alarms in effect
 on the node. If there are any, it will exit with a non-zero status.
 
 The two commands in combination deliver the stage 3 check:
@@ -545,7 +545,7 @@ rabbitmq-diagnostics -q check_running &amp;&amp; rabbitmq-diagnostics -q check_l
 </pre>
 
 The probability of false positives is low. Systems hovering around their
-[high runtime memory watermark](/alarms.html) will have a high probability of false positives.
+[high runtime memory watermark](./alarms.html) will have a high probability of false positives.
 During upgrades and maintenance windows can raise significantly.
 
 Specifically for memory alarms, the `GET /api/nodes/{node}/memory` HTTP API endpoint can be used for additional checks.
@@ -584,7 +584,7 @@ curl --silent -u guest:guest -X GET http://127.0.0.1:15672/api/nodes/rabbit@host
 # =&gt; }
 </pre>
 
-The [breakdown information](/memory-use.html) it produces can be reduced down to a single value using [jq](https://stedolan.github.io/jq/manual/)
+The [breakdown information](./memory-use.html) it produces can be reduced down to a single value using [jq](https://stedolan.github.io/jq/manual/)
 or similar tools:
 
 <pre class="lang-bash">
@@ -592,7 +592,7 @@ curl --silent -u guest:guest -X GET http://127.0.0.1:15672/api/nodes/rabbit@host
 # =&gt; 397365248
 </pre>
 
-[`rabbitmq-diagnostics -q memory_breakdown`](/rabbitmq-diagnostics.8.html) provides access to the same per category data
+[`rabbitmq-diagnostics -q memory_breakdown`](./rabbitmq-diagnostics.8.html) provides access to the same per category data
 and supports various units:
 
 <pre class="lang-bash">
@@ -623,7 +623,7 @@ rabbitmq-diagnostics -q memory_breakdown --unit "MB"
 Includes all checks in stage 3 plus a check on all enabled listeners
 (using a temporary TCP connection).
 
-To inspect all listeners enabled on a node, use [`rabbitmq-diagnostics listeners`](/rabbitmq-diagnostics.8.html):
+To inspect all listeners enabled on a node, use [`rabbitmq-diagnostics listeners`](./rabbitmq-diagnostics.8.html):
 
 <pre class="lang-bash">
 rabbitmq-diagnostics -q listeners
@@ -634,7 +634,7 @@ rabbitmq-diagnostics -q listeners
 # =&gt; Interface: [::], port: 15671, protocol: https, purpose: HTTP API over TLS (HTTPS)
 </pre>
 
-[`rabbitmq-diagnostics check_port_connectivity`](/rabbitmq-diagnostics.8.html) is a command that
+[`rabbitmq-diagnostics check_port_connectivity`](./rabbitmq-diagnostics.8.html) is a command that
 performs the basic TCP connectivity check mentioned above:
 
 <pre class="lang-bash">
@@ -647,9 +647,9 @@ maintenance windows can raise significantly.
 
 #### Stage 5
 
-Includes all checks in stage 4 plus checks that there are no failed [virtual hosts](/vhosts.html).
+Includes all checks in stage 4 plus checks that there are no failed [virtual hosts](./vhosts.html).
 
-[`rabbitmq-diagnostics check_virtual_hosts`](/rabbitmq-diagnostics.8.html) is a command
+[`rabbitmq-diagnostics check_virtual_hosts`](./rabbitmq-diagnostics.8.html) is a command
 checks whether any virtual host dependencies may have failed. This is done for all
 virtual hosts.
 
@@ -664,19 +664,19 @@ high CPU load.
 
 ### <a id="readiness-probes" class="anchor" href="#readiness-probes">Health Checks as Readiness Probes</a>
 
-In some environments, node restarts are controlled with a designated [health check](/monitoring.html#health-checks).
+In some environments, node restarts are controlled with a designated [health check](./monitoring.html#health-checks).
 The checks verify that one node has started and the deployment process can proceed to the next one.
 If the check does not pass, the deployment of the node is considered to be incomplete and the deployment process
 will typically wait and retry for a period of time. One popular example of such environment is Kubernetes
 where an operator-defined [readiness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate)
 can prevent a deployment from proceeding when the [`OrderedReady` pod management policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#deployment-and-scaling-guarantees) is used.
 
-Given the [peer syncing behavior during node restarts](/clustering.html#restarting-schema-sync), such a health check can prevent a cluster-wide restart
+Given the [peer syncing behavior during node restarts](./clustering.html#restarting-schema-sync), such a health check can prevent a cluster-wide restart
 from completing in time. Checks that explicitly or implicitly assume a fully booted node that's rejoined
 its cluster peers will fail and block further node deployments.
 
 Most health check, even relatively basic ones, implicitly assume that the node has
-finished booting. They are not suitable for nodes that are [awaiting schema table sync](/clustering.html#restarting-schema-sync) from a peer.
+finished booting. They are not suitable for nodes that are [awaiting schema table sync](./clustering.html#restarting-schema-sync) from a peer.
 
 One very common example of such check is
 
@@ -695,7 +695,7 @@ rabbitmq-diagnostics ping
 </pre>
 
 This basic check would allow the deployment to proceed and the nodes to eventually rejoin each other,
-assuming they are [compatible](/upgrade.html).
+assuming they are [compatible](./upgrade.html).
 
 
 #### Optional Check 1
@@ -703,7 +703,7 @@ assuming they are [compatible](/upgrade.html).
 This check verifies that an expected set of plugins is enabled. It is orthogonal to
 the primary checks.
 
-[`rabbitmq-plugins list --enabled`](/rabbitmq-plugins.8.html#list) is the command that lists enabled plugins
+[`rabbitmq-plugins list --enabled`](./rabbitmq-plugins.8.html#list) is the command that lists enabled plugins
 on a node:
 
 <pre class="lang-bash">
@@ -730,7 +730,7 @@ rabbitmq-plugins -q is_enabled rabbitmq_shovel
 </pre>
 
 The probability of false positives is generally low but raises
-in environments where environment variables that can affect [rabbitmq-plugins](/cli.html)
+in environments where environment variables that can affect [rabbitmq-plugins](./cli.html)
 are overridden.
 
 ## <a id="deprecations" class="anchor" href="#deprecations">Deprecated Health Checks and Monitoring Features</a>
@@ -758,7 +758,7 @@ assumes a fully booted node.
 
 `rabbitmq-diagnostics observer` is a command-line tool similar to `top`, `htop`, `vmstat`. It is a command line
 alternative to [Erlang's Observer application](http://erlang.org/doc/man/observer.html). It provides
-access to many metrics, including detailed state of individual [runtime](/runtime.html) processes:
+access to many metrics, including detailed state of individual [runtime](./runtime.html) processes:
 
  * Runtime version information
  * CPU and schedule stats
@@ -897,6 +897,6 @@ Note that this list is by no means complete.
 
 ## <a id="log-aggregation" class="anchor" href="#log-aggregation">Log Aggregation</a>
 
-[Logs](/logging.html) are also very important in troubleshooting a distributed system. Like metrics, logs can provide
+[Logs](./logging.html) are also very important in troubleshooting a distributed system. Like metrics, logs can provide
 important clues that will help identify the root cause. Collect logs from all RabbitMQ nodes as well
 as all applications (if possible).

--- a/site/mpl.md
+++ b/site/mpl.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Mozilla Public License
 
 This page contains the complete license text as used in the
-RabbitMQ [distributions](/download.html).
+RabbitMQ [distributions](./download.html).
 
 
 ## The License

--- a/site/mqtt.md
+++ b/site/mqtt.md
@@ -69,7 +69,7 @@ The plugin must be enabled on all cluster nodes.
 * Retained messages with pluggable storage backends
 
 MQTT clients can interoperate with other protocols. All the functionality in
-the [management UI](/management.html) and several other plugins can be
+the [management UI](./management.html) and several other plugins can be
 used with MQTT, although there may be some limitations or the need to
 tweak the defaults.
 
@@ -77,7 +77,7 @@ tweak the defaults.
 ## <a id="enabling-plugin" class="anchor" href="#enabling-plugin">Enabling the Plugin</a>
 
 The MQTT plugin is included in the RabbitMQ distribution. Before clients can successfully
-connect, it must be enabled using [rabbitmq-plugins](/cli.html):
+connect, it must be enabled using [rabbitmq-plugins](./cli.html):
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_mqtt
@@ -89,7 +89,7 @@ they have a set of credentials for an existing user with the appropriate permiss
 ### <a id="authentication" class="anchor" href="#authentication">Users and Authentication</a>
 
 For an MQTT connection to succeed, it must successfully authenticate and the user must
-have the [appropriate permissions](/access-control.html) to the virtual host used by the
+have the [appropriate permissions](./access-control.html) to the virtual host used by the
 plugin (see below).
 
 MQTT clients can (and usually do) specify a set of credentials when they connect.
@@ -98,11 +98,11 @@ The plugin supports anonymous authentication but its use is highly discouraged a
 to certain limitations (listed below) enforced for a reasonable level of security
 by default.
 
-Users and their permissions can be managed using [rabbitmqctl](/cli.html), [management UI](/management.html)
+Users and their permissions can be managed using [rabbitmqctl](./cli.html), [management UI](./management.html)
 or HTTP API.
 
 For example, the following commands create a new user for MQTT connections with full access
-to the default [virtual host](/vhosts.html) used by this plugin:
+to the default [virtual host](./vhosts.html) used by this plugin:
 
 <pre class="lang-bash">
 # username and password are both "mqtt-test"
@@ -124,7 +124,7 @@ There is also support for multi-tenancy.
 The plugin builds on top of RabbitMQ core protocol's entities: exchanges and queues. Messages published
 to MQTT topics use a topic exchange (`amq.topic` by default) internally. Subscribers consume from
 RabbitMQ queues bound to the topic exchange. This both enables interoperability
-with other protocols and makes it possible to use the [Management plugin](/management.html)
+with other protocols and makes it possible to use the [Management plugin](./management.html)
 to inspect queue sizes, message rates, and so on.
 
 Note that MQTT uses slashes ("/") for topic segment separators and
@@ -145,7 +145,7 @@ that make sure remote clients can successfully connect:
  * Create one or more new user(s), grant them full permissions to the virtual host used by the MQTT plugin and make clients
    that connect from remote hosts use those credentials. This is the recommended option.
  * Set `default_user` and `default_pass` via [MQTT plugin configuration](#config) to a non-`guest` user who has the
-[appropriate permissions](/access-control.html).
+[appropriate permissions](./access-control.html).
 
 
 ### <a id="anonymous-connections" class="anchor" href="#anonymous-connections">Anonymous Connections</a>
@@ -250,9 +250,9 @@ node out of two means the loss of a quorum of online nodes.
 
 RabbitMQ's Raft implementation keeps a portion of the operation log in memory as well as on disk.
 In environments where the MQTT plugin is the only Raft-based feature used
-(namely where [quorum queues](/quorum-queues.html) are not used), reducing the portion of
+(namely where [quorum queues](./quorum-queues.html) are not used), reducing the portion of
 the log stored in memory will reduce memory footprint of the plugin in case of
-[high connection churn](/connections.html#high-connection-churn).
+[high connection churn](./connections.html#high-connection-churn).
 
 The configuration key of interest is `raft.wal_max_size_bytes`:
 
@@ -262,13 +262,13 @@ The configuration key of interest is `raft.wal_max_size_bytes`:
 raft.wal_max_size_bytes = 67108864
 </pre>
 
-If [quorum queues](/quorum-queues.html) are adopted at a later point, this setting
+If [quorum queues](./quorum-queues.html) are adopted at a later point, this setting
 should be revisited to be closer to the default one.
 
 
 ## <a id="config" class="anchor" href="#config">Plugin Configuration</a>
 
-Here is a sample [configuration](/configure.html#config-file) that demonstrates a number of MQTT plugin settings:
+Here is a sample [configuration](./configure.html#config-file) that demonstrates a number of MQTT plugin settings:
 
 <pre class="lang-ini">
 mqtt.listeners.tcp.default = 1883
@@ -295,7 +295,7 @@ all interfaces on port 1883 and have a default user login/passcode
 of `guest`/`guest`.
 
 To change the listener port, edit your
-[Configuration file](/configure.html#configuration-files),
+[Configuration file](./configure.html#configuration-files),
 to contain a `tcp_listeners` variable for the `rabbitmq_mqtt` application.
 
 For example, a minimalistic configuration file which changes the listener
@@ -318,7 +318,7 @@ mqtt.listeners.tcp.2 = ::1:1883
 The plugin supports TCP listener option configuration.
 
 The settings use a common prefix, `mqtt.tcp_listen_options`, and control
-things such as TCP buffer sizes, inbound TCP connection queue length, whether [TCP keepalives](/heartbeats.html#tcp-keepalives)
+things such as TCP buffer sizes, inbound TCP connection queue length, whether [TCP keepalives](./heartbeats.html#tcp-keepalives)
 are enabled and so on. See the [Networking guide](networking.html) for details.
 
 <pre class="lang-ini">
@@ -338,7 +338,7 @@ mqtt.tcp_listen_options.send_timeout  = 120
 
 ### <a id="tls" class="anchor" href="#tls">TLS Support</a>
 
-To use TLS for MQTT connections, [TLS must be configured](/ssl.html) in the broker. To enable
+To use TLS for MQTT connections, [TLS must be configured](./ssl.html) in the broker. To enable
 TLS-enabled MQTT connections, add a TLS listener for MQTT using the `mqtt.listeners.ssl.*` configuration keys.
 
 The plugin will use core RabbitMQ server
@@ -377,7 +377,7 @@ connect to.
 #### Port to Virtual Host Mapping
 
 First way is mapping MQTT plugin (TCP or TLS) listener ports to vhosts. The mapping
-is specified thanks to the `mqtt_port_to_vhost_mapping` [global runtime parameter](/parameters.html).
+is specified thanks to the `mqtt_port_to_vhost_mapping` [global runtime parameter](./parameters.html).
 Let's take the following plugin configuration:
 
 <pre class="lang-ini">
@@ -479,7 +479,7 @@ Note that:
 * Clients **must not** supply username and password.
 
 You can optionally specify a virtual host for a client certificate by using the `mqtt_default_vhosts`
-[global runtime parameter](/parameters.html). The value of this global parameter must contain a JSON document that
+[global runtime parameter](./parameters.html). The value of this global parameter must contain a JSON document that
 maps certificates' subject's Distinguished Name to their target virtual host. Let's see how to
 map 2 certificates, `O=client,CN=guest` and `O=client,CN=rabbit`, to the `vhost1` and `vhost2`
 virtual hosts, respectively.
@@ -563,7 +563,7 @@ This feature is disabled by default, to enable it for MQTT clients:
 mqtt.proxy_protocol = true
 </pre>
 
-See the [Networking Guide](/networking.html#proxy-protocol) for more information
+See the [Networking Guide](./networking.html#proxy-protocol) for more information
 about the proxy protocol.
 
 ## <a id="sparkplug-support" class="anchor" href="#sparkplug-support">Sparkplug Support</a>
@@ -605,7 +605,7 @@ different benefits, trade-offs, and limitations.
 
 ## <a id="disabling-plugin" class="anchor" href="#disabling-plugin">Disabling the Plugin</a>
 
-Before the plugin is disabled on a node, or a node removed from the cluster, it must be decommissioned using [`rabbitmqctl`](/cli.html):
+Before the plugin is disabled on a node, or a node removed from the cluster, it must be decommissioned using [`rabbitmqctl`](./cli.html):
 
 <pre class="lang-bash">
 rabbitmqctl decommission_mqtt_node &lt;node&gt;

--- a/site/nack.md
+++ b/site/nack.md
@@ -19,10 +19,10 @@ limitations under the License.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-Consumers in AMQP 0-9-1 can choose to use [manual acknowledgements](/confirms.html)
+Consumers in AMQP 0-9-1 can choose to use [manual acknowledgements](./confirms.html)
 of deliveries.
 
-The [AMQP 0-9-1 specification](/specification.html) defines the `basic.reject`
+The [AMQP 0-9-1 specification](./specification.html) defines the `basic.reject`
 method that allows clients to reject individual, delivered
 messages, instructing the broker to either discard them or
 requeue them. Unfortunately, `basic.reject`
@@ -43,7 +43,7 @@ unacknowledged, delivered messages up to and including the
 message specified in the `delivery_tag` field of the `basic.nack` method. In this respect,
 `basic.nack` complements the bulk acknowledgement semantics of `basic.ack`.
 
-Negative acknowledgements work for both [long running consumers](/consumers.html)
+Negative acknowledgements work for both [long running consumers](./consumers.html)
 and polling-based ones (that use `basic.get`).
 
 When a message is requeued, it will be placed to its original

--- a/site/nettick.md
+++ b/site/nettick.md
@@ -28,7 +28,7 @@ Periodic tick messages are exchanged between all pairs of nodes to
 maintain the connections and to detect disconnections.
 Network interruptions could otherwise go undetected for a fairly long
 period of time (depending on the transport and OS kernel settings e.g. for TCP).
-Fundamentally this is the same problem that [heartbeats](/heartbeats.html)
+Fundamentally this is the same problem that [heartbeats](./heartbeats.html)
 seek to address in messaging protocols, just between different peers:
 RabbitMQ cluster nodes and CLI tools.
 
@@ -71,7 +71,7 @@ latency, but increases the risk of detecting spurious
 
 The impact of changing the default `net_ticktime` should be
 carefully considered. All nodes in a cluster must use the same
-`net_ticktime`. The following sample [advanced.config](/configure.html#advanced-config-file)
+`net_ticktime`. The following sample [advanced.config](./configure.html#advanced-config-file)
 configuration demonstrates doubling the default `net_ticktime` from
 60 to 120 seconds:
 

--- a/site/networking.md
+++ b/site/networking.md
@@ -319,7 +319,7 @@ CLI tools might be used. epmd port must be open for CLI tools and clustering
 to function.
 
 On Windows, the following settings have no effect when RabbitMQ runs as a service.
-Please see <a href="/windows-quirks.html">Windows Quirks</a> for details.
+Please see <a href="./windows-quirks.html">Windows Quirks</a> for details.
 
 The range used by RabbitMQ can also be controlled via two configuration keys:
 
@@ -997,7 +997,7 @@ are effective for both IPv4 and IPv6 connections):
         <code>net.ipv4.tcp_keepalive_time</code>, <code>net.ipv4.tcp_keepalive_intvl</code>,
         and <code>net.ipv4.tcp_keepalive_probes</code> configure TCP keepalive.
 
-        AMQP 0-9-1 and STOMP have <a href="/heartbeats.html">Heartbeats</a> which partially
+        AMQP 0-9-1 and STOMP have <a href="./heartbeats.html">Heartbeats</a> which partially
         undo its effect, namely that it can take minutes to detect an unresponsive peer,
         e.g. in case of a hardware or power failure. MQTT also has its own keepalives
         mechanism which is the same idea under a different name.
@@ -1097,7 +1097,7 @@ TCP stack tuning is a broad topic that is covered in much detail elsewhere:
         When set to <code>true</code>, enables TCP keepalives (see above).
         Default is <code>false</code>. Makes sense for environments where
         connections can go idle for a long time (at least 10 minutes),
-        although using <a href="/heartbeats.html">heartbeats</a> is still recommended over
+        although using <a href="./heartbeats.html">heartbeats</a> is still recommended over
         this option.
       </td>
     </tr>

--- a/site/networking.md
+++ b/site/networking.md
@@ -36,7 +36,7 @@ There are several areas which can be configured or tuned. Each has a section in 
 
  * [Interfaces](#interfaces) the node listens on for client connections
  * IP version preferences: [dual stack](#dual-stack), [IPv6-only](#single-stack-ipv6) and [IPv4-only](#single-stack-ipv4)
- * [Ports](#ports) used by clients, [inter-node traffic](#epmd-inet-dist-port-range) in clusters and [CLI tools](/cli.html)
+ * [Ports](#ports) used by clients, [inter-node traffic](#epmd-inet-dist-port-range) in clusters and [CLI tools](./cli.html)
  * [IPv6 support](#distribution-ipv6) for inter-node traffic
  * [TLS](#tls-support) for client connections
  * Tuning for a [large number of concurrent connections](#tuning-for-large-number-of-connections)
@@ -72,7 +72,7 @@ such as
 
 [Tanzu RabbitMQ](tanzu) provides an [inter-node traffic compression](clustering-compression.html) feature.
 
-A methodology for [troubleshooting of networking-related issues](/troubleshooting-networking.html)
+A methodology for [troubleshooting of networking-related issues](./troubleshooting-networking.html)
 is covered in a separate guide.
 
 
@@ -139,7 +139,7 @@ listeners.tcp.1 = 192.168.1.99:5672
 </pre>
 
 It is possible to disable non-TLS connections by disabling all regular TCP listeners.
-Only [TLS-enabled](/ssl.html) clients will be able to connect:
+Only [TLS-enabled](./ssl.html) clients will be able to connect:
 
 <pre class="lang-ini">
 # disables non-TLS listeners, only TLS-enabled clients will be able to connect
@@ -177,13 +177,13 @@ Make sure the following ports are accessible:
  * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
    and is allocated from a dynamic range (computed as server distribution port + 10000 through
    server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672, 15671: [HTTP API](/management.html) clients, [management UI](/management.html) and [rabbitmqadmin](/management-cli.html), without and with TLS
-   (only if the [management plugin](/management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](/stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](/mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](/web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](/web-mqtt.html) is enabled)
- * 15692: Prometheus metrics (only if the [Prometheus plugin](/prometheus.html) is enabled)
+ * 15672, 15671: [HTTP API](./management.html) clients, [management UI](./management.html) and [rabbitmqadmin](./management-cli.html), without and with TLS
+   (only if the [management plugin](./management.html) is enabled)
+ * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](./stomp.html) is enabled)
+ * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](./mqtt.html) is enabled
+ * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](./web-stomp.html) is enabled)
+ * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](./web-mqtt.html) is enabled)
+ * 15692: Prometheus metrics (only if the [Prometheus plugin](./prometheus.html) is enabled)
 
 It is possible to [configure RabbitMQ](configure.html)
 to use [different ports and specific network interfaces](networking.html).
@@ -195,7 +195,7 @@ Starting with RabbitMQ `3.8.8`, client connection listeners can be *suspended* t
 connections from being accepted. Existing connections will not be affected in any way.
 
 This can be useful during node operations and is one of the steps performed
-when a node is [put into maintenance mode](/upgrade.html#maintenance-mode).
+when a node is [put into maintenance mode](./upgrade.html#maintenance-mode).
 
 To suspend all listeners on a node and prevent new client connections to it, use `rabbitmqctl suspend_listeners`:
 
@@ -222,7 +222,7 @@ rabbitmqctl resume_listeners
 rabbitmqctl resume_listeners -n rabbit@node2.cluster.rabbitmq.svc
 </pre>
 
-Both operations will leave [log entries](/logging.html) in the node's log.
+Both operations will leave [log entries](./logging.html) in the node's log.
 
 
 ## <a id="epmd" class="anchor" href="#epmd">EPMD and Inter-node Communication</a>
@@ -231,8 +231,8 @@ Both operations will leave [log entries](/logging.html) in the node's log.
 
 [epmd](http://www.erlang.org/doc/man/epmd.html) (for Erlang Port Mapping Daemon)
 is a small additional daemon that runs alongside every RabbitMQ node and is used by
-the [runtime](/runtime.html) to discover what port a particular node listens on for
-inter-node communication. The port is then used by peer nodes and [CLI tools](/cli.html).
+the [runtime](./runtime.html) to discover what port a particular node listens on for
+inter-node communication. The port is then used by peer nodes and [CLI tools](./cli.html).
 
 When a node or CLI tool needs to contact node `rabbit@hostname2` it will do the following:
 
@@ -277,7 +277,7 @@ variable:
 export ERL_EPMD_PORT="4369"
 </pre>
 
-All hosts in a [cluster](/clustering.html) must use the same port.
+All hosts in a [cluster](./clustering.html) must use the same port.
 
 When `ERL_EPMD_PORT` is changed, both RabbitMQ node and `epmd` on the host must be stopped.
 For `epmd`, use
@@ -303,7 +303,7 @@ For RabbitMQ, the default range is limited to a single value computed as
 in using port 25672. This single port can be [configured](configure.html)
 using the `RABBITMQ_DIST_PORT` environment variable.
 
-RabbitMQ [command line tools](/cli.html) also use a range of ports. The default range is computed by taking the RabbitMQ
+RabbitMQ [command line tools](./cli.html) also use a range of ports. The default range is computed by taking the RabbitMQ
 distribution port value and adding 10000 to it. The next 10 ports are also part
 of this range. Thus, by default, this range is 35672 through 35682. This range
 can be configured using the <span class="envvar">RABBITMQ_CTL_DIST_PORT_MIN</span>
@@ -361,7 +361,7 @@ name rabbit at port 25672
 Inter-node connections use a buffer for data pending to be sent. Temporary
 throttling on inter-node traffic is applied when the buffer is at max allowed
 capacity. The limit is controlled via the `RABBITMQ_DISTRIBUTION_BUFFER_SIZE`
-[environment variable](/configure.html#supported-environment-variables)
+[environment variable](./configure.html#supported-environment-variables)
 in kilobytes. Default value is 128 MB (`128000` kB).
 
 In clusters with heavy inter-node traffic increasing this value may
@@ -464,7 +464,7 @@ systemctl restart epmd.socket epmd.service
 ## <a id="intermediaries" class="anchor" href="#intermediaries">Intermediaries: Proxies and Load Balancers</a>
 
 Proxies and load balancers are fairly commonly used to distribute client connections
-between [cluster nodes](/clustering.html). Proxies can also be useful
+between [cluster nodes](./clustering.html). Proxies can also be useful
 to make it possible for clients to access RabbitMQ nodes without exposing them publicly.
 Intermediaries can also have side effects on connections.
 
@@ -479,10 +479,10 @@ are therefore very important.
 Intermediaries also may terminate "idle" TCP connections
 when there's no activity on them for a certain period of
 time. Most of the time it is not desirable. Such events will result in
-[abrupt connection closure log messages](/logging.html#connection-lifecycle-events)
+[abrupt connection closure log messages](./logging.html#connection-lifecycle-events)
 on the server end and I/O exceptions on the client end.
 
-When [heartbeats](/heartbeats.html) are enabled on a connection, it results in
+When [heartbeats](./heartbeats.html) are enabled on a connection, it results in
 periodic light network traffic. Therefore heartbeats have a side effect
 of guarding client connections that can go idle for periods of
 time against premature closure by proxies and load balancers.
@@ -530,7 +530,7 @@ have their own settings that enable support for the proxy protocol.
 ## <a id="tls-support" class="anchor" href="#tls-support">TLS (SSL) Support</a>
 
 It is possible to encrypt connections using TLS with RabbitMQ. Authentication
-using peer certificates is also possible. Please refer to the [TLS/SSL guide](/ssl.html)
+using peer certificates is also possible. Please refer to the [TLS/SSL guide](./ssl.html)
 for more information.
 
 
@@ -563,7 +563,7 @@ For maximum throughput, it is possible to increase buffer size using a group of 
  * `mqtt.tcp_listen_options` for MQTT
  * `stomp.tcp_listen_options` for STOMP
 
-Note that increasing TCP buffer size will increase how much [RAM the node uses](/memory-use.html)
+Note that increasing TCP buffer size will increase how much [RAM the node uses](./memory-use.html)
 for every client connection.
 
 The following example sets TCP buffers for AMQP 0-9-1 connections to 192 KiB:
@@ -621,7 +621,7 @@ total throughput.
 Several factors can limit how many concurrent connections a single node can support:
 
  * Maximum number of [open file handles](#open-file-handle-limit) (including sockets) as well as other kernel-enforced resource limits
- * Amount of [RAM used by each connection](/memory-use.html)
+ * Amount of [RAM used by each connection](./memory-use.html)
  * Amount of CPU resources used by each connection
  * Maximum number of Erlang processes the VM is configured to allow.
 
@@ -634,7 +634,7 @@ TCP connections.
 
 How the limit is configured [varies from OS to OS](https://github.com/basho/basho_docs/blob/master/content/riak/kv/2.2.3/using/performance/open-files-limit.md) and distribution to distribution, e.g. depending on whether systemd is used.
 For Linux, Controlling System Limits on Linux
-in our [Debian](/install-debian.html#kernel-resource-limits) and [RPM](/install-rpm.html#kernel-resource-limits)
+in our [Debian](./install-debian.html#kernel-resource-limits) and [RPM](./install-rpm.html#kernel-resource-limits)
 installation guides provides. Linux kernel limit management is covered by many resources on the Web,
 including the [open file handle limit](https://ro-che.info/articles/2017-03-26-increase-open-files-limit).
 
@@ -666,7 +666,7 @@ using a group of config options:
  * `mqtt.tcp_listen_options` for MQTT
  * `stomp.tcp_listen_options` for STOMP
 
-Decreasing TCP buffer size will decrease how much [RAM the node uses](/memory-use.html)
+Decreasing TCP buffer size will decrease how much [RAM the node uses](./memory-use.html)
 for every client connection.
 
 This is often necessary in environments where the number of concurrent connections
@@ -729,7 +729,7 @@ Increasing the interval value to 30-60s will reduce CPU footprint and peak memor
 This comes with a downside: with the value in the example above, metrics of said entities
 will refresh every 60 seconds.
 
-This can be perfectly reasonable in an [externally monitored](/monitoring.html#monitoring-frequency) production system
+This can be perfectly reasonable in an [externally monitored](./monitoring.html#monitoring-frequency) production system
 but will make management UI less convenient to use for operators.
 
 ### <a id="tuning-for-large-number-of-connections-channel-max" class="anchor" href="#tuning-for-large-number-of-connections-channel-max">Limiting Number of Channels on a Connection</a>
@@ -766,7 +766,7 @@ tcp_listen_options.backlog = 4096
 tcp_listen_options.nodelay = true
 </pre>
 
-which should be used together with the following bits in the [advanced config file](/configure.html#advanced-config-file):
+which should be used together with the following bits in the [advanced config file](./configure.html#advanced-config-file):
 
 <pre class="lang-erlang">
 [
@@ -776,7 +776,7 @@ which should be used together with the following bits in the [advanced config fi
   ]}].
 </pre>
 
-When using the [classic config format](/configure.html#erlang-term-config-file),
+When using the [classic config format](./configure.html#erlang-term-config-file),
 everything is configured in a single file:
 
 <pre class="lang-erlang">
@@ -817,7 +817,7 @@ tcp_listen_options.backlog = 4096
 tcp_listen_options.nodelay = true
 </pre>
 
-In the [classic config format](/configure.html#erlang-term-config-file):
+In the [classic config format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 [
@@ -850,7 +850,7 @@ which will negatively affect overall system availability.
 
 Due to a combination of certain TCP features
 and defaults of most modern Linux distributions, closed connections can be detected after
-a prolonged period of time. This is covered in the [heartbeats guide](/heartbeats.html).
+a prolonged period of time. This is covered in the [heartbeats guide](./heartbeats.html).
 This can be one contributing factor to connection build-up. Another is the `TIME_WAIT` TCP
 connection state. The state primarily exists to make sure that retransmitted segments from closed
 connections won't "reappear" on a different (newer) connection with the same client host and port.
@@ -874,11 +874,11 @@ If a node fails to accept connections it is important to first gather data (metr
 determine the state of the system and the limiting factor (exhausted resource).
 Tools such as [netstat](https://en.wikipedia.org/wiki/Netstat),
 [ss](https://linux.die.net/man/8/ss), [lsof](https://en.wikipedia.org/wiki/Lsof) can be used
-to inspect TCP connections of a node. See [Troubleshooting Networking](/troubleshooting-networking.html) for examples.
+to inspect TCP connections of a node. See [Troubleshooting Networking](./troubleshooting-networking.html) for examples.
 
 ### <a id="dealing-with-high-connection-churn-tcp-keepalives" class="anchor" href="#dealing-with-high-connection-churn-tcp-keepalives"></a>
 
-While [heartbeats](/heartbeats.html) are sufficient for detecting defunct connections,
+While [heartbeats](./heartbeats.html) are sufficient for detecting defunct connections,
 they are not going to be sufficient in high connection churn scenarios. In those cases
 heartbeats should be combined with [TCP keepalives](#tcp-keepalives) to speed
 up disconnected client detection.
@@ -1116,14 +1116,14 @@ Below is the default TCP socket option configuration used by RabbitMQ:
 ## <a id="heartbeats" class="anchor" href="#heartbeats">Heartbeats</a>
 
 Some protocols supported by RabbitMQ, including AMQP 0-9-1, support <em>heartbeats</em>, a way to detect dead
-TCP peers quicker. Please refer to the [Heartbeats guide](/heartbeats.html)
+TCP peers quicker. Please refer to the [Heartbeats guide](./heartbeats.html)
 for more information.
 
 
 ## <a id="nettick" class="anchor" href="#nettick">Net Tick Time</a>
 
-[Heartbeats](/heartbeats.html) are used to detect peer or connection failure
-between clients and RabbitMQ nodes. [net_ticktime](/nettick.html) serves
+[Heartbeats](./heartbeats.html) are used to detect peer or connection failure
+between clients and RabbitMQ nodes. [net_ticktime](./nettick.html) serves
 the same purpose but for cluster node communication. Values lower than 5 (seconds)
 may result in false positive and are not recommended.
 
@@ -1216,7 +1216,7 @@ e.g. `rmq1.dev.megacorp.local`.
 
 If the `reverse_dns_lookups` configuration option is set to `true`,
 RabbitMQ will perform reverse DNS lookups for client IP addresses and list hostnames
-in connection information (e.g. in the [Management UI](/management.html)).
+in connection information (e.g. in the [Management UI](./management.html)).
 
 Reverse DNS lookups can potentially take a long time if node's hostname resolution is not
 optimally configured. This can increase latency when accepting client connections.
@@ -1235,8 +1235,8 @@ reverse_dns_lookups = false
 
 ### <a id="dns-verify-resolution" class="anchor" href="#dns-verify-resolution">Verify Hostname Resolution</a> on a Node or Locally
 
-Since hostname resolution is a [prerequisite for successful inter-node communication](/clustering.html#hostname-resolution-requirement),
-starting with [RabbitMQ `3.8.6`](/changelog.html), CLI tools provide two commands that help verify
+Since hostname resolution is a [prerequisite for successful inter-node communication](./clustering.html#hostname-resolution-requirement),
+starting with [RabbitMQ `3.8.6`](./changelog.html), CLI tools provide two commands that help verify
 that hostname resolution on a node works as expected. The commands are not meant to replace
 [`dig`](https://en.wikipedia.org/wiki/Dig_(command)) and other specialised DNS tools but rather
 provide a way to perform most basic checks while taking [Erlang runtime hostname resolver features](https://erlang.org/doc/apps/erts/inet_cfg.html)
@@ -1277,12 +1277,12 @@ inetrc File Host Entries
 
 ## <a id="logging" class="anchor" href="#logging">Connection Event Logging</a>
 
-See [Connection Lifecycle Events](/logging.html#connection-lifecycle-events) in the logging guide.
+See [Connection Lifecycle Events](./logging.html#connection-lifecycle-events) in the logging guide.
 
 
 ## <a id="troubleshooting-where-to-start" class="anchor" href="#troubleshooting-where-to-start">Troubleshooting Network Connectivity</a>
 
-A methodology for [troubleshooting of networking-related issues](/troubleshooting-networking.html)
+A methodology for [troubleshooting of networking-related issues](./troubleshooting-networking.html)
 is covered in a separate guide.
 
 

--- a/site/news.xml
+++ b/site/news.xml
@@ -23,7 +23,7 @@ limitations under the License.
   </head>
   <body>
     <p>
-      <a href="news.atom"><img src="img/feed-icon-14x14.png" height="14" width="14" alt="Subscribe" title="Subscribe" />Subscribe to this atom feed</a>
+      <a href="news.atom"><img src="./img/feed-icon-14x14.png" height="14" width="14" alt="Subscribe" title="Subscribe" />Subscribe to this atom feed</a>
     </p>
     <p>
       Also keep an eye on the <a href="changelog.html">change log</a> and <a href="http://groups.google.com/forum/#!forum/rabbitmq-users">RabbitMQ mailing list</a>.

--- a/site/news.xml
+++ b/site/news.xml
@@ -74,7 +74,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -109,7 +109,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -143,7 +143,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -178,7 +178,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -212,7 +212,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -246,7 +246,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -280,7 +280,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -314,7 +314,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -348,7 +348,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -382,7 +382,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -416,7 +416,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -450,7 +450,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -484,7 +484,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that exposes a handful of new metrics through the Prometheus API.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -518,7 +518,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -552,7 +552,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -586,7 +586,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -620,7 +620,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -654,7 +654,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -688,7 +688,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -722,7 +722,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -756,7 +756,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -790,7 +790,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -824,7 +824,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -858,7 +858,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -892,7 +892,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -926,7 +926,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -960,7 +960,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -1026,7 +1026,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -1060,7 +1060,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that includes a security vulnerability patch for <a href="https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-5452-hxj4-773x">CVE-2021-32719</a>.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -1094,7 +1094,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that includes a security vulnerability patch for <a href="https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-c3hj-rg5h-2772">CVE-2021-32718</a>.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
@@ -1129,7 +1129,7 @@ limitations under the License.
         <p>
           This is a maintenance release that follows-up to 3.8.15 to
           reintroduce AWS peer discovery plugin that was unintentionally excluded.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and is the first
@@ -1163,7 +1163,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that includes two security patches.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This is the last release to support Erlang/OTP 22.
@@ -1216,7 +1216,7 @@ limitations under the License.
         <p>
           This is a maintenance release that restores compatibility with Erlang 22.3
           for a specific feature.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on
@@ -1225,7 +1225,7 @@ limitations under the License.
         </p>
         <p>
           We encourage all users of earlier versions of RabbitMQ to upgrade to this latest release
-          and run it on <a href="/which-erlang.html">Erlang/OTP 23</a>.
+          and run it on <a href="./which-erlang.html">Erlang/OTP 23</a>.
         </p>
         <p>
           As always, we welcome any questions, bug reports, and other feedback
@@ -1247,7 +1247,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on
@@ -1256,7 +1256,7 @@ limitations under the License.
         </p>
         <p>
           We encourage all users of earlier versions of RabbitMQ to upgrade to this latest release
-          and run it on <a href="/which-erlang.html">Erlang/OTP 23</a>.
+          and run it on <a href="./which-erlang.html">Erlang/OTP 23</a>.
         </p>
         <p>
           As always, we welcome any questions, bug reports, and other feedback
@@ -1278,10 +1278,10 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that contains bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 22.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 22.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1311,7 +1311,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that follows-up to 3.8.10 with two bug fixes.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/v3K5nZNsfwM">requires Erlang/OTP 22.3</a>.
@@ -1344,7 +1344,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that focuses on bug fixes and usability improvements.
-          It also includes a few deprecations. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          It also includes a few deprecations. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/v3K5nZNsfwM">requires Erlang/OTP 22.3</a>.
@@ -1372,11 +1372,11 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that focuses on bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/v3K5nZNsfwM">drops support for Erlang/OTP 21.3</a>.
-          22.3 is now the <a href="/which-erlang.html">minimum supported version</a>.
+          22.3 is now the <a href="./which-erlang.html">minimum supported version</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1406,7 +1406,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that focuses on bug fixes and usability improvements.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This is the last release to <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/v3K5nZNsfwM">support Erlang/OTP 21.3</a>.
@@ -1439,7 +1439,7 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that includes a security vulnerability fix (<a href="https://tanzu.vmware.com/security/cve-2020-5419">CVE-2020-5419</a>).
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1469,11 +1469,11 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that includes a security vulnerability fix (<a href="https://tanzu.vmware.com/security/cve-2020-5419">CVE-2020-5419</a>).
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series are now <a href="/versions.html">only covered under the limited extended support policy</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series are now <a href="./versions.html">only covered under the limited extended support policy</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1502,7 +1502,7 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.6.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           Starting with this release, core RabbitMQ and plugins that ship with it
@@ -1540,7 +1540,7 @@ limitations under the License.
         </p>
 
         <p>
-          See <a href="/kubernetes/operator/operator-overview.html">Operator Overview</a>
+          See <a href="./kubernetes/operator/operator-overview.html">Operator Overview</a>
           to learn what the Operator does, what Kubernetes flavours and versions are supported, and so on.
         </p>
         <p>
@@ -1562,7 +1562,7 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.5.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release features <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/wlPIWz3UYHQ">complete Erlang 23 support</a>.
@@ -1594,7 +1594,7 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.4.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           This release <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/wlPIWz3UYHQ">introduces Erlang 23 support</a>.
@@ -1626,11 +1626,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.26.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series are now <a href="/versions.html">only covered under the limited extended support policy</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series are now <a href="./versions.html">only covered under the limited extended support policy</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1659,11 +1659,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.25.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series are now <a href="/versions.html">only covered under the limited extended support policy</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series are now <a href="./versions.html">only covered under the limited extended support policy</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1692,10 +1692,10 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.3.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1724,11 +1724,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.24.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series will <a href="/versions.html">go out of support</a> on March 31, 2020.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series will <a href="./versions.html">go out of support</a> on March 31, 2020.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1757,11 +1757,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.23.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series will <a href="/versions.html">go out of support</a> on March 31, 2020.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series will <a href="./versions.html">go out of support</a> on March 31, 2020.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1790,10 +1790,10 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.2.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1822,11 +1822,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.22.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series will <a href="/versions.html">go out of support</a> on March 31, 2020.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series will <a href="./versions.html">go out of support</a> on March 31, 2020.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1856,10 +1856,10 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.1.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1889,10 +1889,10 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that includes a security patch for <a href="https://pivotal.io/security/cve-2019-11287">CVE-2019-11287</a>.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1921,11 +1921,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.20.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series will <a href="/versions.html">go out of support</a> on March 31, 2020.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series will <a href="./versions.html">go out of support</a> on March 31, 2020.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -1954,11 +1954,11 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.19.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
-          RabbitMQ 3.7 series will <a href="/versions.html">go out of support</a> on March 31, 2020.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
+          RabbitMQ 3.7 series will <a href="./versions.html">go out of support</a> on March 31, 2020.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 21.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 21.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2023,7 +2023,7 @@ limitations under the License.
           which will be announced shortly.
         </p>
         <p>
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2079,10 +2079,10 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.17.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 20.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2111,10 +2111,10 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.16.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 20.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2144,10 +2144,10 @@ limitations under the License.
         </p>
         <p>
           This is a maintenance release that introduces <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/vcRLhpUdg_o">Erlang 22 support</a>.
-          Release notes can be found <a href="/changelog.html">in the change log</a>.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 20.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2201,10 +2201,10 @@ limitations under the License.
           The RabbitMQ team is pleased to announce the release of RabbitMQ 3.7.14.
         </p>
         <p>
-          This is a maintenance release. Release notes can be found <a href="/changelog.html">in the change log</a>.
+          This is a maintenance release. Release notes can be found <a href="./changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 20.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2236,7 +2236,7 @@ limitations under the License.
           This is a maintenance release. Release notes can be found <a href="changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 20.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2268,7 +2268,7 @@ limitations under the License.
           This is a maintenance release. Release notes can be found <a href="changelog.html">in the change log</a>.
         </p>
         <p>
-          This release <a href="/which-erlang.html">requires Erlang/OTP 20.3</a>.
+          This release <a href="./which-erlang.html">requires Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2300,7 +2300,7 @@ limitations under the License.
           This is a maintenance release. Release notes can be found <a href="changelog.html">in the change log</a>.
         </p>
         <p>
-          This is the first RabbitMQ release to <a href="/which-erlang.html">require Erlang/OTP 20.3</a>.
+          This is the first RabbitMQ release to <a href="./which-erlang.html">require Erlang/OTP 20.3</a>.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
@@ -2434,7 +2434,7 @@ limitations under the License.
           error.
         </p>
         <p>
-          Services and tools that do not use PackageCloud (and thus rely on RabbitMQ's own <a href="/signatures.html">release signing key</a> for signing)
+          Services and tools that do not use PackageCloud (and thus rely on RabbitMQ's own <a href="./signatures.html">release signing key</a> for signing)
           are not affected by this transition.
         </p>
         <p>
@@ -2588,7 +2588,7 @@ limitations under the License.
           </ul>
         </p>
         <p>
-          We encourage all 3.6.x users to <a href="/upgrade.html">upgrade</a> to <a href="/changelog.html">the latest release</a>.
+          We encourage all 3.6.x users to <a href="./upgrade.html">upgrade</a> to <a href="./changelog.html">the latest release</a>.
         </p>
         <p>
           We welcome any questions you may have on our
@@ -2731,7 +2731,7 @@ limitations under the License.
         <p>
           RabbitMQ users who run on Windows should be aware that default Erlang cookie
           location in Erlang/OTP 20.2 <a href="https://groups.google.com/forum/#!topic/rabbitmq-users/dzetiXNy0Ec">has changed</a>.
-          RabbitMQ documentation guides <a href="/cli.html">were updated</a> to explain the difference.
+          RabbitMQ documentation guides <a href="./cli.html">were updated</a> to explain the difference.
           Users on other operating systems are not affected.
         </p>
         <p>
@@ -2870,7 +2870,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release <a href="https://www.rabbitmq.com/signatures.html">are signed</a>.
-          Please refer to the <a href="/install-debian.html">Debian/Ubuntu</a>, <a href="/install-rpm.html">RHEL/CentOS/SUSE</a>, and <a href="/download.html">other installation guides</a>
+          Please refer to the <a href="./install-debian.html">Debian/Ubuntu</a>, <a href="./install-rpm.html">RHEL/CentOS/SUSE</a>, and <a href="./download.html">other installation guides</a>
           for installation instructions.
         </p>
 
@@ -2910,7 +2910,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release <a href="https://www.rabbitmq.com/signatures.html">are signed</a>.
-          Please refer to the <a href="/install-debian.html">Debian/Ubuntu</a>, <a href="/install-rpm.html">RHEL/CentOS/SUSE</a>, and <a href="/download.html">other installation guides</a>
+          Please refer to the <a href="./install-debian.html">Debian/Ubuntu</a>, <a href="./install-rpm.html">RHEL/CentOS/SUSE</a>, and <a href="./download.html">other installation guides</a>
           for installation instructions.
         </p>
 
@@ -2950,7 +2950,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release <a href="https://www.rabbitmq.com/signatures.html">are signed</a>.
-          Please refer to the <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">RPM installation guides</a> for Debian/Ubuntu and RHEL/CentOS installation instructions.
+          Please refer to the <a href="./install-debian.html">Debian</a> and <a href="./install-rpm.html">RPM installation guides</a> for Debian/Ubuntu and RHEL/CentOS installation instructions.
         </p>
 
         <p>
@@ -2989,7 +2989,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release <a href="https://www.rabbitmq.com/signatures.html">are signed</a>.
-          Please refer to the <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">RPM installation guides</a> for Debian/Ubuntu and RHEL/CentOS installation instructions.
+          Please refer to the <a href="./install-debian.html">Debian</a> and <a href="./install-rpm.html">RPM installation guides</a> for Debian/Ubuntu and RHEL/CentOS installation instructions.
         </p>
 
         <p>
@@ -3028,7 +3028,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release <a href="https://www.rabbitmq.com/signatures.html">are signed</a>.
-          Please refer to the <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">RPM installation guides</a> for Debian/Ubuntu and RHEL/CentOS installation instructions.
+          Please refer to the <a href="./install-debian.html">Debian</a> and <a href="./install-rpm.html">RPM installation guides</a> for Debian/Ubuntu and RHEL/CentOS installation instructions.
         </p>
 
         <p>
@@ -3075,7 +3075,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release are signed with a <a href="https://groups.google.com/forum/#!msg/rabbitmq-users/BO5cmEsdEhc/Jupz1_Q4AwAJ">new 4096-bit OpenGPG key</a>.
-          Please refer to the <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">RPM installation guides</a> for more details.
+          Please refer to the <a href="./install-debian.html">Debian</a> and <a href="./install-rpm.html">RPM installation guides</a> for more details.
         </p>
 
         <p>
@@ -3116,7 +3116,7 @@ limitations under the License.
 
         <p>
           All artifacts in this release are signed with a <a href="https://groups.google.com/forum/#!msg/rabbitmq-users/BO5cmEsdEhc/Jupz1_Q4AwAJ">new 4096-bit OpenGPG key</a>.
-          Please refer to the <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">RPM installation guides</a> for more details.
+          Please refer to the <a href="./install-debian.html">Debian</a> and <a href="./install-rpm.html">RPM installation guides</a> for more details.
         </p>
 
         <p>
@@ -6069,7 +6069,7 @@ j8ZGl+/bUPvV/SuMHp61DbfBXjbeBmnP3mycMwo6LMr+ZBqwbVJq
     <p>RabbitMQ customers will see an increase in availability of training, professional
     services and support offerings as the RabbitMQ business is integrated with SpringSource. </p>
 
-    <p>For more details please see <a href="/resources/SpringSourceAcquiresRabbitTech.pdf">the
+    <p>For more details please see <a href="./resources/SpringSourceAcquiresRabbitTech.pdf">the
     full press release</a>.</p>
 
     <p>Contacts:</p>
@@ -6532,14 +6532,14 @@ or directly at <a href="mailto:info@rabbitmq.com">info@rabbitmq.com</a>.</p>
     <doc:text>
       <p>The RabbitMQ and AMQP team gave a presentation at QCon London last week. Slides presented are available here:</p>
   <ul class="plain">
-    <li><a href="/resources/RabbitMQcon.pdf">RabbitMQ slides</a></li>
-    <li><a href="/resources/AMQP-QCon-London-2000-5.pdf">AMQP chairman's slides</a></li>
+    <li><a href="./resources/RabbitMQcon.pdf">RabbitMQ slides</a></li>
+    <li><a href="./resources/AMQP-QCon-London-2000-5.pdf">AMQP chairman's slides</a></li>
   </ul>
   <p>See also:</p>
       <ul class="plain">
     <li><a href="http://gojko.net/2009/03/11/qcon-london-2009-mom-interoperability-finally/">Gojko Adzic's review</a></li>
   </ul>
-  <p>If you're looking for a place to start <a href="/how.html">try here</a>.</p>
+  <p>If you're looking for a place to start <a href="./how.html">try here</a>.</p>
 
     </doc:text>
       </doc:item>

--- a/site/page.xsl
+++ b/site/page.xsl
@@ -55,11 +55,11 @@ limitations under the License.
       <meta content='width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1, user-scalable=no' id='viewport' name='viewport'/>
       <link href="https://fonts.googleapis.com/css?family=Raleway:400,500,600,700" rel="stylesheet"/>
 
-      <link rel="stylesheet" href="/css/rabbit.css" type="text/css"/>
-      <link rel="stylesheet" href="/css/highlightjs_style.css" type="text/css" />
+      <link rel="stylesheet" href="./css/rabbit.css" type="text/css"/>
+      <link rel="stylesheet" href="./css/highlightjs_style.css" type="text/css" />
 
       <xsl:if test="$site-mode = 'next'">
-        <link rel="stylesheet" href="/css/rabbit-next.css" type="text/css"/>
+        <link rel="stylesheet" href="./css/rabbit-next.css" type="text/css"/>
       </xsl:if>
       <xsl:if test="$site-mode = 'previous'">
         <doc:style>
@@ -71,10 +71,10 @@ limitations under the License.
         </doc:style>
       </xsl:if>
       <xsl:comment><![CDATA[[if IE 6]>
-      <link rel="stylesheet" href="/css/rabbit-ie6.css" type="text/css" />
+      <link rel="stylesheet" href="./css/rabbit-ie6.css" type="text/css" />
       <![endif]]]></xsl:comment>
-      <link rel="icon" type="/image/vnd.microsoft.icon" href="/favicon.ico"/>
-      <link rel="stylesheet" href="/css/tutorial.css" type="text/css"/>
+      <link rel="icon" type="/image/vnd.microsoft.icon" href="./favicon.ico"/>
+      <link rel="stylesheet" href="./css/tutorial.css" type="text/css"/>
       <script async="true" type="text/javascript" src="/js/site.js"></script>
 
       <title><xsl:value-of select="//html:title"/> — RabbitMQ</title>
@@ -166,17 +166,17 @@ limitations under the License.
   <!-- Remember to edit the wordpress template too! -->
   <xsl:template name="page-header">
     <div class="rabbit-logo">
-      <a href="/"><img src="./img/logo-rabbitmq.svg" alt="RabbitMQ"/></a>
+      <a href="./"><img src="./img/logo-rabbitmq.svg" alt="RabbitMQ"/></a>
     </div>
     <a class='btn menubtn' onclick='showHide()'>Menu <img src="./img/carrot-down-white.svg"/></a>
     <div class='mobilemenuicon' onclick='showHide()'><img src="./img/mobile-menu-icon.svg"/></div>
     <div id="nav">
       <ul id="mainNav">
-        <li><a href="/#features">Features</a></li>
-        <li><a href="/#getstarted">Get Started</a></li>
-        <li><a href="/#support">Support</a></li>
-        <li><a href="/#community">Community</a></li>
-        <li><a href="/documentation.html">Docs</a></li>
+        <li><a href="./#features">Features</a></li>
+        <li><a href="./#getstarted">Get Started</a></li>
+        <li><a href="./#support">Support</a></li>
+        <li><a href="./#community">Community</a></li>
+        <li><a href="./documentation.html">Docs</a></li>
         <xsl:if test="$site-mode = 'www'">
           <li><a href="https://blog.rabbitmq.com/">Blog</a></li>
         </xsl:if>
@@ -195,14 +195,14 @@ limitations under the License.
     </div>
       <div class='container'>
         <div class="rabbit-logo">
-          <a href="/"><img src="./img/logo-rabbitmq-white.svg" alt="RabbitMQ"/></a>
+          <a href="./"><img src="./img/logo-rabbitmq-white.svg" alt="RabbitMQ"/></a>
         </div>
         <ul class='footerNav'>
-          <li><a href="/#features">Features</a></li>
-          <li><a href="/#getstarted">Get Started</a></li>
-          <li><a href="/#support">Support</a></li>
-          <li><a href="/#community">Community</a></li>
-          <li><a href="/documentation.html">Docs</a></li>
+          <li><a href="./#features">Features</a></li>
+          <li><a href="./#getstarted">Get Started</a></li>
+          <li><a href="./#support">Support</a></li>
+          <li><a href="./#community">Community</a></li>
+          <li><a href="./documentation.html">Docs</a></li>
           <xsl:if test="$site-mode = 'www'">
             <li><a href="https://blog.rabbitmq.com/">Blog</a></li>
           </xsl:if>
@@ -211,7 +211,7 @@ limitations under the License.
           Copyright &#169; 2007-2022 <a href="https://tanzu.vmware.com/">VMware</a>, Inc. or its affiliates. All rights reserved.
           <a href="https://www.vmware.com/help/legal.html">Terms of Use</a> &#8226;
           <a href="https://www.vmware.com/help/privacy.html">Privacy</a> &#8226;
-          <a href="/trademark-guidelines.html">Trademark Guidelines</a> &#8226;
+          <a href="./trademark-guidelines.html">Trademark Guidelines</a> &#8226;
           <a href="https://www.vmware.com/help/privacy/california-privacy-rights.html">Your California Privacy Rights</a> &#8226;
           <a class="ot-sdk-show-settings">Cookie Settings</a>
           <br/>
@@ -369,7 +369,7 @@ limitations under the License.
           <a class="adownload" href="{@url}"><xsl:value-of select="@downloadfile"/></a>
         </xsl:when>
         <xsl:otherwise>
-          <a class="adownload" href="/releases/{@downloadpath}/{@downloadfile}"><xsl:value-of select="@downloadfile"/></a>
+          <a class="adownload" href="./releases/{@downloadpath}/{@downloadfile}"><xsl:value-of select="@downloadfile"/></a>
         </xsl:otherwise>
       </xsl:choose>
 
@@ -377,7 +377,7 @@ limitations under the License.
       <xsl:choose>
         <xsl:when test="../@signature = 'yes' and not(@signature = 'no') and @downloadpath">
           <td class="signature">
-            <a href="/releases/{@downloadpath}/{@downloadfile}.asc">(Signature)</a>
+            <a href="./releases/{@downloadpath}/{@downloadfile}.asc">(Signature)</a>
           </td>
         </xsl:when>
         <xsl:when test="../@signature = 'yes' and not(@signature = 'no') and not(@downloadpath)">
@@ -402,7 +402,7 @@ limitations under the License.
       <xsl:when test="@type = 'plugin'">
         <p>
           For more information about the installation of plugins, refer to the
-          <a href="/plugin-development.html#getting-started">Plugin Development: Getting Started</a> documentation.
+          <a href="./plugin-development.html#getting-started">Plugin Development: Getting Started</a> documentation.
         </p>
       </xsl:when>
     </xsl:choose>

--- a/site/page.xsl
+++ b/site/page.xsl
@@ -166,10 +166,10 @@ limitations under the License.
   <!-- Remember to edit the wordpress template too! -->
   <xsl:template name="page-header">
     <div class="rabbit-logo">
-      <a href="/"><img src="/img/logo-rabbitmq.svg" alt="RabbitMQ"/></a>
+      <a href="/"><img src="./img/logo-rabbitmq.svg" alt="RabbitMQ"/></a>
     </div>
-    <a class='btn menubtn' onclick='showHide()'>Menu <img src="/img/carrot-down-white.svg"/></a>
-    <div class='mobilemenuicon' onclick='showHide()'><img src="/img/mobile-menu-icon.svg"/></div>
+    <a class='btn menubtn' onclick='showHide()'>Menu <img src="./img/carrot-down-white.svg"/></a>
+    <div class='mobilemenuicon' onclick='showHide()'><img src="./img/mobile-menu-icon.svg"/></div>
     <div id="nav">
       <ul id="mainNav">
         <li><a href="/#features">Features</a></li>
@@ -195,7 +195,7 @@ limitations under the License.
     </div>
       <div class='container'>
         <div class="rabbit-logo">
-          <a href="/"><img src="/img/logo-rabbitmq-white.svg" alt="RabbitMQ"/></a>
+          <a href="/"><img src="./img/logo-rabbitmq-white.svg" alt="RabbitMQ"/></a>
         </div>
         <ul class='footerNav'>
           <li><a href="/#features">Features</a></li>

--- a/site/parameters.md
+++ b/site/parameters.md
@@ -365,7 +365,7 @@ and the policy definitions applied to them.
 ### <a id="why-operator-policies-exist" class="anchor" href="#why-operator-policies-exist">Difference From Regular Policies</a>
 
 Sometimes it is necessary for the operator to enforce certain policies.
-For example, it may be desirable to force [queue TTL](/ttl.html) but
+For example, it may be desirable to force [queue TTL](./ttl.html) but
 still let other users manage policies. Operator policies allow for that.
 
 Operator policies are much like regular ones but their

--- a/site/partitions.md
+++ b/site/partitions.md
@@ -21,8 +21,8 @@ limitations under the License.
 
 This guide covers one specific aspect of clustering: network
 failures between nodes, their effects and recovery options.
-For a general overview of clustering, see [Clustering](/clustering.html)
-and [Peer Discovery and Cluster Formation](/cluster-formation.html) guides.
+For a general overview of clustering, see [Clustering](./clustering.html)
+and [Peer Discovery and Cluster Formation](./cluster-formation.html) guides.
 
 Clustering can be used to achieve different goals: increased
 data safety through replication, increased availability for
@@ -47,9 +47,9 @@ the RabbitMQ log in a form like:
 2020-05-18 06:55:37.324 [error] &lt;0.341.0&gt; Mnesia(rabbit@warp10): ** ERROR ** mnesia_event got {inconsistent_database, running_partitioned_network, rabbit@hostname2}
 </pre>
 
-Partition presence can be identified via server [logs](/logging.html),
-[HTTP API](/management.html) (for [monitoring](/monitoring.html))
-and a [CLI command](/cli.html):
+Partition presence can be identified via server [logs](./logging.html),
+[HTTP API](./management.html) (for [monitoring](./monitoring.html))
+and a [CLI command](./cli.html):
 
 <pre class="lang-bash">
 rabbitmq-diagnostics cluster_status
@@ -110,7 +110,7 @@ be created or deleted separately.
 
 [Classic mirrored queues](ha.html) which are split across the partition will end up with
 one leader on each side of the partition, again with both sides
-acting independently. [Quorum queues](/quorum-queues.html) will elect a new leader on the
+acting independently. [Quorum queues](./quorum-queues.html) will elect a new leader on the
 majority side. Quorum queue replicas on the minority side will no longer
 make progress (i.e. accept new messages, deliver to consumers, etc), all this work will be
 done by the new leader.
@@ -160,7 +160,7 @@ authority for the state of the system (schema, messages)
 to use; any changes which have occurred on other partitions will be lost.
 
 Stop all nodes in the other partitions, then start them all up
-again. When they [rejoin the cluster](/clustering.html#restarting) they
+again. When they [rejoin the cluster](./clustering.html#restarting) they
 will restore state from the trusted partition.
 
 Finally, you should also restart all the nodes in the trusted
@@ -233,7 +233,7 @@ If using the <code>pause_if_all_down</code> mode, additional parameters are requ
   <li><code>recover</code>: recover action, can be <code>ignore</code> or <code>autoheal</code></li>
 </ul>
 
-Example [config snippet](/configure.html#config-file) that uses <code>pause_if_all_down</code>:
+Example [config snippet](./configure.html#config-file) that uses <code>pause_if_all_down</code>:
 
 <pre class="lang-plaintext">
 cluster_partition_handling = pause_if_all_down

--- a/site/passwords.md
+++ b/site/passwords.md
@@ -24,8 +24,8 @@ and passwords used by the internal authentication backend. If
 a different authentication backend is used, most
 material in this guide will not be applicable.
 
-RabbitMQ supports multiple [authentication mechanisms](/access-control.html#mechanisms). Some of them use
-username/password pairs. These credential pairs are then handed over to [authentication backends](/access-control.html#backends)
+RabbitMQ supports multiple [authentication mechanisms](./access-control.html#mechanisms). Some of them use
+username/password pairs. These credential pairs are then handed over to [authentication backends](./access-control.html#backends)
 that perform authentication. One of the backends, known as internal or built-in, uses internal RabbitMQ data store
 to store user credentials. When a new user is added using `rabbitmqctl`, her password is combined with a salt value
 and hashed.
@@ -39,7 +39,7 @@ SHA-256 is used by default. More algorithms can be provided by plugins.
 
 ## <a id="changing-algorithm" class="anchor" href="#changing-algorithm">Configuring Algorithm to Use</a>
 
-It is possible to change what algorithm is used via [RabbitMQ configuration file](/configure.html#config-file),
+It is possible to change what algorithm is used via [RabbitMQ configuration file](./configure.html#config-file),
 for example, to use SHA-512:
 
 <pre class="lang-plaintext">
@@ -53,7 +53,7 @@ Out of the box, the following hashing modules are provided:
  * `rabbit_password_hashing_md5` (for backwards compatibility)
 
 Updated hashing algorithm will be applied to newly created users
-or when password is changed using [rabbitmqctl](/man/rabbitmqctl.8.html).
+or when password is changed using [rabbitmqctl](./man/rabbitmqctl.8.html).
 
 
 ## <a id="upgrading-to-3-6-x" class="anchor" href="#upgrading-to-3-6-x">Upgrading from pre-3.6.0 Versions</a>
@@ -65,7 +65,7 @@ therefore they will be able to authenticate. No upgrade steps are required.
 When importing definitions exported from versions earlier than
 3.6.0 into a 3.6.1 or later release, existing user records will use
 MD5 for password hashing. In order to migrate them to a more secure algorithm,
-use [rabbitmqctl](/man/rabbitmqctl.8.html) to update their passwords.
+use [rabbitmqctl](./man/rabbitmqctl.8.html) to update their passwords.
 
 
 ## <a id="credential-validation" class="anchor" href="#credential-validation">Credential Validation</a>
@@ -108,8 +108,8 @@ This means that validation rules cannot
 use `#` in regular expression values. Leading and trailing spaces in values will also
 be stripped by the config file parser.
 
-Also note that when passwords are used with CLI tools commands that [manage users](/access-control.html#user-management),
-shell escaping of certain characters [must be taken into account](/access-control.html#passwords-and-shell-escaping).
+Also note that when passwords are used with CLI tools commands that [manage users](./access-control.html#user-management),
+shell escaping of certain characters [must be taken into account](./access-control.html#passwords-and-shell-escaping).
 
 
 ### <a id="custom-credential-validation" class="anchor" href="#custom-credential-validation">Custom Credential Validators</a>
@@ -124,12 +124,12 @@ Credential validators can also validate usernames or apply any other logic
 
 ## <a id="passwordless-users" class="anchor" href="#passwordless-users">Passwordless Users</a>
 
-[Internal authentication backend](/access-control.html) allows for users without a password
+[Internal authentication backend](./access-control.html) allows for users without a password
 or with a blank one (assuming credential validator also allows it). Such users are only meant to be used
-with passwordless [authentication mechanisms](/authentication.html) such as [authentication using x509 certificates](https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl).
+with passwordless [authentication mechanisms](./authentication.html) such as [authentication using x509 certificates](https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl).
 
 In order to create a passwordless user, create one with any password that passes validation and clear
-the password using [rabbitmqctl](/cli.html)'s `clear_password` command:
+the password using [rabbitmqctl](./cli.html)'s `clear_password` command:
 
 <pre class="lang-bash">
 rabbitmqctl add_user passwordless-user "pa$$wordless"
@@ -139,9 +139,9 @@ rabbitmqctl clear_password passwordless-user
 </pre>
 
 Starting with versions `3.6.15` and `3.7.3`, authentication attempts that use a blank password
-will be unconditionally rejected by the [internal authentication backend](/access-control.html) with a distinctive error
-message in the [server log](/logging.html). Connections that authenticate using x509 certificates or use an external service
-for authentication (e.g. [LDAP](/ldap.html)) can use blank passwords.
+will be unconditionally rejected by the [internal authentication backend](./access-control.html) with a distinctive error
+message in the [server log](./logging.html). Connections that authenticate using x509 certificates or use an external service
+for authentication (e.g. [LDAP](./ldap.html)) can use blank passwords.
 
 
 ## <a id="x509-certificate-authentication" class="anchor" href="#x509-certificate-authentication">Authentication Using TLS (x509) Certificates</a>

--- a/site/persistence-conf.md
+++ b/site/persistence-conf.md
@@ -29,9 +29,9 @@ before drawing any conclusions.
 Some related guides include:
 
  * [Main configuration guide](configure.html)
- * [File and Directory Locations](/relocate.html)
- * [Runtime Tuning](/runtime.html)
- * [Queues](/queues.html#runtime-characteristics) and their runtime characteristics
+ * [File and Directory Locations](./relocate.html)
+ * [Runtime Tuning](./runtime.html)
+ * [Queues](./queues.html#runtime-characteristics) and their runtime characteristics
 
 
 ## <a id="how-it-works" class="anchor" href="#how-it-works">How Persistence Works</a>
@@ -152,7 +152,7 @@ simultaneously.
 
 ### <a id="file-handles" class="anchor" href="#file-handles">Too Few File Handles</a>
 
-The RabbitMQ server is limited in the [number of file handles](/networking.html#open-file-handle-limit) it can open.
+The RabbitMQ server is limited in the [number of file handles](./networking.html#open-file-handle-limit) it can open.
 Every running network connection requires one file handle, and the rest are available
 for queues to use. If there are more disk-accessing queues than
 file handles after network connections have been taken into
@@ -172,7 +172,7 @@ notably if given more file handles.
 
 ### <a id="async-threads" class="anchor" href="#async-threads">I/O Thread Pool Size</a>
 
-[The runtime](/runtime.html) uses a pool threads to handle
+[The runtime](./runtime.html) uses a pool threads to handle
 long-running file I/O operations. These are shared among all virtual hosts and queues.
 Every active file I/O operation uses one async thread while it is occurring.
 Having too few async threads can therefore hurt performance.
@@ -200,7 +200,7 @@ when the server should be busy with persistence, while the
 reported time per I/O operation increases.
 
 The number of async threads is configured by the `+A`
-[runtime flag](/runtime.html). It is likely to be a good idea to experiment
+[runtime flag](./runtime.html). It is likely to be a good idea to experiment
 with several different values before changing this.
 
 

--- a/site/platforms.md
+++ b/site/platforms.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 Our goal is for RabbitMQ to run on as wide a range of platforms as
 possible. RabbitMQ can potentially run on any platform that provides
-[a supported Erlang version](/which-erlang.html), from multi-core nodes and cloud-based
+[a supported Erlang version](./which-erlang.html), from multi-core nodes and cloud-based
 deployments to embedded systems.
 
 The following platforms are supported by Erlang and could therefore
@@ -35,10 +35,10 @@ run RabbitMQ:
 The open source release of RabbitMQ is most commonly used and deployed on the
 following platforms:
 
- * [Ubuntu and Debian-based](/install-debian.html) Linux distributions
- * [Fedora, RHEL, CentOS and RPM-based](/install-rpm.html) Linux distributions
- * [Windows Server](/install-windows.html)
- * [macOS](/install-generic-unix.html)
+ * [Ubuntu and Debian-based](./install-debian.html) Linux distributions
+ * [Fedora, RHEL, CentOS and RPM-based](./install-rpm.html) Linux distributions
+ * [Windows Server](./install-windows.html)
+ * [macOS](./install-generic-unix.html)
  * openSUSE Leap
 
 
@@ -50,7 +50,7 @@ RabbitMQ is available in the [commercial RabbitMQ distribution documentation](ht
 
 ## <a id="windows" class="anchor" href="#windows">Windows</a>
 
-RabbitMQ will run on any Windows version that [supported Erlang/OTP releases](/which-erlang.html)
+RabbitMQ will run on any Windows version that [supported Erlang/OTP releases](./which-erlang.html)
 can run on, both desktop and server editions. This includes Windows 10, Server 2012 through 2022.
 
 
@@ -67,7 +67,7 @@ RabbitMQ can run on physical or virtual hardware, including many
 IaaS providers and containers. This also allows unsupported platforms that are
 able to emulate a supported platform to run RabbitMQ.
 
-A number of companies offer RabbitMQ-as-a-service in multiple clouds. Please see  [Installation Guide](/download.html)
+A number of companies offer RabbitMQ-as-a-service in multiple clouds. Please see  [Installation Guide](./download.html)
 to learn more.
 
 

--- a/site/plugin-development.md
+++ b/site/plugin-development.md
@@ -202,7 +202,7 @@ The following table should explain the purpose of the various files in the repos
     <td><a href="https://github.com/rabbitmq/rabbitmq-metronome/blob/master/priv/schema/rabbitmq_metronome.schema"><code>rabbitmq_metronome.schema</code></a></td>
     <td>
       A <a href="https://github.com/Kyorai/cuttlefish">Cuttlefish</a> configuration schema.
-      Used to translate <a href="/configure.html#configuration-files">configuration file</a>
+      Used to translate <a href="./configure.html#configuration-files">configuration file</a>
       to the internal format used by RabbitMQ and its runtime.
 
       Metronome schema contains mappings for the <code>metronome.exchange</code> setting,

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -22,7 +22,7 @@ limitations under the License.
 This guide covers
 
  * [Plugin support](#overview) in RabbitMQ
- * How to [enable a plugin](#ways-to-enable-plugins) using [CLI tools](/cli.html)
+ * How to [enable a plugin](#ways-to-enable-plugins) using [CLI tools](./cli.html)
  * [Plugin directories](#plugin-directories)
  * How to [preconfigure plugins](#enabled-plugins-file) on a node at deployment time
  * [Troubleshooting](#troubleshooting) of a number of common issues
@@ -30,17 +30,17 @@ This guide covers
 
 and more.
 
-[Plugin development](/plugin-development.html) is covered in a separate guide.
+[Plugin development](./plugin-development.html) is covered in a separate guide.
 
 
 ## <a id="basics" class="anchor" href="#basics">The Basics</a>
 
 RabbitMQ supports plugins. Plugins extend core broker functionality in a variety of ways: with support
-for more protocols, system state [monitoring](/monitoring.html), additional AMQP 0-9-1 exchange types,
+for more protocols, system state [monitoring](./monitoring.html), additional AMQP 0-9-1 exchange types,
 node [federation](federation.html), and more. A number of features are implemented as plugins
 that ship in the core distribution.
 
-This guide covers the plugin mechanism and plugins that ship in the [latest release](/changelog.html) of the RabbitMQ distribution.
+This guide covers the plugin mechanism and plugins that ship in the [latest release](./changelog.html) of the RabbitMQ distribution.
 3rd party plugins can be installed separately. A set of [curated plugins](#plugin-tiers) is also available.
 
 Plugins are activated when a node is started or at runtime when a [CLI tool](cli.html)
@@ -49,7 +49,7 @@ the [rabbitmq-plugins](cli.html):
 
 <pre class="lang-bash">rabbitmq-plugins enable &lt;plugin-name&gt;</pre>
 
-For example, to enable the Kubernetes [peer discovery](/cluster-formation.html) plugin:
+For example, to enable the Kubernetes [peer discovery](./cluster-formation.html) plugin:
 
 <pre class="lang-bash">rabbitmq-plugins enable rabbitmq_peer_discovery_k8s</pre>
 
@@ -57,11 +57,11 @@ And to disable a plugin, use:
 
 <pre class="lang-bash">rabbitmq-plugins disable &lt;plugin-name&gt;</pre>
 
-For example, to disable the [`rabbitmq-top`](/memory-use.html#breakdown-top) plugin:
+For example, to disable the [`rabbitmq-top`](./memory-use.html#breakdown-top) plugin:
 
 <pre class="lang-bash">rabbitmq-plugins disable rabbitmq_top</pre>
 
-A list of plugins available locally (in the node's [plugins directory](/relocate.html)) as well
+A list of plugins available locally (in the node's [plugins directory](./relocate.html)) as well
 as their status (enabled or disabled) can be obtained using `rabbitmq-plugins list`:
 
 <pre class="lang-bash">rabbitmq-plugins list</pre>
@@ -81,9 +81,9 @@ the tool will not contact any nodes and instead will modify the file containing
 the list of enabled plugins (appropriately named `enabled_plugins`) directly.
 This option is often optimal for node provisioning automation.
 
-The `enabled_plugins` file is usually [located](/relocate.html) in the node
+The `enabled_plugins` file is usually [located](./relocate.html) in the node
 data directory or under `/etc`, together with configuration files. The file contains
-a list of plugin names ending with a dot. For example, when [rabbitmq_management](/management.html) and
+a list of plugin names ending with a dot. For example, when [rabbitmq_management](./management.html) and
 [rabbitmq_shovel](shovel.html) plugins are enabled,
 the file contents will look like this:
 
@@ -110,9 +110,9 @@ RabbitMQ loads plugins from the local filesystem. Plugins are distributed as
 archives (`.ez` files) with compiled code modules and metadata.
 Since some plugins [ship with RabbitMQ](#plugin-tiers), every
 node has at least one default plugin directory. The path varies between
-package types and can be [overridden](/relocate.html) using the
-`RABBITMQ_PLUGINS_DIR` [environment variable](/configure.html#customise-environment).
-Please see [File and Directory Locations guide](/relocate.html) to learn about the default
+package types and can be [overridden](./relocate.html) using the
+`RABBITMQ_PLUGINS_DIR` [environment variable](./configure.html#customise-environment).
+Please see [File and Directory Locations guide](./relocate.html) to learn about the default
 value on various platforms.
 
 The built-in plugin directory is by definition version-independent: its contents will change
@@ -141,7 +141,7 @@ by them.
 
 3rd party plugin directories will differ from platform to platform and installation method
 to installation method. For example, `/usr/lib/rabbitmq/plugins` is a 3rd party plugin directory
-path used by RabbitMQ [Debian packages](/install-debian.html).
+path used by RabbitMQ [Debian packages](./install-debian.html).
 
 Plugin directory can be located by executing the `rabbitmq-plugins directories` command on the host
 with a running RabbitMQ node:
@@ -187,7 +187,7 @@ directory that is then added to its code path. This directory is known
 as the expanded plugins directory. It is usually managed entirely by RabbitMQ
 but if node directories are changed to non-standard ones, that directory will likely
 need to be overridden, too. It can be done using the `RABBITMQ_PLUGINS_EXPAND_DIR`
-[environment variable](/configure.html#customise-environment). The directory
+[environment variable](./configure.html#customise-environment). The directory
 must be readable and writable by the effective operating system user of the RabbitMQ node.
 
 
@@ -244,7 +244,7 @@ which rabbitmq-plugins
 
 In some environments, in particular development ones, `rabbitmq-plugins`
 comes from a different installation than the running server node. This can be the case
-when a node is installed using a [binary build package](/install-generic-unix.html)
+when a node is installed using a [binary build package](./install-generic-unix.html)
 but CLI tools come from the local package manager such as `apt` or Homebrew.
 
 In that case CLI tools will have a different [enabled plugins file](#enabled-plugins-file)
@@ -295,7 +295,7 @@ a dependency, it won't be listed in the enabled plugins file and thus its CLI co
 
 Plugins that ship with the RabbitMQ distributions are often referred
 to as tier 1 plugins. Provided that a standard distribution package is
-used they do not need to be [installed](/installing-plugins.html) but do need to be
+used they do not need to be [installed](./installing-plugins.html) but do need to be
 enabled before they can be used.
 
 In addition to the plugins bundled with the server, team RabbitMQ

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -471,7 +471,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
 
         <ul>
           <li>
-            <a href="/shovel.html">Documentation for the Shovel plugin</a>
+            <a href="./shovel.html">Documentation for the Shovel plugin</a>
           </li>
         </ul>
       </td>
@@ -480,7 +480,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
     <tr>
       <th>rabbitmq_shovel_management</th>
       <td>
-        Shows <a href="/shovel.html">Shovel</a> status in the management API and UI.
+        Shows <a href="./shovel.html">Shovel</a> status in the management API and UI.
         Only of use when using <code>rabbitmq_shovel</code> in
         conjunction with <code>rabbitmq_management</code>. In a
         heterogeneous cluster this should be installed on the same
@@ -534,7 +534,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
     <tr>
       <th>rabbitmq_web_mqtt</th>
       <td>
-        MQTT-over-WebSockets: a bridge exposing <a href="/mqtt.html">rabbitmq_mqtt</a> to Web
+        MQTT-over-WebSockets: a bridge exposing <a href="./mqtt.html">rabbitmq_mqtt</a> to Web
         browsers using WebSockets.
         <ul>
           <li><a href="web-mqtt.html">Documentation for the

--- a/site/priority.md
+++ b/site/priority.md
@@ -20,7 +20,7 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 RabbitMQ has priority queue implementation in the core as of version `3.5.0`.
-Any queue can be turned into a priority one using client-provided [optional arguments](/queues.html#optional-arguments)
+Any queue can be turned into a priority one using client-provided [optional arguments](./queues.html#optional-arguments)
 (but, unlike other features that use optional arguments, not policies).
 The implementation supports a limited number of priorities: 255. Values between 1 and 10 are recommended.
 
@@ -77,7 +77,7 @@ published with the maximum priority.
 
 If priority queues are desired, we recommend using between 1 and 10.
 Currently using more priorities will consume more CPU resources by using more Erlang processes.
-[Runtime scheduling](/runtime.html) would also be affected.
+[Runtime scheduling](./runtime.html) would also be affected.
 
 ## <a id="interaction-with-consumers" class="anchor" href="#interaction-with-consumers">Interaction with Consumers</a>
 
@@ -103,14 +103,14 @@ RabbitMQ queues: they support persistence, paging, mirroring,
 and so on. There are a couple of interactions that developers should be
 aware of.
 
-[Messages which should expire](/ttl.html) will still
+[Messages which should expire](./ttl.html) will still
 only expire from the head of the queue. This means that unlike
 with normal queues, even per-queue TTL can lead to expired
 lower-priority messages getting stuck behind non-expired
 higher priority ones. These messages will never be delivered,
 but they will appear in queue statistics.
 
-[Queues which have a max-length set](/maxlength.html) will, as usual, drop messages from the head of the
+[Queues which have a max-length set](./maxlength.html) will, as usual, drop messages from the head of the
 queue to enforce the limit. This means that higher priority
 messages might be dropped to make way for lower priority ones,
 which might not be what you would expect.
@@ -118,8 +118,8 @@ which might not be what you would expect.
 
 ## <a id="using-policies" class="anchor" href="#using-policies">Why Policy Definition is not Supported</a>
 
-The most convenient way to define optional arguments for a queue is via [policies](/parameters.html).
-Policies are the recommended way to configure [TTL](/ttl.html), [queue length limits](maxlength.html) and
+The most convenient way to define optional arguments for a queue is via [policies](./parameters.html).
+Policies are the recommended way to configure [TTL](./ttl.html), [queue length limits](maxlength.html) and
 other [optional queue arguments](queues.html).
 
 However, policies cannot be used to configure priorities because policies are dynamic

--- a/site/prometheus.md
+++ b/site/prometheus.md
@@ -7,10 +7,10 @@ This guide covers RabbitMQ monitoring with two popular tools:
 and <a href="https://grafana.com/grafana" target="_blank">Grafana</a>, a metrics visualisation system.
 
 These tools together form a powerful toolkit for long-term metric collection and monitoring of RabbitMQ clusters.
-While [RabbitMQ management UI](/management.html) also provides access to a subset of metrics, it by
+While [RabbitMQ management UI](./management.html) also provides access to a subset of metrics, it by
 design doesn't try to be a long term metric collection solution.
 
-Please read through the main [guide on monitoring](/monitoring.html) first. Monitoring principles and
+Please read through the main [guide on monitoring](./monitoring.html) first. Monitoring principles and
 available metrics are mostly relevant when Prometheus and Grafana are used.
 
 Some key topics covered by this guide are
@@ -40,19 +40,19 @@ As of 3.8.0, RabbitMQ ships with built-in Prometheus & Grafana support.
 Support for Prometheus metric collector ships in the `rabbitmq_prometheus` plugin.
 The plugin exposes all RabbitMQ metrics on a dedicated TCP port, in Prometheus text format.
 
-These metrics provide deep insights into the state of RabbitMQ nodes and [the runtime](/runtime.html).
+These metrics provide deep insights into the state of RabbitMQ nodes and [the runtime](./runtime.html).
 They make reasoning about the behaviour of RabbitMQ, applications that use it and various infrastructure
 elements a lot more informed.
 
 ### <a id="overview-grafana" class="anchor" href="#overview-grafana">Grafana Support</a>
 
 Collected metrics are not very useful unless they are visualised. Team RabbitMQ provides a [prebuilt set of Grafana dashboards](https://grafana.com/rabbitmq)
-that visualise a large number of available RabbitMQ and [runtime](/runtime.html) metrics in context-specific ways.
+that visualise a large number of available RabbitMQ and [runtime](./runtime.html) metrics in context-specific ways.
 
 There is a number of dashboards available:
 
  * an overview dashboard
- * runtime [memory allocators](/runtime.html#allocators) dashboard
+ * runtime [memory allocators](./runtime.html#allocators) dashboard
  * an [inter-node communication](https://www.rabbitmq.com/clustering.html#cluster-membership)
 (Erlang distribution) dashboard
  * a Raft metric dashboard
@@ -70,7 +70,7 @@ good practices and are thus recommended.
 When RabbitMQ is integrated with Prometheus and Grafana, this is what the
 RabbitMQ Overview dashboard looks like:
 
-![RabbitMQ Overview Dashboard](/img/rabbitmq-overview-dashboard.png)
+![RabbitMQ Overview Dashboard](./img/rabbitmq-overview-dashboard.png)
 
 
 ## <a id="quick-start" class="anchor" href="#quick-start">Quick Start</a>
@@ -148,7 +148,7 @@ Grafana will suggest changing your password. For the sake of this example, we su
 
 Navigate to the **RabbitMQ-Overview** dashboard that will look like this:
 
-![RabbitMQ Overview Dashboard Localhost](/img/rabbitmq-overview-dashboard-localhost.png)
+![RabbitMQ Overview Dashboard Localhost](./img/rabbitmq-overview-dashboard-localhost.png)
 
 Congratulations! You now have a 3-nodes RabbitMQ cluster integrated with
 Prometheus & Grafana running locally. This is a perfect time to learn more
@@ -157,7 +157,7 @@ about the available dashboards.
 
 ## <a id="rabbitmq-overview-dashboard" class="anchor" href="#rabbitmq-overview-dashboard">RabbitMQ Overview Dashboard</a>
 
-All metrics available in the [management UI](/management.html) Overview
+All metrics available in the [management UI](./management.html) Overview
 page are available in the Overview Grafana dashboard. They are grouped by object type,
 with a focus on RabbitMQ nodes and message rates.
 
@@ -175,7 +175,7 @@ metric states:
 * **Blue** means under-utilisation or some form of degradation
 * **Red** means the value of the metric is below or above the range that is considered healthy
 
-![RabbitMQ Overview Dashboard Single-stat](/img/rabbitmq-overview-dashboard-single-stat.png)
+![RabbitMQ Overview Dashboard Single-stat](./img/rabbitmq-overview-dashboard-single-stat.png)
 
 Default ranges for the [single stat metrics](https://grafana.com/docs/features/panels/singlestat/) **will not be optimal for all**
 RabbitMQ deployments. For example, in environments with many consumers and/or
@@ -203,7 +203,7 @@ a minority of nodes perform the majority of work.
 
 In the example below, connections are spread out evenly across all nodes most of the time:
 
-![RabbitMQ Overview Dashboard CONNECTIONS](/img/rabbitmq-overview-dashboard-connections.png)
+![RabbitMQ Overview Dashboard CONNECTIONS](./img/rabbitmq-overview-dashboard-connections.png)
 
 ### <a id="graph-colour-labelling" class="anchor" href="#graph-colour-labelling">Colour Labelling in Graphs</a>
 
@@ -225,14 +225,14 @@ Most metrics have pre-configured thresholds. They define expected operating boun
 On the graphs they appear as semi-transparent
 orange or red areas, as seen in the example below.
 
-![RabbitMQ Overview Dashboard Single-stat](/img/rabbitmq-overview-dashboard-memory-threshold.png)
+![RabbitMQ Overview Dashboard Single-stat](./img/rabbitmq-overview-dashboard-memory-threshold.png)
 
 Metric values in the **orange** area signal that some pre-defined threshold has been
 exceeded. This may be acceptable, especially if the metric recovers. A metric that
 comes close to the orange area is considered to be in healthy state.
 
 Metric values in the **red** area need attention and may identify some form of service degradation.
-For example, metrics in the red area can indicate that an [alarm](/alarms.html) in effect
+For example, metrics in the red area can indicate that an [alarm](./alarms.html) in effect
 or when the node is [out of file descriptors](networking.html) and cannot accept any more connections or open new files.
 
 In the example above, we have a RabbitMQ cluster that runs at optimal memory
@@ -243,7 +243,7 @@ go down (as it indicates the amount of **available** memory).
 Because the system has more memory available than is allocated to the RabbitMQ node it hosts, we
 notice the dip below **0 B**. This emphasizes the importance of leaving spare
 memory available for the OS, housekeeping tasks that cause short-lived memory usage spikes,
-and other processes. When a RabbitMQ node exhausts all memory that it is allowed to use, a [memory alarm](/alarms.html) is
+and other processes. When a RabbitMQ node exhausts all memory that it is allowed to use, a [memory alarm](./alarms.html) is
 triggered and publishers across the entire cluster will be blocked.
 
 On the right side of the graph we can see that consumers catch up and the amount of memory used goes down.
@@ -263,9 +263,9 @@ requirements.
 
 Most metrics have a help icon in the top-left corner of the panel.
 
-![RabbitMQ Overview Dashboard Single-stat](/img/rabbitmq-overview-dashboard-disk-documentation.png)
+![RabbitMQ Overview Dashboard Single-stat](./img/rabbitmq-overview-dashboard-disk-documentation.png)
 
-Some, like the available disk space metric, link to dedicated pages in [RabbitMQ documentation](/documentation.html).
+Some, like the available disk space metric, link to dedicated pages in [RabbitMQ documentation](./documentation.html).
 These pages contain information relevant to the metric. Getting familiar with the linked guides
 is highly recommended and will help the operator understand what the metric means better.
 
@@ -273,15 +273,15 @@ is highly recommended and will help the operator understand what the metric mean
 
 Any metric drawn in red hints at an anti-pattern in the system. Such graphs try to highlight sub-optimal
 uses of RabbitMQ. A **red graphs with non-zero metrics should be investigated**. Such metrics might indicate
-an issue in RabbitMQ configuration or sub-optimal actions by clients ([publishers](/publishers.html) or [consumers](/consumers.html)).
+an issue in RabbitMQ configuration or sub-optimal actions by clients ([publishers](./publishers.html) or [consumers](./consumers.html)).
 
-In the example below we can see the usage of greatly inefficient [polling consumers](/consumers.html#fetching) that keep polling, even though
+In the example below we can see the usage of greatly inefficient [polling consumers](./consumers.html#fetching) that keep polling, even though
 most or even all polling operation return no messages. Like any polling-based algorithm, it is wasteful
 and should be avoided where possible.
 
-It is a lot more and efficient to have RabbitMQ [push messages to the consumer](/consumers.html).
+It is a lot more and efficient to have RabbitMQ [push messages to the consumer](./consumers.html).
 
-![RabbitMQ Overview Dashboard Antipatterns](/img/rabbitmq-overview-dashboard-antipattern.png)
+![RabbitMQ Overview Dashboard Antipatterns](./img/rabbitmq-overview-dashboard-antipattern.png)
 
 ### <a id="example-workloads" class="anchor" href="#example-workloads">Example Workloads</a>
 
@@ -303,15 +303,15 @@ gmake down
 ## <a id="other-dashboards" class="anchor" href="#other-dashboards">More Dashboards: Raft and Erlang Runtime</a>
 
 There are two more Grafana dashboards available: **RabbitMQ-Raft** and **Erlang-Distribution**. They collect and
-visualise metrics related to the Raft consensus algorithm (used by [Quorum Queues](/quorum-queues.html) and other features) as well
-as more nitty-gritty [runtime metrics](/runtime.html) such as inter-node communication buffers.
+visualise metrics related to the Raft consensus algorithm (used by [Quorum Queues](./quorum-queues.html) and other features) as well
+as more nitty-gritty [runtime metrics](./runtime.html) such as inter-node communication buffers.
 
 The dashboards have corresponding RabbitMQ clusters and PerfTest instances which are started and stopped the same
 as the Overview one. Feel free to experiment with the other workloads
 that are included in [the same `docker` directory](https://github.com/rabbitmq/rabbitmq-server/tree/master/deps/rabbitmq_prometheus/docker).
 
 For example, the `docker-compose-dist-tls.yml` Compose manifest is meant to stress
-the [inter-node communication links](/clustering.html). This workload uses a lot of system resources.
+the [inter-node communication links](./clustering.html). This workload uses a lot of system resources.
 `docker-compose-qq.yml` contains a quorum queue workload.
 
 To stop and delete all containers used by the workloads, run `docker-compose -f [file] down` or
@@ -327,7 +327,7 @@ Unlike the [Quick Start](#quick-start) above, this section covers monitoring set
 
 We will assume that the following tools are provisioned and running:
 
- * A [3-node RabbitMQ 3.8 cluster](/cluster-formation.html)
+ * A [3-node RabbitMQ 3.8 cluster](./cluster-formation.html)
  * Prometheus, including network connectivity with all RabbitMQ cluster nodes
  * Grafana, including configuration that lists the above Prometheus instance as one of the data sources
 
@@ -354,7 +354,7 @@ rabbitmqctl -q set_cluster_name testing-prometheus
 
 ### Enable `rabbitmq_prometheus`
 
-Next, enable the **rabbitmq_prometheus** [plugin](/plugins.html) on all nodes:
+Next, enable the **rabbitmq_prometheus** [plugin](./plugins.html) on all nodes:
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_prometheus
@@ -408,7 +408,7 @@ for beginners.
 Prometheus will periodically scrape (read) metrics from the systems it
 monitors, every 60 seconds by default. RabbitMQ metrics are updated
 periodically, too, every 5 seconds by default. Since [this value is
-configurable](/management.html#statistics-interval), check the metrics update
+configurable](./management.html#statistics-interval), check the metrics update
 interval by running the following command on any of the nodes:
 
 <pre class="lang-bash">
@@ -435,7 +435,7 @@ To confirm that Prometheus is scraping RabbitMQ metrics from all nodes, ensure
 that all RabbitMQ endpoints are **Up** on the Prometheus Targets page, as shown
 below:
 
-![Prometheus RabbitMQ Targets](/img/monitoring/prometheus/prometheus-targets.png)
+![Prometheus RabbitMQ Targets](./img/monitoring/prometheus/prometheus-targets.png)
 
 ### <a id="port" class="anchor" href="#listener">Network Interface and Port</a>
 
@@ -446,7 +446,7 @@ prometheus.tcp.port = 15692
 </pre>
 
 It is possible to configure what interface the Prometheus plugin API endpoint will use, similarly
-to [messaging protocol listeners](/networking.html#interfaces), using
+to [messaging protocol listeners](./networking.html#interfaces), using
 the `prometheus.tcp.ip` key:
 
 <pre class="lang-ini">
@@ -461,7 +461,7 @@ rabbitmq-diagnostics -s listeners
 # => Interface: [::], port: 15692, protocol: http/prometheus, purpose: Prometheus exporter API over HTTP
 </pre>
 
-or [tools such as `lsof`, `ss` or `netstat`](/troubleshooting-networking.html#ports).
+or [tools such as `lsof`, `ss` or `netstat`](./troubleshooting-networking.html#ports).
 
 ### <a id="metric-aggregation" class="anchor" href="#metric-aggregation">Aggregated and Per-Object Metrics</a>
 
@@ -555,7 +555,7 @@ dashboards.
 1. Copy paste the file contents in Grafana, then click **Load**, as seen below:
     - Alternatively, paste the dashboard ID in the field **Grafana.com Dashboard**.
 
-![Grafana Import Dashboard](/img/grafana-import-dashboard.png)
+![Grafana Import Dashboard](./img/grafana-import-dashboard.png)
 
 Repeat the process for all other Grafana dashboards that you would like to use with
 this RabbitMQ deployment.
@@ -568,7 +568,7 @@ Congratulations! Your RabbitMQ is now monitored with Prometheus & Grafana!
 ## <a id="tls" class="anchor" href="#tls">Securing Prometheus Scraping Endpoint with TLS</a>
 
 The Prometheus metrics can be secured with TLS similar to the other listeners.
-For example, in the [configuration file](/configure.html#configuration-files)
+For example, in the [configuration file](./configure.html#configuration-files)
 
 <pre class="lang-ini">
 prometheus.ssl.port       = 15691
@@ -579,7 +579,7 @@ prometheus.ssl.password   = password-if-keyfile-is-encrypted
 </pre>
 
 
-To enable TLS with [peer verification](/ssl.html#peer-verification), use a config similar to
+To enable TLS with [peer verification](./ssl.html#peer-verification), use a config similar to
 
 <pre class="lang-ini">
 prometheus.ssl.port       = 15691
@@ -597,5 +597,5 @@ prometheus.ssl.fail_if_no_peer_cert = true
 
 RabbitMQ versions prior to 3.8 can use a separate plugin,
 [prometheus_rabbitmq_exporter](https://github.com/deadtrickster/prometheus_rabbitmq_exporter),
-to expose metrics to Prometheus. The plugin uses [RabbitMQ HTTP API](/monitoring.html) internally
+to expose metrics to Prometheus. The plugin uses [RabbitMQ HTTP API](./monitoring.html) internally
 and requires visualisation to be set up separately.

--- a/site/protocol.xml
+++ b/site/protocol.xml
@@ -29,7 +29,7 @@ limitations under the License.
   </head>
   <body>
     <p>
-      AMQP 0-9-1 is a binary messaging protocol and <a href="/tutorials/amqp-concepts.html">semantic framework</a>
+      AMQP 0-9-1 is a binary messaging protocol and <a href="./tutorials/amqp-concepts.html">semantic framework</a>
       for microservices and enterprise messaging.
     </p>
 
@@ -38,7 +38,7 @@ limitations under the License.
       Despite similar names and, to some extent, a common lineage, AMQP 0-9-1 and AMQP 1.0
       are completely different messaging protocols and not a revision of the same idea.
       AMQP 1.0 has a different scope and topology model. RabbitMQ supports AMQP 0-9-1, AMQP 1.0,
-      MQTT and STOMP. See <a href="/documentation.html">documentation ToC</a> for details.
+      MQTT and STOMP. See <a href="./documentation.html">documentation ToC</a> for details.
     </p>
 
     <h2 id="downloads">Downloads</h2>

--- a/site/protocols.md
+++ b/site/protocols.md
@@ -23,20 +23,20 @@ helps differentiate between them.
 
 ## <a id="amqp-091" class="anchor" href="#amqp-091">AMQP 0-9-1 and extensions</a>
 
-RabbitMQ was originally developed to [support AMQP 0-9-1](/protocol.html).
+RabbitMQ was originally developed to [support AMQP 0-9-1](./protocol.html).
 As such this protocol is the "core" protocol supported by
 the broker. All of these variants are fairly similar to each other,
 with later versions tidying up unclear or unhelpful parts of earlier
-versions. We have [extended](/extensions.html) AMQP 0-9-1
+versions. We have [extended](./extensions.html) AMQP 0-9-1
 in various ways.
 
 AMQP 0-9-1 is a binary protocol, and defines quite strong
 messaging semantics. For clients it's a reasonably easy
 protocol to implement, and as such there
-are [a large number of client libraries](/devtools.html) available for
+are [a large number of client libraries](./devtools.html) available for
 many different programming languages and environments.
 
-AMQP 0-9-1 is the protocol used by [RabbitMQ tutorials](/getstarted.html).
+AMQP 0-9-1 is the protocol used by [RabbitMQ tutorials](./getstarted.html).
 
 
 ## <a id="stomp" class="anchor" href="#stomp">STOMP</a>

--- a/site/publishers.md
+++ b/site/publishers.md
@@ -252,13 +252,13 @@ and set by RabbitMQ at routing and delivery time:
       <td>Delivery tag</td>
       <td>Positive integer</td>
       <td>
-        Delivery identifier, see <a href="/confirms.html">Confirms</a>.
+        Delivery identifier, see <a href="./confirms.html">Confirms</a>.
       </td>
     </tr>
     <tr>
       <td>Redelivered</td>
       <td>Boolean</td>
-      <td>Set to `true` if this message was previously <a href="/confirms.html#consumer-nacks-requeue">delivered and requeued</a></td>
+      <td>Set to `true` if this message was previously <a href="./confirms.html#consumer-nacks-requeue">delivered and requeued</a></td>
     </tr>
     <tr>
       <td>Exchange</td>
@@ -333,19 +333,19 @@ at the time of publishing:
     <tr>
       <td>Correlation ID</td>
       <td>String</td>
-      <td>Helps correlate requests with responses, see <a href="/getstarted.html">tutorial 6</a></td>
+      <td>Helps correlate requests with responses, see <a href="./getstarted.html">tutorial 6</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Reply To</td>
       <td>String</td>
-      <td>Carries response queue name, see <a href="/getstarted.html">tutorial 6</a></td>
+      <td>Carries response queue name, see <a href="./getstarted.html">tutorial 6</a></td>
       <td>No</td>
     </tr>
     <tr>
       <td>Expiration</td>
       <td>String</td>
-      <td><a href="/ttl.html">Per-message TTL</a></td>
+      <td><a href="./ttl.html">Per-message TTL</a></td>
       <td>No</td>
     </tr>
     <tr>
@@ -357,7 +357,7 @@ at the time of publishing:
     <tr>
       <td>User ID</td>
       <td>String</td>
-      <td>User ID, <a href="/validated-user-id.html">validated</a> if set</td>
+      <td>User ID, <a href="./validated-user-id.html">validated</a> if set</td>
       <td>No</td>
     </tr>
     <tr>

--- a/site/quorum-queues.md
+++ b/site/quorum-queues.md
@@ -55,7 +55,7 @@ Topics covered in this guide include
 
 and more.
 
-This guide assumes general familiarity with [RabbitMQ clustering](/clustering.html).
+This guide assumes general familiarity with [RabbitMQ clustering](./clustering.html).
 
 
 ## <a id="motivation" class="anchor" href="#motivation">Motivation</a>
@@ -72,7 +72,7 @@ If intentionally simplified, [quorum](https://en.wikipedia.org/wiki/Quorum_(dist
 be defined as an agreement between the majority of nodes (`(N/2)+1` where `N` is the total number of
 system participants).
 
-When applied to queue mirroring in RabbitMQ [clusters](/clustering.html)
+When applied to queue mirroring in RabbitMQ [clusters](./clustering.html)
 this means that the majority of replicas (including the currently elected queue leader)
 agree on the state of the queue and its contents.
 
@@ -99,7 +99,7 @@ A client library that can use regular mirrored queues will be able to use quorum
 The following operations work the same way for quorum queues as they do for regular queues:
 
  * Consumption (subscription)
- * [Consumer acknowledgements](/confirms.html) (except for global [QoS and prefetch](#global-qos))
+ * [Consumer acknowledgements](./confirms.html) (except for global [QoS and prefetch](#global-qos))
  * Cancelling consumers
  * Purging
  * Deletion
@@ -119,14 +119,14 @@ Some features are not currently supported by quorum queues.
 | [Exclusivity](queues.html) | yes | no |
 | Per message persistence | per message | always |
 | Membership changes | automatic | manual  |
-| [Message TTL (Time-To-Live)](/ttl.html) | yes | yes (since 3.10) |
-| [Queue TTL](/ttl.html#queue-ttl) | yes | yes |
-| [Queue length limits](/maxlength.html) | yes | yes (except `x-overflow`: `reject-publish-dlx`) |
-| [Lazy behaviour](/lazy-queues.html) | yes | yes through the [Memory Limit](#memory-limit) feature (before 3.10); always (since 3.10) |
-| [Message priority](/priority.html) | yes | no |
-| [Consumer priority](/consumer-priority.html) | yes | yes |
-| [Dead letter exchanges](/dlx.html) | yes | yes |
-| Adheres to [policies](/parameters.html#policies) | yes | yes (see policy support below) |
+| [Message TTL (Time-To-Live)](./ttl.html) | yes | yes (since 3.10) |
+| [Queue TTL](./ttl.html#queue-ttl) | yes | yes |
+| [Queue length limits](./maxlength.html) | yes | yes (except `x-overflow`: `reject-publish-dlx`) |
+| [Lazy behaviour](./lazy-queues.html) | yes | yes through the [Memory Limit](#memory-limit) feature (before 3.10); always (since 3.10) |
+| [Message priority](./priority.html) | yes | no |
+| [Consumer priority](./consumer-priority.html) | yes | yes |
+| [Dead letter exchanges](./dlx.html) | yes | yes |
+| Adheres to [policies](./parameters.html#policies) | yes | yes (see policy support below) |
 | Poison message handling | no | yes |
 | Global [QoS Prefetch](#global-qos) | yes | no |
 
@@ -141,22 +141,22 @@ assumed [use cases](#use-cases).
 Quorum queues by design are replicated and durable, therefore the exclusive property makes
 no sense in their context. Therefore quorum queues cannot be exclusive.
 
-Quorum queues are not meant to be used as [temporary queues](/queues.html#temporary-queues).
+Quorum queues are not meant to be used as [temporary queues](./queues.html#temporary-queues).
 
 #### TTL (before RabbitMQ 3.10)
 
-Quorum queues support [Queue TTL](/ttl.html#queue-ttl), but do not support message TTL.
+Quorum queues support [Queue TTL](./ttl.html#queue-ttl), but do not support message TTL.
 
 #### TTL (since RabbitMQ 3.10)
 
-Quorum queues support both [Queue TTL](/ttl.html#queue-ttl) and message TTL
-(including [Per-Queue Message TTL in Queues](/ttl.html#per-queue-message-ttl) and
-[Per-Message TTL in Publishers](/ttl.html#per-message-ttl-in-publishers)).
+Quorum queues support both [Queue TTL](./ttl.html#queue-ttl) and message TTL
+(including [Per-Queue Message TTL in Queues](./ttl.html#per-queue-message-ttl) and
+[Per-Message TTL in Publishers](./ttl.html#per-message-ttl-in-publishers)).
 When using any form of message TTL, the memory overhead increases by 2 bytes per message.
 
 #### Length Limit
 
-Quorum queues has support for [queue length limits](/maxlength.html).
+Quorum queues has support for [queue length limits](./maxlength.html).
 
 The `drop-head` and `reject-publish` overflow behaviours are supported but they
 do not support `reject-publish-dlx` configurations as Quorum queues take a different
@@ -171,9 +171,9 @@ on how many messages are in flight at the time.
 
 #### <a id="dead-lettering" class="anchor" href="#dead-lettering">Dead Lettering</a>
 
-Quorum queues support [dead letter exchanges](/dlx.html) (DLXs).
+Quorum queues support [dead letter exchanges](./dlx.html) (DLXs).
 
-Traditionally, using DLXs in a clustered environment has not been [safe](/dlx.html#safety).
+Traditionally, using DLXs in a clustered environment has not been [safe](./dlx.html#safety).
 
 Since RabbitMQ 3.10 quorum queues support a safer form of dead-lettering that uses
 `at-least-once` guarantees for the message transfer between queues
@@ -202,7 +202,7 @@ To enable `at-least-once` dead-lettering for a source quorum queue, apply all of
 * Set `dead-letter-strategy` to `at-least-once` (default is `at-most-once`).
 * Set `overflow` to `reject-publish` (default is `drop-head`).
 * Configure a `dead-letter-exchange`.
-* Enable [feature flag](/feature-flags.html) `stream_queue` (enabled by default
+* Enable [feature flag](./feature-flags.html) `stream_queue` (enabled by default
 for RabbitMQ clusters created in 3.9 or later).
 
 It is recommended to additionally configure `max-length` or `max-length-bytes`
@@ -253,7 +253,7 @@ It uses a prefetch size of 32 messages to limit the amount of message bodies kep
 are received from the target queues.
 
 That prefetch size can be increased by the `dead_letter_worker_consumer_prefetch` setting in the `rabbit` app section of the
-[advanced config file](/configure.html#advanced-config-file) if high dead-lettering throughput
+[advanced config file](./configure.html#advanced-config-file) if high dead-lettering throughput
 (thousands of messages per second) is required.
 
 For a source quorum queue, it is possible to switch dead-letter strategy dynamically from `at-most-once`
@@ -270,7 +270,7 @@ the message delivery mode must be set to persistent when publishing messages to 
 
 Quorum queues store their content on disk (per Raft requirements) as well as in memory (up to the [in memory limit configured](#memory-limit)).
 
-The [`lazy` mode configuration](/lazy-queues.html#configuration) does not apply.
+The [`lazy` mode configuration](./lazy-queues.html#configuration) does not apply.
 
 It is possible to [limit how many messages a quorum queue keeps in memory](#memory-limit) using a policy which
 can achieve a behaviour similar to lazy queues.
@@ -286,20 +286,20 @@ was large.
 The [memory limit](#memory-limit) configuration is still permitted but has no
 effect. The only option now is effectively the same as configuring: `x-max-in-memory-length=0`
 
-The [`lazy` mode configuration](/lazy-queues.html#configuration) does not apply.
+The [`lazy` mode configuration](./lazy-queues.html#configuration) does not apply.
 
 #### <a id="global-qos" class="anchor" href="#global-qos">Global QoS</a>
 
-Quorum queues do not support global [QoS prefetch](/confirms.html#channel-qos-prefetch) where a channel sets a single
+Quorum queues do not support global [QoS prefetch](./confirms.html#channel-qos-prefetch) where a channel sets a single
 prefetch limit for all consumers using that channel. If an attempt
 is made to consume from a quorum queue from a channel with global QoS enabled
 a channel error will be returned.
 
-Use [per-consumer QoS prefetch](/consumer-prefetch.html), which is the default in several popular clients.
+Use [per-consumer QoS prefetch](./consumer-prefetch.html), which is the default in several popular clients.
 
 #### Priorities
 
-Quorum queues do not currently support [priorities](/priority.html), including [consumer priorities](/consumer-priority.html).
+Quorum queues do not currently support [priorities](./priority.html), including [consumer priorities](./consumer-priority.html).
 
 To achieve priority processing with Quorum Queues multiple queues should be used instead;
 one for each priority.
@@ -359,7 +359,7 @@ In some cases quorum queues should not be used. They typically involve:
 
  * Temporary nature of queues: transient or exclusive queues, high queue churn (declaration and deletion rates)
  * Lowest possible latency: the underlying consensus algorithm has an inherently higher latency due to its data safety features
- * When data safety is not a priority (e.g. applications do not use [manual acknowledgements and publisher confirms](/confirms.html) are not used)
+ * When data safety is not a priority (e.g. applications do not use [manual acknowledgements and publisher confirms](./confirms.html) are not used)
  * Very long queue backlogs (quorum queues currently keep all messages in memory at all times, up to a [limit](#memory-limit))
 
 
@@ -367,7 +367,7 @@ In some cases quorum queues should not be used. They typically involve:
 ## <a id="usage" class="anchor" href="#usage">Usage</a>
 
 As stated earlier, quorum queues share most of the fundamentals with other [queue](queues.html) types.
-A client library that can specify [optional queue arguments](/queues.html#optional-arguments) will be able to use quorum queues.
+A client library that can specify [optional queue arguments](./queues.html#optional-arguments) will be able to use quorum queues.
 
 First we will cover how to declare a quorum queue.
 
@@ -375,12 +375,12 @@ First we will cover how to declare a quorum queue.
 
 To declare a quorum queue set the `x-queue-type` queue argument to `quorum`
 (the default is `classic`). This argument must be provided by a client
-at queue declaration time; it cannot be set or changed using a [policy](/parameters.html#policies).
+at queue declaration time; it cannot be set or changed using a [policy](./parameters.html#policies).
 This is because policy definition or applicable policy can be changed dynamically but
 queue type cannot. It must be specified at the time of declaration.
 
 Declaring a queue with an `x-queue-type` argument set to `quorum` will declare a quorum queue with
-up to five replicas (default [replication factor](#replication-factor)), one per each [cluster node](/clustering.html).
+up to five replicas (default [replication factor](#replication-factor)), one per each [cluster node](./clustering.html).
 
 For example, a cluster of three nodes will have three replicas, one on each node.
 In a cluster of seven nodes, five nodes will have one replica each but two nodes won't host any replicas.
@@ -388,15 +388,15 @@ In a cluster of seven nodes, five nodes will have one replica each but two nodes
 After declaration a quorum queue can be bound to any exchange just as any other
 RabbitMQ queue.
 
-If declaring using [management UI](/management.html), queue type must be specified using
+If declaring using [management UI](./management.html), queue type must be specified using
 the queue type drop down menu.
 
 ### Client Operations
 
 The following operations work the same way for quorum queues as they do for classic queues:
 
- * [Consumption](/consumers.html) (subscription)
- * [Consumer acknowledgements](/confirms.html) (keep [QoS Prefetch Limitations](#global-qos) in mind)
+ * [Consumption](./consumers.html) (subscription)
+ * [Consumer acknowledgements](./confirms.html) (keep [QoS Prefetch Limitations](#global-qos) in mind)
  * Cancellation of consumers
  * Purging of queue messages
  * Queue deletion
@@ -482,7 +482,7 @@ to a member (replica) list of a quorum queue or a set of quorum queues.
 When a node has to be decommissioned (permanently removed from the cluster), it must be explicitly
 removed from the member list of all quorum queues it currently hosts replicas for.
 
-Several [CLI commands](/cli.html) are provided to perform the above operations:
+Several [CLI commands](./cli.html) are provided to perform the above operations:
 
 <pre class="lang-bash">
 rabbitmq-queues add_member [-p &lt;vhost&gt;] &lt;queue-name&gt; &lt;node&gt;
@@ -514,7 +514,7 @@ it replaces.
 Once declared, the RabbitMQ nodes a quorum queue resides on won't change even if the
 members of the RabbitMQ cluster change (e.g. a node is decommissioned or added).
 To re-balance after a RabbitMQ cluster change quorum queues will have to be manually adjusted using the `rabbitmq-queues`
-[command line tool](/cli.html):
+[command line tool](./cli.html):
 
 <pre class="lang-bash">
 # rebalances all quorum queues
@@ -596,7 +596,7 @@ smaller uneven number of nodes.
 Performance tails off quite a bit for quorum queue node sizes larger than 5.
 We do not recommend running quorum queues on more than 7 RabbitMQ nodes. The
 default quorum queue size is 3 and is controllable using the
-`x-quorum-initial-group-size` [queue argument](/queues.html#optional-arguments).
+`x-quorum-initial-group-size` [queue argument](./queues.html#optional-arguments).
 
 ### <a id="data-safety" class="anchor" href="#data-safety">Data Safety</a>
 
@@ -618,7 +618,7 @@ system buffer or otherwise fail to reach the queue leader.
 A quorum queue should be able to tolerate a minority of queue members becoming unavailable
 with no or little effect on availability.
 
-Note that depending on the [partition handling strategy](/partitions.html)
+Note that depending on the [partition handling strategy](./partitions.html)
 used RabbitMQ may restart itself during recovery and reset the node but as long as that
 does not happen, this availability guarantee should hold true.
 
@@ -640,7 +640,7 @@ will therefore remain consistent.
 ## <a id="performance" class="anchor" href="#performance">Performance Characteristics</a>
 
 Quorum queues are designed to trade latency for throughput and have been tested
-and compared against durable [classic mirrored queues](/ha.html) in 3, 5 and 7 node configurations at several
+and compared against durable [classic mirrored queues](./ha.html) in 3, 5 and 7 node configurations at several
 message sizes. In scenarios using both consumer acks and publisher confirms
  quorum queues have been observed to have equal or greater throughput to
 classic mirrored queues.
@@ -722,16 +722,16 @@ The following `advanced.config` example modifies all values listed above:
 
 Quorum queue support handling of [poison messages](https://en.wikipedia.org/wiki/Poison_message),
 that is, messages that cause a consumer to repeatedly requeue a delivery (possibly due to a consumer failure)
-such that the message is never consumed completely and [positively acknowledged](/confirms.html) so that it can be marked for
+such that the message is never consumed completely and [positively acknowledged](./confirms.html) so that it can be marked for
 deletion by RabbitMQ.
 
 Quorum queues keep track of the number of unsuccessful delivery attempts and expose it in the
 "x-delivery-count" header that is included with any redelivered message.
 
-It is possible to set a delivery limit for a queue using a [policy](/parameters.html#policies) argument, `delivery-limit`.
+It is possible to set a delivery limit for a queue using a [policy](./parameters.html#policies) argument, `delivery-limit`.
 
 When a message has been returned more times than the limit the message will be dropped or
-[dead-lettered](/dlx.html) (if a DLX is configured).
+[dead-lettered](./dlx.html) (if a DLX is configured).
 
 
 
@@ -746,7 +746,7 @@ Quorum queues use a write-ahead-log (WAL) for all operations.
 WAL operations are stored both in memory and written to disk.
 When the current WAL file reaches a predefined limit, it is flushed to a WAL segment file on disk
 and the system will begin to release the memory used by that batch of log entries.
-The segment files are then compacted over time as consumers [acknowledge deliveries](/confirms.html).
+The segment files are then compacted over time as consumers [acknowledge deliveries](./confirms.html).
 Compaction is the process that reclaims disk space.
 
 The WAL file size limit at which it is flushed to disk can be controlled:
@@ -767,10 +767,10 @@ More will be required in high-throughput systems. 4 times is a good starting poi
 
 Before RabbitMQ 3.10 it was possible to limit the amount of memory each quorum queue will use for the part of its log that
 is kept in memory. Note that these limits are different from those of the [in-memory Raft WAL table](#resource-use)
-and [queue length limits](/maxlength.html).
+and [queue length limits](./maxlength.html).
 
-The limit is controlled using [optional queue arguments](/queues.html#optional-arguments)
-that are best configured using a [policy](/parameters.html#policies).
+The limit is controlled using [optional queue arguments](./queues.html#optional-arguments)
+that are best configured using a [policy](./parameters.html#policies).
 
  * `x-max-in-memory-length` sets a limit as a number of messages. Must be a non-negative integer.
  * `x-max-in-memory-bytes` sets a limit as the total size of message bodies (payloads), in bytes. Must be a non-negative integer.
@@ -785,7 +785,7 @@ Internally quorum queues are implemented using a log where all operations includ
 messages are persisted. To avoid this log growing too large it needs to be
 truncated regularly. To be able to truncate a section of the log all messages
 in that section needs to be acknowledged. Usage patterns that continuously
-[reject or nack](/nack.html) the same message with the `requeue` flag set to true
+[reject or nack](./nack.html) the same message with the `requeue` flag set to true
 could cause the log to grow in an unbounded fashion and eventually fill
 up the disks.
 

--- a/site/relocate.md
+++ b/site/relocate.md
@@ -39,7 +39,7 @@ values should work just fine.
 
 ### <a id="directory-and-path-restrictions" class="anchor" href="#directory-and-path-restrictions">Path and Directory Name Restrictions</a>
 
-Some of the environment variable configure paths and locations (node's base or data directory, [plugin source and expansion directories](/plugins.html),
+Some of the environment variable configure paths and locations (node's base or data directory, [plugin source and expansion directories](./plugins.html),
 and so on). Those paths have must exclude a number of characters:
 
  * `*` and `?` (on Linux, macOS, BSD and other UNIX-like systems)
@@ -53,8 +53,8 @@ When changing file or directory locations, it is important to
 make sure that they have sufficient permissions for RabbitMQ
 node OS process to read and write from. It's best to assume
 that most directories and files used by RabbitMQ require read,
-write, and file creation permissions. [Debian](/install-debian.html),
-[RPM](/install-rpm.html) and [Windows installer](/install-windows.html) scripts
+write, and file creation permissions. [Debian](./install-debian.html),
+[RPM](./install-rpm.html) and [Windows installer](./install-windows.html) scripts
 will set up file system permissions suitable for most
 environments, however, when strict default permissions are
 used system-wide, it may be necessary to run additional

--- a/site/relocate.md
+++ b/site/relocate.md
@@ -82,7 +82,7 @@ file and directories have sufficient permissions
       the <code>.config</code> extension. If
       the <a href="configure.html#configuration-files">configuration
       file</a> is present it is used by the server to configure
-      RabbitMQ components. See <a href="/configure.html">Configuration guide</a>
+      RabbitMQ components. See <a href="./configure.html">Configuration guide</a>
       for more information.
     </td>
   </tr>
@@ -91,7 +91,7 @@ file and directories have sufficient permissions
     <td>
       Path to a directory of RabbitMQ configuration files in the new-style (.conf) format.
       The files will be loaded in alphabetical order. Prefixing each files with a number
-      is a common practice. See <a href="/configure.html">Configuration guide</a>
+      is a common practice. See <a href="./configure.html">Configuration guide</a>
       for more information.
     </td>
   </tr>
@@ -128,14 +128,14 @@ file and directories have sufficient permissions
     <td>RABBITMQ_SCHEMA_DIR</td>
     <td>
       The directory where RabbitMQ keeps its configuration schema used by
-      the <a href="/configure.html#configuration-files">new style configuration file</a>.
+      the <a href="./configure.html#configuration-files">new style configuration file</a>.
     </td>
   </tr>
 
   <tr>
     <td>RABBITMQ_LOG_BASE</td>
     <td>
-      This base directory contains the RabbitMQ server's <a href="/logging.html">log
+      This base directory contains the RabbitMQ server's <a href="./logging.html">log
       files</a>, unless <b>RABBITMQ_LOGS</b> is set.
     </td>
   </tr>
@@ -152,11 +152,11 @@ file and directories have sufficient permissions
     <td>RABBITMQ_PLUGINS_DIR</td>
     <td>
       The list of directories where <a
-      href="/plugins.html">plugin</a> archive files are located and extracted
+      href="./plugins.html">plugin</a> archive files are located and extracted
       from. This is <code>PATH</code>-like variable, where
       different paths are separated by an OS-specific separator
       (<code>:</code> for Unix, <code>;</code> for Windows).
-      Plugins can be <a href="/plugins.html#plugin-directories">installed</a> to any of the
+      Plugins can be <a href="./plugins.html#plugin-directories">installed</a> to any of the
       directories listed here.
     </td>
   </tr>
@@ -164,7 +164,7 @@ file and directories have sufficient permissions
   <tr>
     <td>RABBITMQ_PLUGINS_EXPAND_DIR</td>
     <td>
-      Working directory used to <a href="/plugins.html#plugin-expansion">expand enabled plugins</a> when starting
+      Working directory used to <a href="./plugins.html#plugin-expansion">expand enabled plugins</a> when starting
       the server. It is
       important that effective RabbitMQ user has sufficient permissions
       to read and create files and subdirectories in this directory.

--- a/site/runtime.md
+++ b/site/runtime.md
@@ -20,7 +20,7 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 RabbitMQ runs on the [Erlang virtual machine](https://erlang.org) and runtime.
-A [compatible version of Erlang](/which-erlang.html) must be installed in order to run RabbitMQ.
+A [compatible version of Erlang](./which-erlang.html) must be installed in order to run RabbitMQ.
 
 The Erlang runtime includes a number of components used by RabbitMQ. The most important ones
 as far as this guide is concerned are
@@ -29,7 +29,7 @@ as far as this guide is concerned are
  * `epmd` resolves node names on a host to an [inter-node communication port](networking.html)
 
 This guide will focus on the virtual machine. For an overview of epmd, please refer to the
-[Networking guide](/networking.html#epmd-inet-dist-port-range).
+[Networking guide](./networking.html#epmd-inet-dist-port-range).
 
 Topics covered include:
 
@@ -51,7 +51,7 @@ Tuning of those flags can significantly change runtime behavior of a node.
 
 ### <a id="configure" class="anchor" href="#configure">Configuring Flags</a>
 
-Most of the settings can be configured using [environment variables](/configure.html#supported-environment-variables).
+Most of the settings can be configured using [environment variables](./configure.html#supported-environment-variables).
 A few settings have dedicated variables, others can only be changed using the following generic
 variables that control what flags are passed by RabbitMQ startup scripts to the Erlang virtual machine.
 
@@ -59,14 +59,14 @@ The generic variables are
 
  * `RABBITMQ_SERVER_ERL_ARGS` allows all VM flags to be overridden, including the defaults set by RabbitMQ scripts
  * `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` allows a set of flags to be appended to the defaults set by RabbitMQ scripts
- * `RABBITMQ_CTL_ERL_ARGS` controls [CLI tool](/cli.html) VM flags
+ * `RABBITMQ_CTL_ERL_ARGS` controls [CLI tool](./cli.html) VM flags
 
 In most cases `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` is the recommended option. It can be used to override defaults
 in a safe manner. For example, if an important flag is omitted from `RABBITMQ_SERVER_ERL_ARGS`, runtime performance
 characteristics or system limits can be unintentionally affected.
 
 As with other environment variables used by RabbitMQ, `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS`
-and friends can be [set using a separate environment variable file](/configure.html#customise-environment).
+and friends can be [set using a separate environment variable file](./configure.html#customise-environment).
 
 
 ## <a id="cpu" class="anchor" href="#cpu">CPU Utilisation</a>
@@ -193,15 +193,15 @@ Speculative busy waiting usually not productive on moderately loaded systems.
 
 #### Reduce Statistics Emission Frequency (Increase the Statistics Emission Interval)
 
-Increase [statistics emission interval](/management.html#statistics-interval) from default 5 seconds to 15 or 30 seconds. This will reduce
+Increase [statistics emission interval](./management.html#statistics-interval) from default 5 seconds to 15 or 30 seconds. This will reduce
 periodic activity that all connections, channels and queues carry out, even if they would otherwise be
-idle as far as client operations go. With most monitoring tools such [monitoring frequency](/monitoring.html#monitoring-frequency)
+idle as far as client operations go. With most monitoring tools such [monitoring frequency](./monitoring.html#monitoring-frequency)
 would be sufficient or even optimal.
 
 
 ## <a id="thread-stats" class="anchor" href="#thread-stats">Thread Statistics</a>: How is Scheduler and CPU Time Spent?
 
-RabbitMQ CLI tools provide a number of [metrics](/monitoring.html) that make it easier to reason
+RabbitMQ CLI tools provide a number of [metrics](./monitoring.html) that make it easier to reason
 about runtime thread activity.
 
 <pre class="lang-bash">
@@ -220,7 +220,7 @@ The command's output will produce a table with percentages by thread activity:
  * `sleep`: sleeping (idle state)
 
 Significant percentage of activity in the external I/O state may indicate that the node
-and/or clients have maxed out network link capacity. This can be confirmed by [infrastructure metrics](/monitoring.html).
+and/or clients have maxed out network link capacity. This can be confirmed by [infrastructure metrics](./monitoring.html).
 
 Significant percentage of activity in the sleeping state might indicate a lightly loaded node or suboptimal
 runtime scheduler configuration for the available hardware and workload.
@@ -282,7 +282,7 @@ can be opened at the same time. When an OS process (such as RabbitMQ's Erlang VM
 the limit, it won't be able to open any new files or accept any more
 TCP connections.
 
-This limit is covered in detail in the [Networking guide](/networking.html#open-file-handle-limit).
+This limit is covered in detail in the [Networking guide](./networking.html#open-file-handle-limit).
 Note that it cannot be configured using Erlang VM flags.
 
 ## <a id="distribution-buffer" class="anchor" href="#distribution-buffer">Inter-node Communication Buffer Size</a>
@@ -305,7 +305,7 @@ RABBITMQ_DISTRIBUTION_BUFFER_SIZE=192000
 RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+zdbbl 192000"
 </pre>
 
-When the buffer is hovering around full capacity, nodes will [log](/logging.html) a warning
+When the buffer is hovering around full capacity, nodes will [log](./logging.html) a warning
 mentioning a busy distribution port (`busy_dist_port`):
 
 <pre class="lang-ini">
@@ -319,7 +319,7 @@ Increasing buffer size may help increase throughput and/or reduce latency.
 The runtime has a limit on the number of Erlang processes ("lightweight threads") that can exist on a node.
 The default is about 1 million. In most environments this is sufficient with a wide safety margin.
 
-Environments that have a particularly [high number of concurrent connections](/networking.html#tuning-for-large-number-of-connections) or a very large number
+Environments that have a particularly [high number of concurrent connections](./networking.html#tuning-for-large-number-of-connections) or a very large number
 of queues (say, hundreds of thousands) this limit might need adjusting. This is done using the
 `RABBITMQ_MAX_NUMBER_OF_PROCESSES` environment variable, which is a convenient way of
 setting the `+P` Erlang VM flag:

--- a/site/sender-selected.md
+++ b/site/sender-selected.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 
 The routing logic in AMQP 0-9-1 does not offer a way for message
-[publishers](/publishers.html) to select intended recipients unless they
+[publishers](./publishers.html) to select intended recipients unless they
 bind their queues to the target destination (an exchange).
 
 The RabbitMQ broker treats the "CC" and "BCC" message headers
@@ -33,7 +33,7 @@ will be routed to all destinations matching the routing key
 supplied as a parameter to the `basic.publish`
 method, as well as the routes supplied in the "CC" and "BCC"
 headers. The type of "CC" and "BCC" values must be an array
-of [longstr](/amqp-0-9-1-reference.html#domain.longstr)
+of [longstr](./amqp-0-9-1-reference.html#domain.longstr)
 and these keys are case-sensitive. If the header does not
 contain "CC" or "BCC" keys then this extension has no effect.
 

--- a/site/shovel-dynamic.md
+++ b/site/shovel-dynamic.md
@@ -371,7 +371,7 @@ the declaration process.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="/confirms.html">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms.html">acknowledge</a> consumed messages.
           If set to <code>on-confirm</code> (the default), messages are
           acknowledged to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
@@ -513,8 +513,8 @@ counterparts.
       <td>src-uri</td>
       <td>
         The AMQP URI for the source. Mandatory. AMQP 1.0 URIs implement
-        as subset of what is described in the <a href="/uri-spec.html">AMQP URI reference</a>.
-        There is no <a href="/vhosts.html">virtual host</a> concept in AMQP 1.0, so URI path
+        as subset of what is described in the <a href="./uri-spec.html">AMQP URI reference</a>.
+        There is no <a href="./vhosts.html">virtual host</a> concept in AMQP 1.0, so URI path
         segments are not supported. The set of query parameters it supports are different from AMQP 0.9.1
         URI(s):
 
@@ -612,7 +612,7 @@ counterparts.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="/confirms.html">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms.html">acknowledge</a> consumed messages.
           If set to <code>on-confirm</code> (the default), messages are
           acknowledged to the source broker after they have been confirmed
           by the destination. This handles network errors and broker

--- a/site/shovel-dynamic.md
+++ b/site/shovel-dynamic.md
@@ -22,29 +22,29 @@ limitations under the License.
 This guide focuses on dynamically configured shovels. It assumes
 familiarity with the key concepts behind the [Shovel plugin](shovel.html).
 
-Unlike with static shovels, dynamic shovels are configured using [runtime parameters](/parameters.html).
+Unlike with static shovels, dynamic shovels are configured using [runtime parameters](./parameters.html).
 They can be started and stopped at any time, including programmatically. Dynamic shovels
 can be used for both transient (one-off) and permanently running workloads.
 
 Information about dynamic shovels is stored in RabbitMQ's schema database,
 along with users, permissions, queues, etc. They therefore can be
-exported together with other [schema definitions](/definitions.html).
+exported together with other [schema definitions](./definitions.html).
 
 
 ## <a id="configuration" class="anchor" href="#configuration">Configuration</a>
 
-Parameters can be defined using [`rabbitmqctl`](/cli.html), through the
-[management HTTP API](/management.html), or (with the `rabbitmq_shovel_management` plugin [enabled](/plugins.html)) through
+Parameters can be defined using [`rabbitmqctl`](./cli.html), through the
+[management HTTP API](./management.html), or (with the `rabbitmq_shovel_management` plugin [enabled](./plugins.html)) through
 the management UI's administrative section.
 
 A shovel is declared with a definition body, which is a JSON object. Some keys are mandatory, others are optional.
 They control connection parameters, protocol used, message transfer source and destination,
-[data safety](/confirms.html) protocol features, and more.
+[data safety](./confirms.html) protocol features, and more.
 
 Every shovel belongs to a virtual host. Note that a Shovel can consume from and publish
 to not only a different virtual host but an entirely different cluster, so
 virtual host selection primarily acts as a way of organising shovels and access to them,
-much like with the rest of [permission in RabbitMQ](/access-control.html).
+much like with the rest of [permission in RabbitMQ](./access-control.html).
 
 Every shovel is also named. The name is used to identify shovels when [inspecting their status](#status),
 [deleting them](#deleting) or [restarting them](#restarting).
@@ -167,7 +167,7 @@ There are other Shovel definition keys that will be covered later in this guide.
 
 ### Using HTTP API
 
-To declare a shovel using the HTTP API, make sure that the [management](/management.html) plugin
+To declare a shovel using the HTTP API, make sure that the [management](./management.html) plugin
 is enabled, then use the following endpoint:
 
 <pre class="lang-ini">
@@ -194,11 +194,11 @@ The request body is a JSON document similar in structure to that described earli
 </pre>
 
 Below is an example that uses `curl` to declare a shovel on a local node using
-[default user credentials](/access-control.html#default-state). The shovel will
+[default user credentials](./access-control.html#default-state). The shovel will
 transfer messages between two queues, `"source-queue"` and `"destination-queue"`, in the default virtual host.
 
 Note that this exact command would fail if invoked against
-a remote node. Please [add a new user](/access-control.html) tagged as `policymaker`
+a remote node. Please [add a new user](./access-control.html) tagged as `policymaker`
 for your own experiments.
 
 <pre class="lang-bash">
@@ -221,7 +221,7 @@ EOF
 
 ### Using Management UI
 
-To declare a shovel using the management UI, first make sure that the [management](/management.html) plugin
+To declare a shovel using the management UI, first make sure that the [management](./management.html) plugin
 is enabled.
 
 Then
@@ -285,7 +285,7 @@ is the name of the shovel.  Both values must be percent-encoded.
 ## <a id="restarting" class="anchor" href="#restarting">Restarting a Shovel</a>
 
 A dynamic Shovel can be restarted. Restarting a shovel briefly interrupts its operations
-and makes it reconnect to both source and destination. When an appropriate [acknowledgement mode](/confirms.html) is
+and makes it reconnect to both source and destination. When an appropriate [acknowledgement mode](./confirms.html) is
 used by a shovel, the interruption is safe: any unacknowledged or unconfirmed ("in flight") messages
 consumed from the source or published to the destination will be automatically requeued
 when the shovel is stopped, and consumed again after the restart.
@@ -661,4 +661,4 @@ counterparts.
 
 ## <a id="status" class="anchor" href="#status">Monitoring Shovels</a>
 
-See [Monitoring Shovels](/shovel.html#status) in the overview Shovel plugin guide.
+See [Monitoring Shovels](./shovel.html#status) in the overview Shovel plugin guide.

--- a/site/shovel-static.md
+++ b/site/shovel-static.md
@@ -22,7 +22,7 @@ limitations under the License.
 This guide focuses on statically configured shovels. It assumes
 familiarity with the key concepts behind the [Shovel plugin](shovel.html).
 
-Unlike with [dynamic shovels](/shovel-dynamic.html), static shovels are configured using the [advanced configuration file](configure.html).
+Unlike with [dynamic shovels](./shovel-dynamic.html), static shovels are configured using the [advanced configuration file](configure.html).
 They are started on node boot and are primarily useful for permanently
 running workloads. Any changes to static shovel configuration would require
 a node restart, which makes them highly inflexible.
@@ -664,7 +664,7 @@ to the other source broker on failure, after a delay of 5
 seconds.
 
 When connected to the source it will declare a direct, fanout exchange
-called `"my_fanout"`, an anonymous queue with a [per-queue message ttl](/ttl.html#per-queue-message-ttl),
+called `"my_fanout"`, an anonymous queue with a [per-queue message ttl](./ttl.html#per-queue-message-ttl),
 and bind the queue to the exchange.
 
 When connected to the destination (the local broker) it will declare a

--- a/site/shovel-static.md
+++ b/site/shovel-static.md
@@ -96,7 +96,7 @@ for AMQP 0-9-1 and AMQP 1.0, respectively:
 {protocol, amqp091}
 </pre>
 
-`uris` is a list of <a href="/uri-spec.html">AMQP connection URIs</a>:
+`uris` is a list of <a href="./uri-spec.html">AMQP connection URIs</a>:
 
 <pre class="lang-erlang">
 {uris, [
@@ -144,7 +144,7 @@ They are described in the table below.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="/confirms.html">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms.html">acknowledge</a> consumed messages.
           If set to <code>on-confirm</code> (the default), messages are
           acknowledged to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
@@ -340,7 +340,7 @@ for AMQP 0-9-1 and AMQP 1.0, respectively:
 {protocol, amqp091}
 </pre>
 
-`uris` is a list of <a href="/uri-spec.html">AMQP connection URIs</a>:
+`uris` is a list of <a href="./uri-spec.html">AMQP connection URIs</a>:
 
 <pre class="lang-erlang">
 {uris, [
@@ -401,7 +401,7 @@ are available to static shovels, such as TLS certificate and private key.
       <td>publish_properties</td>
       <td>
         <p>
-          This optional key controls <a href="/publishers.html#message-properties">message properties</a>
+          This optional key controls <a href="./publishers.html#message-properties">message properties</a>
           set or overridden by the shovel. It takes the following form
         </p>
 <pre class="lang-erlang">

--- a/site/shovel.md
+++ b/site/shovel.md
@@ -28,7 +28,7 @@ and what they can do.
 Sometimes it is necessary to reliably and continually move messages from a source (typically a queue)
 in one cluster to a destination (an exchange, topic, etc) in another cluster.
 
-The `rabbitmq_shovel` [plugin](/plugins.html) allows you to
+The `rabbitmq_shovel` [plugin](./plugins.html) allows you to
 configure a number of shovels (transfer workers), which do just that
 and run as part of a RabbitMQ cluster.
 
@@ -65,7 +65,7 @@ different geographic or administrative domains that
 ### WAN-friendly
 
 The Shovel plugin uses [client connections](connections.html) under the hood.
-[Acknowledgements and publisher confirms](/confirms.html) are used to ensure data safety in case of connection
+[Acknowledgements and publisher confirms](./confirms.html) are used to ensure data safety in case of connection
 and node failures.
 
 ### Cross-protocol and Product Message Transfers
@@ -86,7 +86,7 @@ There is no requirement to run the shovel on the same broker
 (or cluster) as its source or destination, although that's the most typical approach;
 the shovel can run on an entirely separate node or cluster.
 
-A comparison between [clustering](/clustering.html), [federation](federation.html)
+A comparison between [clustering](./clustering.html), [federation](federation.html)
 is provided in the [Distributed Messaging](distributed.html) guide.
 
 
@@ -95,9 +95,9 @@ is provided in the [Distributed Messaging](distributed.html) guide.
 In essence, a shovel is a minimalistic message pump. Each shovel:
 
  * [Connects](connections.html) to the source and destination clusters
- * [Consumes](/consumers.html) messages from a queue
- * [Re-publishes](/publishers.html) to a destination
- * Uses [data safety features](/confirms.html) on both ends and handles failures
+ * [Consumes](./consumers.html) messages from a queue
+ * [Re-publishes](./publishers.html) to a destination
+ * Uses [data safety features](./confirms.html) on both ends and handles failures
 
 The shovel configuration allows each of these processes to be tailored.
 
@@ -121,9 +121,9 @@ destination are re-issued upon reconnection.
 
 ### Consumption
 
-The Shovel's consumer will [acknowledge](/confirms.html) messages
+The Shovel's consumer will [acknowledge](./confirms.html) messages
 automatically on receipt, after (re-)publication, or after
-[confirmation of its publication](/confirms.html) from the destination server.
+[confirmation of its publication](./confirms.html) from the destination server.
 
 ### Re-publishing
 
@@ -133,17 +133,17 @@ Most publishing and message properties are controlled by the operator.
 ## <a id="getting-started" class="anchor" href="#getting-started">Getting started</a>
 
 The Shovel plugin is included in the RabbitMQ distribution.
-To enable it, use [rabbitmq-plugins](/cli.html):
+To enable it, use [rabbitmq-plugins](./cli.html):
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_shovel
 </pre>
 
-[Management UI](/management.html) users may also wish to enable the `rabbitmq_shovel_management` plugin
+[Management UI](./management.html) users may also wish to enable the `rabbitmq_shovel_management` plugin
 for [Shovel status monitoring](#status).
 
 There are two distinct ways to define shovels: [dynamic shovels](shovel-dynamic.html) are defined using
-[runtime parameters](/parameters.html) and [static shovels](shovel-static.html) are defined in the [`advanced.config` file](configure.html).
+[runtime parameters](./parameters.html) and [static shovels](shovel-static.html) are defined in the [`advanced.config` file](configure.html).
 
 The pros and cons with each approach are covered below. Most users should consider
 dynamic shovels first for their ease of reconfiguration and management.
@@ -188,14 +188,14 @@ creation.
 
 ## <a id="authn-authz-for-shovels" class="anchor" href="#authn-authz-for-shovels">Authentication and authorisation for Shovels</a>
 
-The plugin uses [Erlang AMQP 0-9-1](/erlang-client-user-guide.html) and [Erlang AMQP 1.0](https://github.com/rabbitmq/rabbitmq-amqp1.0-client)
+The plugin uses [Erlang AMQP 0-9-1](./erlang-client-user-guide.html) and [Erlang AMQP 1.0](https://github.com/rabbitmq/rabbitmq-amqp1.0-client)
 clients under the hood to open connections to its source and/or destination. Just like any other
-[client library connection](connections.html), a Shovel connection must [successfully authenticate](/access-control.html)
-and be [authorized to access](/access-control.html) the virtual host and resources it is trying to use.
+[client library connection](connections.html), a Shovel connection must [successfully authenticate](./access-control.html)
+and be [authorized to access](./access-control.html) the virtual host and resources it is trying to use.
 This is true for both sources and destinations.
 
 Authentication and authorisation failures of shovel connections will be
-[logged](/logging.html) by the node that's running the shovel.
+[logged](./logging.html) by the node that's running the shovel.
 
 
 ## <a id="clustering" class="anchor" href="#clustering">Shovel Failure Handling in Clusters</a>
@@ -220,20 +220,20 @@ be restarted on another cluster node when a node failure is detected.
 
 ## <a id="tls" class="anchor" href="#tls">Securing Shovel Connections with TLS</a>
 
-Shovel connections can use [TLS](/ssl.html). Because Shovel uses
+Shovel connections can use [TLS](./ssl.html). Because Shovel uses
 client libraries under the hood, it is necessary to both configure
-the source broker to [listen for TLS connections](/ssl.html)
+the source broker to [listen for TLS connections](./ssl.html)
 and the Shovel to use TLS when connecting.
 
 To configure Shovel to use TLS, one needs to
 
- * Specify CA certificate and client certificate/key pair, as well as other parameters (e.g. [peer verification depth](/ssl.html#peer-verification-depth)) via [URI query parameters](/uri-query-parameters.html)
- * Configure Erlang client to [use TLS](/ssl.html)
+ * Specify CA certificate and client certificate/key pair, as well as other parameters (e.g. [peer verification depth](./ssl.html#peer-verification-depth)) via [URI query parameters](./uri-query-parameters.html)
+ * Configure Erlang client to [use TLS](./ssl.html)
 
 
 Just like with "regular" client connections, server's CA should be
-[trusted](/ssl.html#peer-verification) on the node where Shovel runs, and vice versa.
-The same [TLS troubleshooting methodology](/troubleshooting-ssl.html) that is recommended
+[trusted](./ssl.html#peer-verification) on the node where Shovel runs, and vice versa.
+The same [TLS troubleshooting methodology](./troubleshooting-ssl.html) that is recommended
 for application connections applies to shovels.
 
 
@@ -245,13 +245,13 @@ There are two ways of discovering the status of shovels.
 
 Shovel status can be reported on the [Management plugin](management.html) user interface
 in the administrative section.
-This requires the `rabbitmq_shovel_management` plugin to be [enabled](/plugins.html)
+This requires the `rabbitmq_shovel_management` plugin to be [enabled](./plugins.html)
 on the node used to access management UI.
 
 
 ### <a id="status-cli" class="anchor" href="#status-cli">Using CLI Tools</a>
 
-Shovel status can be obtained by direct query of the Shovel plugin app using [`rabbitmqctl`](/cli.html):
+Shovel status can be obtained by direct query of the Shovel plugin app using [`rabbitmqctl`](./cli.html):
 
 <pre class="lang-bash">
 # use the -n switch to target a remote node

--- a/site/shovel.md
+++ b/site/shovel.md
@@ -150,15 +150,15 @@ dynamic shovels first for their ease of reconfiguration and management.
 
 <table>
   <tr>
-    <th><a href="/shovel-static.html">Static Shovels</a></th>
-    <th><a href="/shovel-dynamic.html">Dynamic Shovels</a></th>
+    <th><a href="./shovel-static.html">Static Shovels</a></th>
+    <th><a href="./shovel-dynamic.html">Dynamic Shovels</a></th>
   </tr>
   <tr>
     <td>
-      Defined in the broker <a href="/configure.html">advanced configuration file</a>.
+      Defined in the broker <a href="./configure.html">advanced configuration file</a>.
     </td>
     <td>
-      Defined using <a href="/parameters.html">runtime parameters</a>.
+      Defined using <a href="./parameters.html">runtime parameters</a>.
     </td>
   </tr>
   <tr>

--- a/site/signatures.md
+++ b/site/signatures.md
@@ -79,7 +79,7 @@ gpg --keyserver "pgp.mit.edu" --recv-keys "0x0A9AF2115F4687BD29803A206B73A36E602
 
 ### <a id="importing-apt" class="anchor" href="#importing-apt">With apt</a>
 
-On Debian and Ubuntu systems, assuming that [apt repositories](/install-debian.html) are used for installation,
+On Debian and Ubuntu systems, assuming that [apt repositories](./install-debian.html) are used for installation,
 trusted repository signing keys must be added to the system before any packages can be installed.
 
 This can be done using key servers or (for the RabbitMQ main signing key) a direct download.
@@ -116,7 +116,7 @@ curl -1sLf "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | sudo gpg 
 
 ### <a id="importing-rpm" class="anchor" href="#importing-rpm">With RPM</a>
 
-On RPM-based systems (RHEL, Fedora, CentOS), assuming that [yum repositories](/install-rpm.html) are used for installation,
+On RPM-based systems (RHEL, Fedora, CentOS), assuming that [yum repositories](./install-rpm.html) are used for installation,
 `rpm --import` should be used to import the key.
 
 #### Direct Download

--- a/site/snapshots.md
+++ b/site/snapshots.md
@@ -62,7 +62,7 @@ intentionally so.
 
 As with our published live releases, we continue to digitally
 sign the snapshot artefacts using [GnuPG](http://www.gnupg.org/) and
-[our release public signing key](/signatures.html).
+[our release public signing key](./signatures.html).
 
 ### <a id="direct-downloads" class="anchor" href="#direct-downloads">Direct Downloads</a>
 
@@ -75,7 +75,7 @@ Team RabbitMQ appreciates community feedback on snapshot builds.
 Please post it to the [RabbitMQ mailing list](https://groups.google.com/forum/#!forum/rabbitmq-users)
 and specify what build was used plus as much context as possible:
 
- * Server [log file(s)](/logging.html)
+ * Server [log file(s)](./logging.html)
  * A code snippet or terminal (shell) transcript that demonstrates steps to reproduce the observations
  * `rabbitmqctl environment` output
  * `rabbitmq-diagnostics status` output

--- a/site/specification.xml
+++ b/site/specification.xml
@@ -40,7 +40,7 @@ limitations under the License.
         <p>
           The 0-9-1 (with and without extensions) specifications are linked to below for
           your convenience.  We recommend reading them if you want to
-          learn more about AMQP 0-9-1. Please see our <a href="/tutorials/amqp-concepts.html">AMQP 0-9-1 Overview guide</a>,
+          learn more about AMQP 0-9-1. Please see our <a href="./tutorials/amqp-concepts.html">AMQP 0-9-1 Overview guide</a>,
            <a href="amqp-0-9-1-reference.html">AMQP 0-9-1 Reference guide</a>, and the rest of
           <a href="documentation.html">documentation</a> for more information.
 	</p>

--- a/site/ssl.md
+++ b/site/ssl.md
@@ -137,11 +137,11 @@ Chains of CA certificates are usually distributed together in a single file. Suc
 
 Here's an example of the most basic chain with one root CA and one leaf (server or client) certificate:
 
-<img class="figure" src="/img/root_ca_and_leaf.png" alt="Root CA and leaf certificates" />
+<img class="figure" src="./img/root_ca_and_leaf.png" alt="Root CA and leaf certificates" />
 
 A chain with intermediate certificates might look like this:
 
-<img class="figure" src="/img/root_intermediate_ca_and_leaf.png" alt="Root CA, intermediate and leaf certificates" />
+<img class="figure" src="./img/root_intermediate_ca_and_leaf.png" alt="Root CA, intermediate and leaf certificates" />
 
 There are organizations that sign and issue certificate/key pairs. Most of them are widely trusted CAs and charge a fee for their services.
 
@@ -204,7 +204,7 @@ ls -l ./result
 
 The certificate chain produced by this basic tls-gen profile looks like this:
 
-<img class="figure" src="/img/root_ca_and_leaf.png" alt="Root CA and leaf certificates" />
+<img class="figure" src="./img/root_ca_and_leaf.png" alt="Root CA and leaf certificates" />
 
 
 ## <a id="enabling-tls" class="anchor" href="#enabling-tls">Enabling TLS Support in RabbitMQ</a>
@@ -226,7 +226,7 @@ Here are the essential configuration settings related to TLS:
     <td><code>listeners.ssl</code></td>
     <td>
       A list of ports to listen on for TLS
-      connections. RabbitMQ can listen on a <a href="/networking.html">single interface or multiple ones</a>.
+      connections. RabbitMQ can listen on a <a href="./networking.html">single interface or multiple ones</a>.
     </td>
   </tr>
   <tr>
@@ -400,11 +400,11 @@ to as the <em>root CA</em> for the chain. Root CAs can be issued by well-known C
 
 Here's an example of the most basic chain with one root CA and one leaf (server or client) certificate:
 
-<img class="figure" src="/img/root_ca_and_leaf.png" alt="Root CA and leaf certificates" />
+<img class="figure" src="./img/root_ca_and_leaf.png" alt="Root CA and leaf certificates" />
 
 A chain with intermediate certificates might look like this:
 
-<img class="figure" src="/img/root_intermediate_ca_and_leaf.png" alt="Root CA, intermediate and leaf certificates" />
+<img class="figure" src="./img/root_intermediate_ca_and_leaf.png" alt="Root CA, intermediate and leaf certificates" />
 
 During peer verification TLS connection client (or server) traverses
 the chain of certificates presented by the peer

--- a/site/ssl.md
+++ b/site/ssl.md
@@ -48,10 +48,10 @@ A number of beginner-oriented primers are available elsewhere on the Web:
 [four](https://blogs.akamai.com/2016/03/enterprise-security---ssltls-primer-part-2---public-key-certificates.html).
 
 TLS can be enabled for all protocols supported by RabbitMQ, not just AMQP 0-9-1,
-which this guide focuses on. [HTTP API](/management.html), [inter-node and CLI tool traffic](/clustering-ssl.html) can be configured
+which this guide focuses on. [HTTP API](./management.html), [inter-node and CLI tool traffic](./clustering-ssl.html) can be configured
 to use TLS (HTTPS) as well.
 
-To configure TLS on Kubernetes using the RabbitMQ Cluster Operator, see the guide for [Configuring TLS](/kubernetes/operator/using-operator.html#tls).
+To configure TLS on Kubernetes using the RabbitMQ Cluster Operator, see the guide for [Configuring TLS](./kubernetes/operator/using-operator.html#tls).
 
 For an overview of common TLS troubleshooting techniques, see [Troubleshooting TLS-related issues](troubleshooting-ssl.html)
 and [Troubleshooting Networking](troubleshooting-networking.html).
@@ -73,7 +73,7 @@ that choose the second option.
 In order to support TLS connections, RabbitMQ needs TLS and
 crypto-related modules to be available in the Erlang/OTP
 installation. The recommended Erlang/OTP version to use with
-TLS is the most recent [supported Erlang release](/which-erlang.html).
+TLS is the most recent [supported Erlang release](./which-erlang.html).
 Earlier versions, even if they are supported, may work for most certificates
 but have known limitations (see below).
 
@@ -97,7 +97,7 @@ more information first.
 ### <a id="known-compatibility-issues" class="anchor" href="#known-compatibility-issues">Known Incompatibilities and Limitations</a>
 
 If Elliptic curve cryptography (ECC) cipher suites is
-expected to be used, a recent [supported Erlang release](/which-erlang.html)
+expected to be used, a recent [supported Erlang release](./which-erlang.html)
 is highly recommended. Earlier releases have known limitations around ECC support.
 
 If you face the above limitations or any other incompatibilities,
@@ -288,7 +288,7 @@ ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert = true
 </pre>
 
-TLS settings can also be configured using the [classic config format](/configure.html#erlang-term-config-file):
+TLS settings can also be configured using the [classic config format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 [
@@ -317,7 +317,7 @@ would need to use `"c:\\ca_certificate.pem"` or `"c:/ca_certificate.pem"`.
 
 ### <a id="enabling-tls-verify-configuration" class="anchor" href="#enabling-tls-verify-configuration">How to Verify that TLS is Enabled</a>
 
-To verify that TLS has been enabled on the node, restart it and inspect its [log file](/logging.html).
+To verify that TLS has been enabled on the node, restart it and inspect its [log file](./logging.html).
 It should contain an entry about a TLS listener being enabled, looking like this:
 
 <pre class="lang-plaintext">
@@ -349,7 +349,7 @@ ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.password   = t0p$3kRe7
 </pre>
 
-The same example using the [classic config format](/configure.html#erlang-term-config-file):
+The same example using the [classic config format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 [
@@ -522,7 +522,7 @@ ssl_options.verify = verify_peer
 ssl_options.fail_if_no_peer_cert = true
 </pre>
 
-The same example in the [classic config format](/configure.html#config-file):
+The same example in the [classic config format](./configure.html#config-file):
 
 <pre class="lang-erlang">
 [
@@ -591,7 +591,7 @@ ssl_options.depth  = 2
 ssl_options.fail_if_no_peer_cert = false
 </pre>
 
-The same example in the [classic config format](/configure.html#config-file):
+The same example in the [classic config format](./configure.html#config-file):
 
 <pre class="lang-erlang">
 [
@@ -1183,7 +1183,7 @@ TLS version by default, as demonstrated in the below table.
   </tbody>
 </table>
 
-Users of [older supported Erlang releases](/which-erlang.html)
+Users of [older supported Erlang releases](./which-erlang.html)
 are encouraged to limit supported TLS versions to 1.2 and later versions only, if possible.
 Consider TLSv1.0 and TLSv1.1 to be **deprecated by the industry**.
 
@@ -1270,10 +1270,10 @@ SSL-Session:
 ### <a id="tls1.3" class="anchor" href="#tls1.3">TLSv1.3</a>
 
 [TLSv1.3](https://wiki.openssl.org/index.php/TLS1.3) is a major revision to the TLS protocol. It is the most recent
-and secure option. Prior to [RabbitMQ `3.8.11`](/changelog.html), TLSv1.3 support was considered
+and secure option. Prior to [RabbitMQ `3.8.11`](./changelog.html), TLSv1.3 support was considered
 experimental and was disabled.
 
-TLSv1.3 support requires the node to be [running on Erlang 23](/which-erlang.html) compiled against a very recent OpenSSL.
+TLSv1.3 support requires the node to be [running on Erlang 23](./which-erlang.html) compiled against a very recent OpenSSL.
 
 
 Clients that use older runtimes (e.g. JDK, .NET, Python) without TLSv1.3 support
@@ -1427,7 +1427,7 @@ X509v3 extensions:
 
 It is possible to configure what cipher suites will be used by RabbitMQ. Note that not all
 suites will be available on all systems. For example, to use Elliptic curve ciphers,
-a recent [supported Erlang release](/which-erlang.html) must be used.
+a recent [supported Erlang release](./which-erlang.html) must be used.
 
 What cipher suites RabbitMQ nodes and clients used can also be effectively limited by the [public key usage fields](#key-usage)
 and their values. It is important to make sure that those key usage options are acceptable before proceeding
@@ -1450,12 +1450,12 @@ rabbitmq-diagnostics cipher_suites --format erlang -q
 </pre>
 
 then `rabbitmq-diagnostics cipher_suites` will list cipher suites in the format
-that's only accepted in the [classic config format](/configure.html#erlang-term-config-file). The OpenSSL format is accepted
+that's only accepted in the [classic config format](./configure.html#erlang-term-config-file). The OpenSSL format is accepted
 by both config formats. Note that cipher suites are not enquoted in the new style config format
 but double quotes are required in the classic format.
 
 The cipher suites listed by the above command are in formats that can be used for inbound and outgoing (e.g. [Shovel](shovel.html), [Federation](federation.html))
-client TLS connections. They are different from those used by [configuration value encryption](/configure.html#configuration-encryption).
+client TLS connections. They are different from those used by [configuration value encryption](./configure.html#configuration-encryption).
 
 When overriding cipher suites, it is highly recommended
 that server-preferred [cipher suite ordering is enforced](#cipher-suite-order).
@@ -1496,7 +1496,7 @@ ssl_options.honor_cipher_order = true
 ssl_options.honor_ecc_order    = true
 </pre>
 
-In the [classic config format](/configure.html#erlang-term-config-file):
+In the [classic config format](./configure.html#erlang-term-config-file):
 
 <pre class="lang-erlang">
 %% list allowed ciphers
@@ -1583,7 +1583,7 @@ Or, in the classic config format:
 
 [ROBOT attack](https://robotattack.org/) affects RabbitMQ installations that rely on RSA
 cipher suites and run on Erlang/OTP versions prior to
-19.3.6.4 and 20.1.7. To mitigate, [upgrade Erlang/OTP](/which-erlang.html) to a patched version
+19.3.6.4 and 20.1.7. To mitigate, [upgrade Erlang/OTP](./which-erlang.html) to a patched version
 and consider [limiting the list of supported cipher suites](#cipher-suites).
 
 #### POODLE

--- a/site/stomp.md
+++ b/site/stomp.md
@@ -24,14 +24,14 @@ in the core distribution. The plugin supports STOMP versions 1.0 through [1.2](h
 with some [extensions and restrictions](#extensions-and-restrictions).
 
 STOMP clients can interoperate with other protocols. All the functionality in
-the [management UI](/management.html) and several other plugins can be
+the [management UI](./management.html) and several other plugins can be
 used with STOMP, although there may be some limitations or the need to
 tweak the defaults.
 
 ## <a id="enabling-plugin" class="anchor" href="#enabling-plugin">Enabling the Plugin</a>
 
 The STOMP plugin is included in the RabbitMQ distribution. Before clients can successfully
-connect, it must be enabled using [rabbitmq-plugins](/cli.html):
+connect, it must be enabled using [rabbitmq-plugins](./cli.html):
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_stomp
@@ -46,7 +46,7 @@ all interfaces on port 61613 and have a default user login/passcode
 of `guest`/`guest`.
 
 To change the listener port, edit your
-[Configuration file](/configure.html#configuration-files),
+[Configuration file](./configure.html#configuration-files),
 to contain a `tcp_listeners` variable for the `rabbitmq_stomp` application.
 
 For example, a minimalistic configuration file which changes the listener
@@ -69,7 +69,7 @@ stomp.listeners.tcp.2 = ::1:61613
 The plugin supports TCP listener option configuration.
 
 The settings use a common prefix, `stomp.tcp_listen_options`, and control
-things such as TCP buffer sizes, inbound TCP connection queue length, whether [TCP keepalives](/heartbeats.html#tcp-keepalives)
+things such as TCP buffer sizes, inbound TCP connection queue length, whether [TCP keepalives](./heartbeats.html#tcp-keepalives)
 are enabled and so on. See the [Networking guide](networking.html) for details.
 
 <pre class="lang-ini">
@@ -89,7 +89,7 @@ stomp.tcp_listen_options.send_timeout  = 120
 
 ## <a id="tls" class="anchor" href="#tls">TLS Support</a>
 
-To use TLS for STOMP connections, [TLS must be configured](/ssl.html) in the broker. To enable
+To use TLS for STOMP connections, [TLS must be configured](./ssl.html) in the broker. To enable
 TLS-enabled STOMP connections, add a TLS listener for STOMP using the `stomp.listeners.ssl.*` configuration keys.
 
 The plugin will use core RabbitMQ server
@@ -199,7 +199,7 @@ This feature is disabled by default. To enable it for STOMP clients:
 stomp.proxy_protocol = true
 </pre>
 
-See the [Networking Guide](/networking.html#proxy-protocol) for more information
+See the [Networking Guide](./networking.html#proxy-protocol) for more information
 about the proxy protocol.
 
 
@@ -310,7 +310,7 @@ Perhaps the most common destination type used by STOMP clients is `/topic/<name>
 They perform topic matching on publishing messages against subscriber patterns
 and can route a message to multiple subscribers (each gets its own copy).
 Topic destinations support all the routing patterns of [AMQP 0-9-1
-topic exchanges](/tutorials/amqp-concepts.html).
+topic exchanges](./tutorials/amqp-concepts.html).
 
 Messages sent to a topic destination that has no active subscribers
 are simply discarded.
@@ -471,7 +471,7 @@ queue and message TTL, queue limits, etc:
  * `x-max-length-bytes`
  * `x-overflow`
  * `x-max-priority`
- * `x-queue-type` (to be able to [declare](/quorum-queues.html#declaring) [quorum queues](/quorum-queues.html))
+ * `x-queue-type` (to be able to [declare](./quorum-queues.html#declaring) [quorum queues](./quorum-queues.html))
 
 The meaning of every header is the same as when a queue is declared over AMQP 0-9-1.
 Please consult the rest of the documentation for details.
@@ -569,7 +569,7 @@ on `SUBSCRIBE` frames to the desired integer count.
 ### <a id="stream-support" class="anchor" href="#stream-support">Stream Support</a>
 
 The `SUBSCRIBE` frame supports a `x-stream-offset` header to specify the offset
-to start consuming from in a [stream](/streams.html). A typical subscription frame
+to start consuming from in a [stream](./streams.html). A typical subscription frame
 for a stream will look like the following:
 
     SUBSCRIBE
@@ -579,7 +579,7 @@ for a stream will look like the following:
     x-stream-offset:next
 
 Note the `ack` and `prefetch-count` headers are also necessary. The `x-stream-offset` header
-has the same semantics as in [AMQP 0.9.1](/streams.html#consuming), the possible values are:
+has the same semantics as in [AMQP 0.9.1](./streams.html#consuming), the possible values are:
 
  * `first` to start consuming from the first available message in the stream
  * `last` to start consuming from the last written chunk of messages
@@ -623,17 +623,17 @@ rules apply:
 ### Optional Queue Properties
 
 With RabbitMQ, `SEND` and `SUBSCRIBE` frames can include a set of headers to configure the queue behaviour,
-for example, use [TTL](/ttl.html) or similar extensions.
+for example, use [TTL](./ttl.html) or similar extensions.
 
 The list of supported headers is
 
- * [x-message-ttl](/ttl.html#per-message-ttl)
- * [x-expires](/ttl.html#queue-ttl)
- * [x-max-length](/maxlength.html)
- * [x-max-length-bytes](/maxlength.html)
- * [x-dead-letter-exchange](/dlx.html)
- * [x-dead-letter-routing-key](/dlx.html)
- * [x-max-priority](/priority.html)
+ * [x-message-ttl](./ttl.html#per-message-ttl)
+ * [x-expires](./ttl.html#queue-ttl)
+ * [x-max-length](./maxlength.html)
+ * [x-max-length-bytes](./maxlength.html)
+ * [x-dead-letter-exchange](./dlx.html)
+ * [x-dead-letter-routing-key](./dlx.html)
+ * [x-max-priority](./priority.html)
 
 For example, if you want to use priority queues with STOMP, you
 can SUBSCRIBE (or SEND) with the following header:
@@ -645,5 +645,5 @@ can SUBSCRIBE (or SEND) with the following header:
 ### Queue Immutability
 
 Once a queue is declared, its properties cannot be changed. Optional arguments
-can be modified with [policies](/parameters.html). Otherwise the queue has to be deleted
+can be modified with [policies](./parameters.html). Otherwise the queue has to be deleted
 and re-declared. This is true for STOMP clients as well as AMQP 0-9-1.

--- a/site/stream.md
+++ b/site/stream.md
@@ -37,7 +37,7 @@ and the [RabbitMQ Stream Go Client](https://github.com/rabbitmq/rabbitmq-stream-
 ## <a id="enabling-plugin" class="anchor" href="#enabling-plugin">Enabling the Plugin</a>
 
 The Stream plugin is included in the RabbitMQ distribution. Before clients can successfully
-connect, it must be enabled using [rabbitmq-plugins](/cli.html):
+connect, it must be enabled using [rabbitmq-plugins](./cli.html):
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_stream
@@ -52,7 +52,7 @@ all interfaces on port 5552 and have a default user login/passcode
 of `guest`/`guest`.
 
 The port stream listener will listen on can be changed
-via [`rabbitmq.conf`](/configure.html#configuration-files).
+via [`rabbitmq.conf`](./configure.html#configuration-files).
 
 Below is a minimalistic configuration file which changes the listener
 port to 12345:
@@ -74,8 +74,8 @@ stream.listeners.tcp.2 = ::1:5552
 The plugin supports TCP listener option configuration.
 
 The settings use a common prefix, `stream.tcp_listen_options`, and control
-things such as TCP buffer sizes, inbound TCP connection queue length, whether [TCP keepalives](/heartbeats.html#tcp-keepalives)
-are enabled and so on. See the [Networking guide](/networking.html) for details.
+things such as TCP buffer sizes, inbound TCP connection queue length, whether [TCP keepalives](./heartbeats.html#tcp-keepalives)
+are enabled and so on. See the [Networking guide](./networking.html) for details.
 
 <pre class="lang-ini">
 stream.listeners.tcp.1 = 127.0.0.1:5552
@@ -140,7 +140,7 @@ The [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-t
 
 ## <a id="tls" class="anchor" href="#tls">TLS Support</a>
 
-To use TLS for stream connections, [TLS must be configured](/ssl.html) in the broker. To enable
+To use TLS for stream connections, [TLS must be configured](./ssl.html) in the broker. To enable
 TLS-enabled stream connections, add a TLS listener for streams using the `stream.listeners.ssl.*` configuration keys.
 
 The plugin will use core RabbitMQ server

--- a/site/streams.md
+++ b/site/streams.md
@@ -27,7 +27,7 @@ plugin and associated client(s). The latter option is recommended as it
 provides access to all stream-specific features and offers best possible throughput (performance).
 
 This page covers the concepts of streams, their usage, and
-their administration and maintenance operations. Please visit the [Stream plugin](/stream.html)
+their administration and maintenance operations. Please visit the [Stream plugin](./stream.html)
 page to learn more about the usage of streams with the binary RabbitMQ Stream protocol.
 
 ### <a id="use-cases" class="anchor" href="#use-cases">Use Cases</a>
@@ -67,7 +67,7 @@ existing queue types either can not provide or provide with downsides:
 
 ## <a id="usage" class="anchor" href="#usage">Usage</a>
 
-An AMQP 0.9.1 client library that can specify [optional queue and consumer arguments](/queues.html#optional-arguments)
+An AMQP 0.9.1 client library that can specify [optional queue and consumer arguments](./queues.html#optional-arguments)
 will be able to use streams as regular AMQP 0.9.1 queues.
 
 Just like queues, streams have to be declared first.
@@ -76,11 +76,11 @@ Just like queues, streams have to be declared first.
 
 To declare a stream, set the `x-queue-type` queue argument to `stream`
 (the default is `classic`). This argument must be provided by a client
-at declaration time; it cannot be set or changed using a [policy](/parameters.html#policies).
+at declaration time; it cannot be set or changed using a [policy](./parameters.html#policies).
 This is because policy definition or applicable policy can be changed dynamically but
 queue type cannot. It must be specified at the time of declaration.
 
-The following snippet shows how to create a stream with the [AMQP 0.9.1 Java client](/api-guide.html):
+The following snippet shows how to create a stream with the [AMQP 0.9.1 Java client](./api-guide.html):
 
 <pre class="lang-java">
 ConnectionFactory factory = new ConnectionFactory();
@@ -101,11 +101,11 @@ so uneven cluster sizes is strongly recommended.
 A stream remains an AMQP 0.9.1 queue, so it can be bound to any exchange after its creation,
 just as any other RabbitMQ queue.
 
-If declaring using [management UI](/management.html), the `stream` type must be specified using
+If declaring using [management UI](./management.html), the `stream` type must be specified using
 the queue type drop down menu.
 
-Streams support 3 additional [queue arguments](/queues.html#optional-arguments)
-that are best configured using a [policy](/parameters.html#policies)
+Streams support 3 additional [queue arguments](./queues.html#optional-arguments)
+that are best configured using a [policy](./parameters.html#policies)
 
 * `x-max-length-bytes`
 
@@ -216,12 +216,12 @@ but some have some queue specific behaviour.
 
  * [Declaration](#declaring)
  * Queue deletion
- * [Publisher confirms](/confirms.html#publisher-confirms)
- * [Consumption](/consumers.html) (subscription): consumption requires QoS
+ * [Publisher confirms](./confirms.html#publisher-confirms)
+ * [Consumption](./consumers.html) (subscription): consumption requires QoS
  prefetch to be set. The acks works as a credit mechanism to advance the current
  offset of the consumer.
  * Setting [QoS prefetch](#global-qos) for consumers
- * [Consumer acknowledgements](/confirms.html) (keep [QoS Prefetch Limitations](#global-qos) in mind)
+ * [Consumer acknowledgements](./confirms.html) (keep [QoS Prefetch Limitations](#global-qos) in mind)
  * Cancellation of consumers
 
 ## <a id="feature-comparison" class="anchor" href="#feature-comparison">Feature Comparison with Regular Queues</a>
@@ -240,47 +240,47 @@ read semantics.
 
 | Feature | Classic | Stream |
 | :-------- | :------- | ------ |
-| [Non-durable queues](/queues.html) | yes | no |
-| [Exclusivity](/queues.html) | yes | no |
+| [Non-durable queues](./queues.html) | yes | no |
+| [Exclusivity](./queues.html) | yes | no |
 | Per message persistence | per message | always |
 | Membership changes | automatic | manual  |
-| [TTL](/ttl.html) | yes | no (but see [Retention](#retention)) |
-| [Queue length limits](/maxlength.html) | yes | no (but see [Retention](#retention))|
-| [Lazy behaviour](/lazy-queues.html) | yes | inherent |
-| [Message priority](/priority.html) | yes | no |
-| [Consumer priority](/consumer-priority.html) | yes | no |
-| [Dead letter exchanges](/dlx.html) | yes | no |
-| Adheres to [policies](/parameters.html#policies) | yes | (see [Retention](#retention)) |
-| Reacts to [memory alarms](/alarms.html) | yes | no (uses minimal RAM) |
+| [TTL](./ttl.html) | yes | no (but see [Retention](#retention)) |
+| [Queue length limits](./maxlength.html) | yes | no (but see [Retention](#retention))|
+| [Lazy behaviour](./lazy-queues.html) | yes | inherent |
+| [Message priority](./priority.html) | yes | no |
+| [Consumer priority](./consumer-priority.html) | yes | no |
+| [Dead letter exchanges](./dlx.html) | yes | no |
+| Adheres to [policies](./parameters.html#policies) | yes | (see [Retention](#retention)) |
+| Reacts to [memory alarms](./alarms.html) | yes | no (uses minimal RAM) |
 | Poison message handling | no | no |
 | Global [QoS Prefetch](#global-qos) | yes | no |
 
 #### Non-durable Queues
 
 Streams are always durable per their assumed [use cases](#use-cases),
-they cannot be [non-durable](/queues.html#properties) like regular queues.
+they cannot be [non-durable](./queues.html#properties) like regular queues.
 
 #### Exclusivity
 
 Streams are always durable per their assumed [use cases](#use-cases), they cannot be
-[exclusive](/queues.html#exclusive-queues) like regular queues.
-They are not meant to be used as [temporary queues](/queues.html#temporary-queues).
+[exclusive](./queues.html#exclusive-queues) like regular queues.
+They are not meant to be used as [temporary queues](./queues.html#temporary-queues).
 
 
 #### Lazy Mode
 
 Streams store all data directly on disk, after a message has been written
-it does not use any memory until it is read. Streams are inherently [lazy](/lazy-queues.html), so to speak.
+it does not use any memory until it is read. Streams are inherently [lazy](./lazy-queues.html), so to speak.
 
 
 #### <a id="global-qos" class="anchor" href="#global-qos">Global QoS</a>
 
-Streams do not support global [QoS prefetch](/confirms.html#channel-qos-prefetch) where a channel sets a single
+Streams do not support global [QoS prefetch](./confirms.html#channel-qos-prefetch) where a channel sets a single
 prefetch limit for all consumers using that channel. If an attempt
 is made to consume from a stream from a channel with global QoS enabled
 a channel error will be returned.
 
-Use [per-consumer QoS prefetch](/consumer-prefetch.html), which is the default in several popular clients.
+Use [per-consumer QoS prefetch](./consumer-prefetch.html), which is the default in several popular clients.
 
 ## <a id="retention" class="anchor" href="#retention">Data Retention</a>
 
@@ -337,7 +337,7 @@ to a replica set of a stream.
 When a node has to be decommissioned (permanently removed from the cluster), it must be explicitly
 removed from the replica list of all streams it currently hosts replicas for.
 
-Two [CLI commands](/cli.html) are provided to perform the above operations,
+Two [CLI commands](./cli.html) are provided to perform the above operations,
 `rabbitmq-streams add_replica` and `rabbitmq-streams delete_replica`:
 
 <pre class="lang-bash">
@@ -454,7 +454,7 @@ system buffer or otherwise fail to reach the stream leader.
 A stream should be able to tolerate a minority of stream replicas becoming unavailable
 with no or little effect on availability.
 
-Note that depending on the [partition handling strategy](/partitions.html)
+Note that depending on the [partition handling strategy](./partitions.html)
 used RabbitMQ may restart itself during recovery and reset the node but as long as that
 does not happen, this availability guarantee should hold true.
 
@@ -480,7 +480,7 @@ All data is stored on disk with only unwritten data stored in memory.
 ## <a id="offset-tracking" class="anchor" href="#offset-tracking">Offset Tracking</a>
 
 When using the broker provided offset tracking features (currently only available
-when using the [Stream plugin](/stream.html)) offsets are persisted in the stream
+when using the [Stream plugin](./stream.html)) offsets are persisted in the stream
 itself as non-message data. This means that as offset persistence is requested the
 stream will grow on disk by some small amount per offset persistence request.
 

--- a/site/trademark-guidelines.md
+++ b/site/trademark-guidelines.md
@@ -35,7 +35,7 @@ limitations under the License.
         <p>
           <strong>Logos:</strong>
         </p>
-        <img src="/img/rabbitmq_logo_strap.png"/>
+        <img src="./img/rabbitmq_logo_strap.png"/>
       </li>
     </ol>
     <p>

--- a/site/troubleshooting-networking.md
+++ b/site/troubleshooting-networking.md
@@ -22,7 +22,7 @@ limitations under the License.
 This guide accompanies the one [on networking](networking.html) and focuses on troubleshooting of
 network connections.
 
-For connections that use TLS there is an additional [guide on troubleshooting TLS](/troubleshooting-ssl.html).
+For connections that use TLS there is an additional [guide on troubleshooting TLS](./troubleshooting-ssl.html).
 
 ## <a id="methodology" class="anchor" href="#methodology">Troubleshooting Methodology</a>
 
@@ -45,7 +45,7 @@ are often effective and sufficient:
  * Verify what TCP [port are used and their accessibility](#ports)
  * Verify [IP routing](#ip-routing)
  * If needed, [take and analyze a traffic dump](#traffic-capture) (traffic capture)
- * Verify that clients can [successfully authenticate](/access-control.html#troubleshooting-authn)
+ * Verify that clients can [successfully authenticate](./access-control.html#troubleshooting-authn)
 
 These steps, when performed in sequence, usually help identify the root cause of
 the vast majority of networking issues. Troubleshooting tools and techniques for
@@ -53,7 +53,7 @@ levels lower than the [Internet (networking) layer](https://en.wikipedia.org/wik
 are outside of the scope of this guide.
 
 Certain problems only happen in environments with a [high degree of connection churn](#detecting-high-connection-churn).
-Client connections can be inspected using the [management UI](/management.html).
+Client connections can be inspected using the [management UI](./management.html).
 It is also possible to [inspect all TCP connections of a node and their state](#inspecting-connections).
 That information collected over time, combined with server logs, will help detect connection churn,
 file descriptor exhaustion and related issues.
@@ -73,7 +73,7 @@ with the expected set of settings related to networking. It also verifies
 that the node is actually running. Here are the recommended steps:
 
  * Make sure the node is running using <code>[rabbitmq-diagnostics][2] status</code>
- * Verify [config file is correctly placed and has correct syntax/structure](/configure.html#configuration-files)
+ * Verify [config file is correctly placed and has correct syntax/structure](./configure.html#configuration-files)
  * Inspect listeners using <code>[rabbitmq-diagnostics][2] listeners</code>
    or the `listeners` section in <code>[rabbitmq-diagnostics][2] status</code>
  * Inspect effective configuration using <code>[rabbitmq-diagnostics][2] environment</code>
@@ -98,30 +98,30 @@ Interface: [::], port: 1883, protocol: mqtt, purpose: MQTT
 
 In the above example, there are 6 TCP listeners on the node:
 
- * [Inter-node](/clustering.html) and [CLI tool](/cli.html) communication on port `25672`
+ * [Inter-node](./clustering.html) and [CLI tool](./cli.html) communication on port `25672`
  * AMQP 0-9-1 (and 1.0, if enabled) listener for non-TLS connections on port `5672`
  * AMQP 0-9-1 (and 1.0, if enabled) listener for TLS-enabled connections on port `5671`
- * [HTTP API](/management.html) listeners on ports 15672 (HTTP) and 15671 (HTTPS)
- * [MQTT](/mqtt.html) listener for non-TLS connections 1883
+ * [HTTP API](./management.html) listeners on ports 15672 (HTTP) and 15671 (HTTPS)
+ * [MQTT](./mqtt.html) listener for non-TLS connections 1883
 
 In second example, there are 4 TCP listeners on the node:
 
- * [Inter-node](/clustering.html) and [CLI tool](/cli.html) communication on port `25672`
+ * [Inter-node](./clustering.html) and [CLI tool](./cli.html) communication on port `25672`
  * AMQP 0-9-1 (and 1.0, if enabled) listener for non-TLS connections, `5672`
  * AMQP 0-9-1 (and 1.0, if enabled) listener for TLS-enabled connections, `5671`
- * [HTTP API](/management.html) listener on ports 15672 (HTTP only)
+ * [HTTP API](./management.html) listener on ports 15672 (HTTP only)
 
 All listeners are bound to all available interfaces.
 
 Inspecting TCP listeners used by a node helps spot non-standard port configuration,
-protocol plugins (e.g. [MQTT](/mqtt.html)) that are supposed to be configured but aren't,
+protocol plugins (e.g. [MQTT](./mqtt.html)) that are supposed to be configured but aren't,
 cases when the node is limited to only a few network interfaces, and so on. If a port is not on the
 listener list it means the node cannot accept any connections on it.
 
 ## <a id="server-logs" class="anchor" href="#server-logs">Inspect Server Logs</a>
 
-RabbitMQ nodes will [log](/logging.html) key
-client [connection lifecycle events](/logging.html#connection-lifecycle-events).
+RabbitMQ nodes will [log](./logging.html) key
+client [connection lifecycle events](./logging.html#connection-lifecycle-events).
 A TCP connection must be successfully established and at least 1 byte of data must be
 sent by the peer for a connection to be considered (and logged as) accepted.
 
@@ -255,11 +255,11 @@ All network activity can be inspected, filtered and analyzed using a traffic cap
 
 [tcpdump](https://en.wikipedia.org/wiki/Tcpdump) and its GUI sibling [Wireshark](https://www.wireshark.org)
 are the industry standards for capturing traffic, filtering and analysis. Both support all protocols supported by RabbitMQ.
-See the [Using Wireshark with RabbitMQ](/amqp-wireshark.html) guide for an overview.
+See the [Using Wireshark with RabbitMQ](./amqp-wireshark.html) guide for an overview.
 
 ## <a id="tls" class="anchor" href="#tls">TLS Connections</a>
 
-For connections that use TLS there is a separate [guide on troubleshooting TLS](/troubleshooting-ssl.html).
+For connections that use TLS there is a separate [guide on troubleshooting TLS](./troubleshooting-ssl.html).
 
 When adopting TLS it is important to make sure that clients
 use correct port to connect (see the list of ports above)
@@ -289,7 +289,7 @@ sudo netstat --all --numeric --tcp --programs
 Both inbound (client, peer nodes, CLI tools) and outgoing (peer nodes,
 Federation links and Shovels) connections can be inspected this way.
 
-<code>[rabbitmqctl][1] list_connections</code>, [management UI](/management.html)
+<code>[rabbitmqctl][1] list_connections</code>, [management UI](./management.html)
 can be used to inspect more connection properties, some of which are RabbitMQ- or
 messaging protocol-specific:
 
@@ -306,14 +306,14 @@ messaging protocol-specific:
 Combining connection information from management UI or CLI tools with those of `netstat` or `ss`
 can help troubleshoot misbehaving applications, application instances and client libraries.
 
-Most relevant connection metrics can be collected, aggregated and [monitored](/monitoring.html)
-using [Prometheus and Grafana](/prometheus.html).
+Most relevant connection metrics can be collected, aggregated and [monitored](./monitoring.html)
+using [Prometheus and Grafana](./prometheus.html).
 
 
 ## <a id="detecting-high-connection-churn" class="anchor" href="#detecting-high-connection-churn">Detecting High Connection Churn</a>
 
 High connection churn (lots of connections opened and closed after a brief
-period of time) [can lead to resource exhaustion](/networking.html#dealing-with-high-connection-churn).
+period of time) [can lead to resource exhaustion](./networking.html#dealing-with-high-connection-churn).
 It is therefore important to be able to identify such scenarios. `netstat` and `ss`
 are most popular options for [inspecting TCP connections](#inspecting-connections).
 A lot of connections in the `TIME_WAIT` state is a likely symptom of high connection churn.

--- a/site/troubleshooting-ssl.md
+++ b/site/troubleshooting-ssl.md
@@ -20,7 +20,7 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 This guide covers a methodology and some tooling that can help diagnose TLS connectivity issues and errors (TLS alerts).
-It accompanies the main guide on [TLS in RabbitMQ](/ssl.html).
+It accompanies the main guide on [TLS in RabbitMQ](./ssl.html).
 The strategy is to test the required components with an alternative TLS
 implementation in the process of elimination to identify the problematic end (client or server).
 
@@ -39,7 +39,7 @@ The steps recommended in this guide are:
  * And finally, test a real client connection against a real server connection again
 
 When testing with a RabbitMQ node and/or a real RabbitMQ client it is important to inspect
-[logs](/logging.html) for both server and client.
+[logs](./logging.html) for both server and client.
 
 ## <a id="verify-config" class="anchor" href="#verify-config">Check Effective Node Configuration</a>
 
@@ -55,8 +55,8 @@ for details.
 This step checks that the broker is listening on the [expected port(s)](networking.html), such as
 5671 for AMQP 0-9-1 and 1.0, 8883 for MQTT, and so on.
 
-To verify that TLS has been enabled on the node, use <code>[rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html) listeners</code>
-or the <code>listeners</code> section in <code>[rabbitmq-diagnostics](/rabbitmq-diagnostics.8.html) status</code>.
+To verify that TLS has been enabled on the node, use <code>[rabbitmq-diagnostics](./rabbitmq-diagnostics.8.html) listeners</code>
+or the <code>listeners</code> section in <code>[rabbitmq-diagnostics](./rabbitmq-diagnostics.8.html) status</code>.
 
 The listeners section will look something like this:
 
@@ -74,10 +74,10 @@ In the above example, there are 6 TCP listeners on the node. Two of them accept 
  * Inter-node and CLI tool communication on port <code>25672</code>
  * AMQP 0-9-1 (and 1.0, if enabled) listener for non-TLS connections on port <code>5672</code>
  * AMQP 0-9-1 (and 1.0, if enabled) listener for TLS-enabled connections on port <code>5671</code>
- * [HTTP API](/management.html) listeners on ports 15672 (HTTP) and 15671 (HTTPS)
- * [MQTT](/mqtt.html) listener for non-TLS connections 1883
+ * [HTTP API](./management.html) listeners on ports 15672 (HTTP) and 15671 (HTTPS)
+ * [MQTT](./mqtt.html) listener for non-TLS connections 1883
 
-If the above steps are not an option, inspecting node's [log file](/logging.html) can be a viable alternative.
+If the above steps are not an option, inspecting node's [log file](./logging.html) can be a viable alternative.
 It should contain an entry about a TLS listener being enabled, looking like this:
 
 <pre class="lang-plaintext">
@@ -88,11 +88,11 @@ It should contain an entry about a TLS listener being enabled, looking like this
 If the node is configured to use TLS but a message similar to the above is not logged,
 it is possible that the configuration file was placed at an incorrect location and was not read by
 the broker or the node was not restarted after config file changes.
-See the [configuration page](/configure.html#introduction) for details
+See the [configuration page](./configure.html#introduction) for details
 on config file verification.
 
 Tools such as <code>lsof</code> and <code>netstat</code> can be used to verify what ports
-a node is listening on, as covered in the [Troubleshooting Networking](/troubleshooting-networking.html) guide.
+a node is listening on, as covered in the [Troubleshooting Networking](./troubleshooting-networking.html) guide.
 
 ## <a id="verify-file-permissions" class="anchor" href="#verify-file-permissions">Check Certificate, Private Key and CA Bundle File Permissions</a>
 
@@ -107,7 +107,7 @@ When certificate or private key files are not readable or do not exist,
 the node will fail to accept TLS-enabled connections or TLS connections will just hang (the behavior
 differs between Erlang/OTP versions).
 
-When [new style configuration format](/configure.html#config-file-formats) is used to configure certificate and private
+When [new style configuration format](./configure.html#config-file-formats) is used to configure certificate and private
 key paths, the node will check if the files exist on boot and refuse to start if that's not the case.
 
 ## <a id="verify-tls-support-in-erlang" class="anchor" href="#verify-tls-support-in-erlang">Check TLS Support in Erlang</a>
@@ -157,7 +157,7 @@ The output in this case will look like so:
  {available_dtls,['dtlsv1.2',dtlsv1]}]
 </pre>
 
-If an error is reported instead, confirm that the Erlang/OTP installation [includes TLS support](/ssl.html#erlang-otp-requirements).
+If an error is reported instead, confirm that the Erlang/OTP installation [includes TLS support](./ssl.html#erlang-otp-requirements).
 
 It is also possible to list cipher suites available on a node:
 
@@ -199,7 +199,7 @@ The example below seeks to confirm that the certificates and keys can be used to
 establish a TLS connection by connecting an <code>s_client</code> client to an <code>s_server</code> server
 in two separate shells (terminal windows).
 
-The example will assume you have the following [certificate and key files](/ssl.html#certificates-and-keys)
+The example will assume you have the following [certificate and key files](./ssl.html#certificates-and-keys)
 (these filenames are used by [tls-gen](https://github.com/rabbitmq/tls-gen)):
 
 <table>
@@ -257,7 +257,7 @@ If the certificates and keys have been correctly created, a TLS connection outpu
 will appear in both tabs. There is now a connection between the example client and the example
 server, similar to <code>telnet</code>.
 
-If the [trust chain](/ssl.html#peer-verification) could be established, the second terminal will display
+If the [trust chain](./ssl.html#peer-verification) could be established, the second terminal will display
 a verification confirmation with the code of <code>0</code>:
 
 <pre class="lang-ini">
@@ -277,13 +277,13 @@ we recommend using [tls-gen](https://github.com/rabbitmq/tls-gen) for generation
 
 ## <a id="verify-cipher-suites" class="anchor" href="#verify-cipher-suites">Validate Available Cipher Suites</a>
 
-RabbitMQ nodes and clients can be limited in what [cipher suites](/ssl.html#cipher-suite) they are allowed
+RabbitMQ nodes and clients can be limited in what [cipher suites](./ssl.html#cipher-suite) they are allowed
 to use during TLS handshake. It is important to make sure that the two sides have
 some cipher suites in common or otherwise the handshake will fail.
 
 Certificate's key usage properties can also limit what cipher suites can be used.
 
-See [Configuring Cipher Suites](/ssl.html#cipher-suites) and [Public Key Usage Extensions](/ssl.html#key-usage) in the main TLS guide
+See [Configuring Cipher Suites](./ssl.html#cipher-suites) and [Public Key Usage Extensions](./ssl.html#key-usage) in the main TLS guide
 to learn more.
 
 <pre class="lang-bash">
@@ -306,7 +306,7 @@ openssl s_client -connect localhost:5671 -cert client_certificate.pem -key clien
 </pre>
 
 The output should appear similar to the case where port 8443 was used. The node log file
-should [contain a new entry when the connection is established](/logging.html#logged-events):
+should [contain a new entry when the connection is established](./logging.html#logged-events):
 
 <pre class="lang-ini">
 2018-09-27 15:46:20 [info] &lt;0.1082.0&gt; accepting AMQP connection &lt;0.1082.0&gt; (127.0.0.1:50915 -> 127.0.0.1:5671)
@@ -364,8 +364,8 @@ or `stunnel` instances first.
 
 ## <a id="verify-verification-depth" class="anchor" href="#verify-verification-depth">Certificate Chains and Verification Depth</a>
 
-When using a client certificate [signed by an intermediate CA](/ssl.html#peer-verification), it may be necessary
-to configure RabbitMQ server to use a higher [verification depth](/ssl.html#peer-verification-depth).
+When using a client certificate [signed by an intermediate CA](./ssl.html#peer-verification), it may be necessary
+to configure RabbitMQ server to use a higher [verification depth](./ssl.html#peer-verification-depth).
 
 Insufficient verification depth will result in TLS peer verification failures.
 

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -43,49 +43,49 @@ TLS, and more.
 
 ## <a id="monitoring" class="anchor" href="#monitoring">Monitoring, Metrics, Health Checks</a>
 
-A very important aspect of troubleshooting a production system is [monitoring and health checks](/monitoring.html).
+A very important aspect of troubleshooting a production system is [monitoring and health checks](./monitoring.html).
 They collect data that can be inspected and analysed, helping identify and detect anomalies.
 
 ## <a id="logging" class="anchor" href="#logging">Logging</a>
 
-Logs is another important source of information for troubleshooting. Separate [guide on logging](/logging.html)
+Logs is another important source of information for troubleshooting. Separate [guide on logging](./logging.html)
 explains where to find log files, how to adjust log levels, what log categories exist, connection
 lifecycle events that can be detected using log files, and more.
 
 
 ## <a id="configuration" class="anchor" href="#configuration">Node Configuration</a>
 
-[Configuration guide](/configure.html) contains a section on [locating config file](/configure.html#verify-configuration-config-file-location).
+[Configuration guide](./configure.html) contains a section on [locating config file](./configure.html#verify-configuration-config-file-location).
 
-Effective node configuration can be inspected using <code>[rabbitmqctl](/cli.html) environment</code> as
-well as a number of [rabbitmq-diagnostics](/cli.html) commands.
+Effective node configuration can be inspected using <code>[rabbitmqctl](./cli.html) environment</code> as
+well as a number of [rabbitmq-diagnostics](./cli.html) commands.
 
 
 ## <a id="cli" class="anchor" href="#cli">CLI Tools Connectivity and Authentication</a>
 
-[CLI Tools guide](/cli.html#erlang-cookie) explains how CLI tools authenticate to nodes, what the Erlang
+[CLI Tools guide](./cli.html#erlang-cookie) explains how CLI tools authenticate to nodes, what the Erlang
 cookie file is, and most common reasons why CLI tools fail to perform operations on server nodes.
 
 
 ## <a id="cluster-formation" class="anchor" href="#cluster-formation">Cluster Formation</a>
 
-[Cluster Formation guide](/cluster-formation.html) contains a [troubleshooting section](/cluster-formation.html#troubleshooting-cluster-formation).
+[Cluster Formation guide](./cluster-formation.html) contains a [troubleshooting section](./cluster-formation.html#troubleshooting-cluster-formation).
 
 
 ## <a id="memory-usage" class="anchor" href="#memory-usage">Memory Usage Analysis</a>
 
-[Reasoning About Memory Use](/memory-use.html) is a dedicated guide on the topic.
+[Reasoning About Memory Use](./memory-use.html) is a dedicated guide on the topic.
 
 
 ## <a id="networking" class="anchor" href="#networking">Networking and Connectivity</a>
 
-[Troubleshooting Networking](/troubleshooting-networking.html) is a dedicated guide on the topic of networking and connectivity.
+[Troubleshooting Networking](./troubleshooting-networking.html) is a dedicated guide on the topic of networking and connectivity.
 
 
 ## <a id="authentication" class="anchor" href="#authentication">Authentication and Authorisation</a>
 
-[Access Control guide](/access-control.html) contains sections on [troubleshooting client authentication](/access-control.html#troubleshooting-authn)
-and [troubleshooting authorisation](/access-control.html#troubleshooting-authz).
+[Access Control guide](./access-control.html) contains sections on [troubleshooting client authentication](./access-control.html#troubleshooting-authn)
+and [troubleshooting authorisation](./access-control.html#troubleshooting-authz).
 
 
 ## <a id="crash-dumps" class="anchor" href="#crash-dumps">Runtime Crash Dump Files</a>
@@ -103,7 +103,7 @@ head -n 3 ./erl_crash.dump
 </pre>
 
 In this specific example, the slogan (uncaught exception message) says that a started node
-timed out [syncing schema metadata from its peers](/clustering.html#restarting), likely because they did not come online
+timed out [syncing schema metadata from its peers](./clustering.html#restarting), likely because they did not come online
 in the configured window of time.
 
 To better understand the state of the Erlang runtime from a <a href="http://erlang.org/doc/apps/erts/crash_dump.html" target="_blank">crash dump file</a>, it
@@ -118,7 +118,7 @@ This is an example of how to invoke it:
 
 A successful result of the above command will open a new application window similar to this:
 
-![Erlang Crash Dump Viewer](/img/erlang-crash-dump-viewer.png)
+![Erlang Crash Dump Viewer](./img/erlang-crash-dump-viewer.png)
 
 For the above to work, the system must have a graphical user interface, and
 Erlang must have been complied with both observer & Wx support.
@@ -132,22 +132,22 @@ relevant topics.
 
 ## <a id="channels" class="anchor" href="#channels">Channels</a> (AMQP 0-9-1)
 
-[Channels guide](channels.html) explains what [channel-level exceptions](/channels.html#error-handling) mean,
+[Channels guide](channels.html) explains what [channel-level exceptions](./channels.html#error-handling) mean,
 how to identify application channel leaks and other relevant topics.
 
 
 ## <a id="tls" class="anchor" href="#tls">TLS</a>
 
-[Troubleshooting TLS](/troubleshooting-ssl.html) is a dedicated guide on the topic of TLS.
+[Troubleshooting TLS](./troubleshooting-ssl.html) is a dedicated guide on the topic of TLS.
 
 
 ## <a id="ldap" class="anchor" href="#ldap">LDAP</a>
 
-[LDAP guide](/ldap.html#troubleshooting) explains how to enable LDAP decision and query logging.
+[LDAP guide](./ldap.html#troubleshooting) explains how to enable LDAP decision and query logging.
 
 
 ## <a id="capturing-traffic" class="anchor" href="#capturing-traffic">Capturing Traffic</a>
 
-A [traffic capture](/amqp-wireshark.html) can provide a lot of information useful when troubleshooting network connectivity, application behaviour,
+A [traffic capture](./amqp-wireshark.html) can provide a lot of information useful when troubleshooting network connectivity, application behaviour,
 connection leaks, channel leaks and more. tcpdump and Wireshark and industry standard open source tools
 for capturing and analyzing network traffic.

--- a/site/ttl.md
+++ b/site/ttl.md
@@ -20,17 +20,17 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 RabbitMQ allows you to set TTL (time to live) for both messages and queues.
-This is controlled by [optional queue arguments](queues.html) and best done using a [policy](/parameters.html).
+This is controlled by [optional queue arguments](queues.html) and best done using a [policy](./parameters.html).
 
 Message TTL can be applied to a single queue, a group of
 queues or applied on the message-by-message basis.
 
-TTL settings also can be enforced by [operator policies](/parameters.html#operator-policies).
+TTL settings also can be enforced by [operator policies](./parameters.html#operator-policies).
 
 ## <a id="per-queue-message-ttl" class="anchor" href="#per-queue-message-ttl">Per-Queue Message TTL in Queues</a>
 
 Message TTL can be set for a given queue by setting the
-`message-ttl` argument with a [policy](/parameters.html#policies)
+`message-ttl` argument with a [policy](./parameters.html#policies)
 or by specifying the same argument at the time of queue declaration.
 
 A message that has been in the queue for longer than the configured TTL is said to
@@ -126,7 +126,7 @@ will (only) accept the string representation of the number.
 When both a per-queue and a per-message TTL are specified, the
 lower value between the two will be chosen.
 
-This example uses [RabbitMQ Java client](/api-guide.html)
+This example uses [RabbitMQ Java client](./api-guide.html)
 to publish a message which can reside in the queue for at most 60 seconds:
 
 <pre class="lang-java">

--- a/site/tutorials/amqp-concepts.md
+++ b/site/tutorials/amqp-concepts.md
@@ -32,9 +32,9 @@ communicate with conforming messaging middleware brokers.
 
 ### <a id="brokers-role" class="anchor" href="#brokers-role">Brokers and Their Role</a>
 
-Messaging brokers receive messages from _[publishers](/publishers.html)_
+Messaging brokers receive messages from _[publishers](../publishers.html)_
 (applications that publish them, also known as producers) and route them to
-_[consumers](/consumers.html)_ (applications that process them).
+_[consumers](../consumers.html)_ (applications that process them).
 
 Since it is a network protocol, the publishers,
 consumers and the broker can all reside on
@@ -50,7 +50,7 @@ _bindings_. Then the broker either deliver messages to
 consumers subscribed to queues, or consumers
 fetch/pull messages from queues on demand.
 
-<img src="/img/tutorials/intro/hello-world-example-routing.png" alt="Publish path from publisher to consumer via exchange and queue" />
+<img src="../img/tutorials/intro/hello-world-example-routing.png" alt="Publish path from publisher to consumer via exchange and queue" />
 
 When publishing a message, publishers may specify various
 _message attributes_ (message meta-data). Some of this
@@ -179,7 +179,7 @@ between consumers and not between queues.
 
 A direct exchange can be represented graphically as follows:
 
-<img src="/img/tutorials/intro/exchange-direct.png" alt="exchange delivering messages to  queues based on routing key" />
+<img src="../img/tutorials/intro/exchange-direct.png" alt="exchange delivering messages to  queues based on routing key" />
 
 ### <a id="exchange-fanout" class="anchor" href="#exchange-fanout">Fanout Exchange</a>
 
@@ -206,7 +206,7 @@ every queue bound to it, its use cases are quite similar:
 
 A fanout exchange can be represented graphically as follows:
 
-<img src="/img/tutorials/intro/exchange-fanout.png" alt="exchange delivering messages to three queues" />
+<img src="../img/tutorials/intro/exchange-fanout.png" alt="exchange delivering messages to three queues" />
 
 ### <a id="exchange-topic" class="anchor" href="#exchange-topic">Topic Exchange</a>
 
@@ -308,12 +308,12 @@ In AMQP 0-9-1, queues can be declared as durable or transient.
 Metadata of a durable queue is stored on disk, while metadata of a transient queue is
 stored in memory when possible.
 
-The same distinction is made for [messages at publishing time](/publishers.html#message-properties).
+The same distinction is made for [messages at publishing time](../publishers.html#message-properties).
 
 In environments and use cases where durability is important, applications
 must use durable queues *and* make sure that publish mark published messages as persisted.
 
-This topic is covered in more detailed in the [Queues guide](/queues.html#durability).
+This topic is covered in more detailed in the [Queues guide](../queues.html#durability).
 
 
 ## <a id="bindings" class="anchor" href="#bindings">Bindings</a>
@@ -340,14 +340,14 @@ duplicated work application developers have to do.
 
 If a message cannot be routed to any queue (for example,
 because there are no bindings for the exchange it was published
-to) it is either [dropped or returned to the publisher](/publishers.html#unroutable),
+to) it is either [dropped or returned to the publisher](../publishers.html#unroutable),
 depending on message attributes the publisher has set.
 
 
 ## <a id="consumers" class="anchor" href="#consumers">Consumers</a>
 
 Storing messages in queues is useless unless applications
-can _[consume](/consumers.html)_ them. In the AMQP 0-9-1 Model, there
+can _[consume](../consumers.html)_ them. In the AMQP 0-9-1 Model, there
 are two ways for applications to do this:
 
  * Subscribe to have messages delivered to them ("push API"): this is the recommended option
@@ -367,7 +367,7 @@ messages. Consumer tags are just strings.
 
 ### <a id="message-acknowledge" class="anchor" href="#message-acknowledge">Message Acknowledgements</a>
 
-[Consumer applications](/consumers.html) – that is, applications that receive and process
+[Consumer applications](../consumers.html) – that is, applications that receive and process
 messages – may occasionally fail to process individual
 messages or will sometimes just crash. There is also the possibility
 of network issues causing problems. This raises a question:
@@ -414,7 +414,7 @@ with acknowledgements. However, if you are using RabbitMQ,
 then there is a solution. RabbitMQ provides an AMQP 0-9-1
 extension known as _negative acknowledgements_ or _nacks_. For
 more information, please refer to the [Confirmations](../confirms.html)
-and [basic.nack extension](/nack.html) guides.
+and [basic.nack extension](../nack.html) guides.
 
 ### <a id="messages-prefetch" class="anchor" href="#messages-prefetch">Prefetching Messages</a>
 
@@ -471,7 +471,7 @@ message itself. Publishing messages as persistent affects
 performance (just like with data stores, durability comes at a
 certain cost in performance).
 
-Learn more in the [Publishers guide](/publishers.html).
+Learn more in the [Publishers guide](../publishers.html).
 
 
 ## <a id="acknowledgements" class="anchor" href="#acknowledgements">Message Acknowledgements</a>
@@ -504,7 +504,7 @@ _methods_. Methods are operations (like HTTP methods)
 and have nothing in common with methods in object-oriented
 programming languages. Protocol methods in AMQP 0-9-1 are grouped into
 _classes_. Classes are just logical groupings of AMQP
-methods. The [AMQP 0-9-1 reference](/amqp-0-9-1-reference.html) has full details of all the AMQP methods.
+methods. The [AMQP 0-9-1 reference](../amqp-0-9-1-reference.html) has full details of all the AMQP methods.
 
 Let us take a look at the _exchange_ class, a group
 of methods related to operations on exchanges. It includes
@@ -530,7 +530,7 @@ brokers in response to the aforementioned "requests").
 As an example, the client asks the broker to declare a new
 exchange using the `exchange.declare` method:
 
-<img src="/img/tutorials/intro/exchange-declare.png" alt="exchange.declare" />
+<img src="../img/tutorials/intro/exchange-declare.png" alt="exchange.declare" />
 
 As shown on the diagram above,
 `exchange.declare` carries several
@@ -539,7 +539,7 @@ exchange name, type, durability flag and so on.
 
 If the operation succeeds, the broker responds with the `exchange.declare-ok` method:
 
-<img src="/img/tutorials/intro/exchange-declare-ok.png" alt="exchange.declare-ok" />
+<img src="../img/tutorials/intro/exchange-declare-ok.png" alt="exchange.declare-ok" />
 
 `exchange.declare-ok` does not carry any
 parameters except for the channel number (channels will be
@@ -549,9 +549,9 @@ The sequence of events is very similar for another
 method pair on the AMQP 0-9-1 _queue_ method class: `queue.declare` and
 `queue.declare-ok`:
 
-<img src="/img/tutorials/intro/queue-declare.png" alt="queue.declare" />
+<img src="../img/tutorials/intro/queue-declare.png" alt="queue.declare" />
 
-<img src="/img/tutorials/intro/queue-declare-ok.png" alt="queue.declare-ok" />
+<img src="../img/tutorials/intro/queue-declare-ok.png" alt="queue.declare-ok" />
 
 Not all AMQP 0-9-1 methods have counterparts. Some
 (`basic.publish` being the most widely used one)
@@ -577,7 +577,7 @@ broker. However, it is undesirable to keep many TCP
 connections open at the same time because doing so consumes
 system resources and makes it more difficult to configure
 firewalls. AMQP 0-9-1 connections are multiplexed with
-_[channels](/channels.html)_ that can be thought of as "lightweight
+_[channels](../channels.html)_ that can be thought of as "lightweight
 connections that share a single TCP connection".
 
 Every protocol operation performed by a client happens on a channel.
@@ -598,7 +598,7 @@ and not share channels between them.
 
 To make it possible for a single broker to host multiple
 isolated "environments" (groups of users, exchanges,
-queues and so on), AMQP 0-9-1 includes the concept of _[virtual hosts](/vhosts.html)_ (vhosts).
+queues and so on), AMQP 0-9-1 includes the concept of _[virtual hosts](../vhosts.html)_ (vhosts).
 They are similar to virtual hosts used by many popular Web servers and provide completely isolated
 environments in which AMQP entities live. Protocol clients
 specify what vhosts they want to use during connection negotiation.
@@ -608,16 +608,16 @@ specify what vhosts they want to use during connection negotiation.
 
 AMQP 0-9-1 has several extension points:
 
- * [Custom exchange types](/devtools.html#miscellaneous) let developers
+ * [Custom exchange types](../devtools.html#miscellaneous) let developers
    implement routing schemes that exchange types provided out-of-the-box do
    not cover well, for example, geodata-based routing.
  * Declaration of exchanges and queues can include additional attributes that the broker
-   can use. For example, [per-queue message TTL](/ttl.html) in RabbitMQ is implemented this way.
+   can use. For example, [per-queue message TTL](../ttl.html) in RabbitMQ is implemented this way.
  * Broker-specific extensions to the protocol. See, for example,
-   [extensions that RabbitMQ implements](/extensions.html).
- * [New AMQP 0-9-1 method classes](/amqp-0-9-1-quickref.html#class.confirm) can be introduced.
- * Brokers can be extended with [additional plugins](/plugins.html),
-   for example, the [RabbitMQ management](/management.html)
+   [extensions that RabbitMQ implements](../extensions.html).
+ * [New AMQP 0-9-1 method classes](../amqp-0-9-1-quickref.html#class.confirm) can be introduced.
+ * Brokers can be extended with [additional plugins](../plugins.html),
+   for example, the [RabbitMQ management](../management.html)
    frontend and HTTP API are implemented as a plugin.
 
 These features make the AMQP 0-9-1 Model even more flexible
@@ -626,7 +626,7 @@ and applicable to a very broad range of problems.
 
 ## <a id="amqp-clients" class="anchor" href="#amqp-clients">AMQP 0-9-1 Clients Ecosystem</a>
 
-There are [many AMQP 0-9-1 clients](/devtools.html) for many
+There are [many AMQP 0-9-1 clients](../devtools.html) for many
 popular programming languages and platforms. Some of them follow AMQP terminology
 closely and only provide implementation of AMQP methods. Some
 others have additional features, convenience methods

--- a/site/tutorials/disclaimer.xml.inc
+++ b/site/tutorials/disclaimer.xml.inc
@@ -7,8 +7,8 @@
     for the sake of brevity. Such simplified code should not be considered production ready.
   </p>
   <p>
-    Please take a look at the rest of the <a href="/documentation.html">documentation</a> before going live with your app.
+    Please take a look at the rest of the <a href="../documentation.html">documentation</a> before going live with your app.
     We particularly recommend the following guides: <a href="../confirms.html">Publisher Confirms and Consumer Acknowledgements</a>,
-    <a href="/production-checklist.html">Production Checklist</a> and <a href="/monitoring.html">Monitoring</a>.
+    <a href="../production-checklist.html">Production Checklist</a> and <a href="../monitoring.html">Monitoring</a>.
   </p>
 </div>

--- a/site/tutorials/tutorial-five-dotnet.md
+++ b/site/tutorials/tutorial-five-dotnet.md
@@ -66,7 +66,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-elixir.md
+++ b/site/tutorials/tutorial-five-elixir.md
@@ -66,7 +66,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-go.md
+++ b/site/tutorials/tutorial-five-go.md
@@ -66,7 +66,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-java.md
+++ b/site/tutorials/tutorial-five-java.md
@@ -66,7 +66,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-javascript.md
+++ b/site/tutorials/tutorial-five-javascript.md
@@ -66,7 +66,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-objectivec.md
+++ b/site/tutorials/tutorial-five-objectivec.md
@@ -50,7 +50,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-php.md
+++ b/site/tutorials/tutorial-five-php.md
@@ -65,7 +65,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-python.md
+++ b/site/tutorials/tutorial-five-python.md
@@ -73,7 +73,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-ruby.md
+++ b/site/tutorials/tutorial-five-ruby.md
@@ -66,7 +66,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-spring-amqp.md
+++ b/site/tutorials/tutorial-five-spring-amqp.md
@@ -68,7 +68,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-five-swift.md
+++ b/site/tutorials/tutorial-five-swift.md
@@ -50,7 +50,7 @@ special cases for binding keys:
 It's easiest to explain this in an example:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-five.png" height="170" />
+  <img src="../img/tutorials/python-five.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-dotnet.md
+++ b/site/tutorials/tutorial-four-dotnet.md
@@ -81,7 +81,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -131,7 +131,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -229,7 +229,7 @@ Putting it all together
 
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-elixir.md
+++ b/site/tutorials/tutorial-four-elixir.md
@@ -77,7 +77,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -127,7 +127,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -217,7 +217,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -87,7 +87,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -137,7 +137,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -273,7 +273,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-java.md
+++ b/site/tutorials/tutorial-four-java.md
@@ -77,7 +77,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -127,7 +127,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -216,7 +216,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-javascript.md
+++ b/site/tutorials/tutorial-four-javascript.md
@@ -76,7 +76,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -126,7 +126,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -223,7 +223,7 @@ Putting it all together
 
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-objectivec.md
+++ b/site/tutorials/tutorial-four-objectivec.md
@@ -61,7 +61,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -111,7 +111,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -202,7 +202,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-php.md
+++ b/site/tutorials/tutorial-four-php.md
@@ -78,7 +78,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -128,7 +128,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -214,7 +214,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-python.md
+++ b/site/tutorials/tutorial-four-python.md
@@ -87,7 +87,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -137,7 +137,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -231,7 +231,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-ruby.md
+++ b/site/tutorials/tutorial-four-ruby.md
@@ -77,7 +77,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -127,7 +127,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -219,7 +219,7 @@ Putting it all together
 
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-spring-amqp.md
+++ b/site/tutorials/tutorial-four-spring-amqp.md
@@ -89,7 +89,7 @@ binding key exactly matches the routing key of the message.
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -139,7 +139,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -232,7 +232,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-four-swift.md
+++ b/site/tutorials/tutorial-four-swift.md
@@ -61,7 +61,7 @@ a `direct` exchange is simple - a message goes to the queues whose
 To illustrate that, consider the following setup:
 
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange.png" height="170" />
+  <img src="../img/tutorials/direct-exchange.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -111,7 +111,7 @@ or `green` will go to `Q2`. All other messages will be discarded.
 Multiple bindings
 -----------------
 <div class="diagram">
-  <img src="/img/tutorials/direct-exchange-multiple.png" height="170" />
+  <img src="../img/tutorials/direct-exchange-multiple.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -200,7 +200,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-four.png" height="170" />
+  <img src="../img/tutorials/python-four.png" height="170" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-one-dotnet.md
+++ b/site/tutorials/tutorial-one-dotnet.md
@@ -35,7 +35,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The .NET client library
@@ -96,7 +96,7 @@ Now we have the .NET project set up we can write some code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 We'll call our message publisher (sender) `Send.cs` and our message consumer (receiver)
@@ -218,7 +218,7 @@ RabbitMQ. So unlike the publisher which publishes a single message, we'll
 keep the consumer running continuously to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 The code (in [`Receive.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/Receive/Receive.cs)) has almost the same `using` statements as `Send`:

--- a/site/tutorials/tutorial-one-elixir.md
+++ b/site/tutorials/tutorial-one-elixir.md
@@ -20,7 +20,7 @@ on behalf of the consumer.
 Our overall design will look like:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one-overall.png" height="100" />
+  <img src="../img/tutorials/python-one-overall.png" height="100" />
   <div class="diagram_source">
 digraph G {
       bgcolor=transparent;
@@ -45,7 +45,7 @@ digraph G {
 >
 > RabbitMQ speaks multiple protocols. This tutorial uses AMQP 0-9-1, which is an open, general-purpose
 > protocol for messaging. There are a number of clients for RabbitMQ
-> in [many different languages](/devtools.html).  In this tutorial
+> in [many different languages](../devtools.html).  In this tutorial
 > series we're going to use [amqp](http://github.com/pma/amqp).
 >
 > To install it you can use the [`hex`](http://hex.pm/) package
@@ -85,7 +85,7 @@ digraph G {
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" height="100" />
+  <img src="../img/tutorials/sending.png" height="100" />
   <div class="diagram_source">
   digraph {
       bgcolor=transparent;
@@ -171,7 +171,7 @@ RabbitMQ, so unlike the producer which publishes a single message,
 we'll keep the consumer running to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" height="100" />
+  <img src="../img/tutorials/receiving.png" height="100" />
   <div class="diagram_source">
   digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -35,7 +35,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The Go RabbitMQ client library
@@ -58,7 +58,7 @@ code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 We'll call our message publisher (sender) `send.go` and our message consumer (receiver)
@@ -161,7 +161,7 @@ RabbitMQ, so unlike the publisher which publishes a single message, we'll
 keep the consumer running to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 The code (in [`receive.go`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/receive.go)) has the same import and helper function as `send`:

--- a/site/tutorials/tutorial-one-java.md
+++ b/site/tutorials/tutorial-one-java.md
@@ -35,7 +35,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The Java client library
@@ -63,7 +63,7 @@ code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 We'll call our message publisher (sender) `Send` and our message consumer (receiver)
@@ -149,7 +149,7 @@ RabbitMQ, so unlike the publisher which publishes a single message, we'll
 keep the consumer running to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 The code (in [`Recv.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/Recv.java)) has almost the same imports as `Send`:

--- a/site/tutorials/tutorial-one-javascript.md
+++ b/site/tutorials/tutorial-one-javascript.md
@@ -35,7 +35,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The amqp.node client library
@@ -57,7 +57,7 @@ code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 We'll call our message publisher (sender) `send.js` and our message consumer (receiver)
@@ -151,7 +151,7 @@ RabbitMQ, so unlike the publisher which publishes a single message, we'll
 keep the consumer running to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 The code (in [`receive.js`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive.js)) has the same require as `send`:

--- a/site/tutorials/tutorial-one-objectivec.md
+++ b/site/tutorials/tutorial-one-objectivec.md
@@ -16,7 +16,7 @@ the middle is a queue - a message buffer that RabbitMQ keeps on behalf of the
 consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The Objective-C client library
@@ -51,7 +51,7 @@ Once the client is added as a dependency, build the project with **Product** ->
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 To keep things easy for the tutorial, we'll put our send and receive code in
@@ -144,7 +144,7 @@ be pushed messages from RabbitMQ, so unlike `send` which publishes a single
 message, it will wait for a message, log it and then quit.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 Setting up is the same as `send`; we open a connection and a

--- a/site/tutorials/tutorial-one-php.md
+++ b/site/tutorials/tutorial-one-php.md
@@ -38,7 +38,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The php-amqplib client library
@@ -75,7 +75,7 @@ code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 We'll call our message publisher (sender) `send.php` and our message receiver
@@ -153,7 +153,7 @@ RabbitMQ, so unlike the publisher which publishes a single message, we'll
 keep the receiver running to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 The code (in [`receive.php`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/receive.php)) has almost the same

--- a/site/tutorials/tutorial-one-python.md
+++ b/site/tutorials/tutorial-one-python.md
@@ -21,7 +21,7 @@ on behalf of the consumer.
 Our overall design will look like:
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one-overall.png" height="100" />
+  <img src="../img/tutorials/python-one-overall.png" height="100" />
   <div class="diagram_source">
 digraph G {
       bgcolor=transparent;
@@ -49,7 +49,7 @@ messages from that queue.
 >
 > RabbitMQ speaks multiple protocols. This tutorial uses AMQP 0-9-1, which is an open,
 > general-purpose protocol for messaging. There are a number of clients for RabbitMQ
-> in [many different languages](/devtools.html).  In this tutorial
+> in [many different languages](../devtools.html).  In this tutorial
 > series we're going to use [Pika 1.0.0](https://pika.readthedocs.org/en/stable/),
 > which is the Python client recommended
 > by the RabbitMQ team. To install it you can use the
@@ -65,7 +65,7 @@ code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" height="100" />
+  <img src="../img/tutorials/sending.png" height="100" />
   <div class="diagram_source">
   digraph {
       bgcolor=transparent;
@@ -153,7 +153,7 @@ connection.close()
 ### Receiving
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" height="100" />
+  <img src="../img/tutorials/receiving.png" height="100" />
   <div class="diagram_source">
   digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-one-ruby.md
+++ b/site/tutorials/tutorial-one-ruby.md
@@ -35,7 +35,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The Bunny client library
@@ -58,7 +58,7 @@ code.
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 We'll call our message producer `send.rb` and our message consumer
@@ -142,7 +142,7 @@ RabbitMQ, so unlike the producer which publishes a single message, we'll
 keep the consumer running to listen for messages and print them out.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 The code (in [`receive.rb`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/receive.rb)) has the same require as `send`:

--- a/site/tutorials/tutorial-one-spring-amqp.md
+++ b/site/tutorials/tutorial-one-spring-amqp.md
@@ -35,7 +35,7 @@ box in the middle is a queue - a message buffer that RabbitMQ keeps
 on behalf of the consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The Spring AMQP Framework
@@ -58,7 +58,7 @@ the artifact id (e.g. `rabbitmq-amqp-tutorials`)
 Search for the RabbitMQ dependency and select the RabbitMQ dependency.
 
 <div class="diagram">
-    <img src="/img/tutorials/spring-initializr.png" alt="(P) ->  [|||]"
+    <img src="../img/tutorials/spring-initializr.png" alt="(P) ->  [|||]"
         height="100" />
 </div>
 
@@ -203,7 +203,7 @@ public class RabbitAmqpTutorialsRunner implements CommandLineRunner {
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 Now there is very little code that needs to go into the

--- a/site/tutorials/tutorial-one-swift.md
+++ b/site/tutorials/tutorial-one-swift.md
@@ -16,7 +16,7 @@ the middle is a queue - a message buffer that RabbitMQ keeps on behalf of the
 consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
+  <img src="../img/tutorials/python-one.png" alt="(P) -> [|||] -> (C)" height="60" />
 </div>
 
 > #### The Objective-C client library
@@ -51,7 +51,7 @@ Once the client is added as a dependency, build the project with **Product** ->
 ### Sending
 
 <div class="diagram">
-  <img src="/img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
+  <img src="../img/tutorials/sending.png" alt="(P) -> [|||]" height="100" />
 </div>
 
 To keep things easy for the tutorial, we'll put our send and receive code in
@@ -149,7 +149,7 @@ be pushed messages from RabbitMQ, so unlike `send` which publishes a single
 message, it will wait for a message, log it and then quit.
 
 <div class="diagram">
-  <img src="/img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
+  <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
 Setting up is the same as `send`; we open a connection and a

--- a/site/tutorials/tutorial-six-dotnet.md
+++ b/site/tutorials/tutorial-six-dotnet.md
@@ -136,7 +136,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -469,5 +469,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-elixir.md
+++ b/site/tutorials/tutorial-six-elixir.md
@@ -131,7 +131,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -369,7 +369,7 @@ complex (but important) problems, like:
    (eg checking bounds) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >
 
 (Full source code for [rpc_client.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/rpc_client.exs) and [rpc_server.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/rpc_server.exs))

--- a/site/tutorials/tutorial-six-go.md
+++ b/site/tutorials/tutorial-six-go.md
@@ -129,7 +129,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -482,5 +482,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-java.md
+++ b/site/tutorials/tutorial-six-java.md
@@ -137,7 +137,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -308,5 +308,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-javascript.md
+++ b/site/tutorials/tutorial-six-javascript.md
@@ -117,7 +117,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -364,5 +364,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -130,7 +130,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -409,5 +409,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-python.md
+++ b/site/tutorials/tutorial-six-python.md
@@ -138,7 +138,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -376,5 +376,5 @@ complex (but important) problems, like:
    (eg checking bounds) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-ruby.md
+++ b/site/tutorials/tutorial-six-ruby.md
@@ -130,7 +130,7 @@ gracefully, and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -413,5 +413,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 >
->If you want to experiment, you may find the [management UI](/management.html) useful for viewing the queues.
+>If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >

--- a/site/tutorials/tutorial-six-spring-amqp.md
+++ b/site/tutorials/tutorial-six-spring-amqp.md
@@ -122,7 +122,7 @@ and the RPC should ideally be idempotent.
 ### Summary
 
 <div class="diagram">
-  <img src="/img/tutorials/python-six.png" height="200" />
+  <img src="../img/tutorials/python-six.png" height="200" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -391,5 +391,5 @@ complex (but important) problems, like:
    (eg checking bounds, type) before processing.
 
 
->If you want to experiment, you may find the [management UI](/management.html)
+>If you want to experiment, you may find the [management UI](../management.html)
 > useful for viewing the queues.

--- a/site/tutorials/tutorial-three-dotnet.md
+++ b/site/tutorials/tutorial-three-dotnet.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -184,7 +184,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -230,7 +230,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-elixir.md
+++ b/site/tutorials/tutorial-three-elixir.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -174,7 +174,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -217,7 +217,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -217,7 +217,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -266,7 +266,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-java.md
+++ b/site/tutorials/tutorial-three-java.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -173,7 +173,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -216,7 +216,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-javascript.md
+++ b/site/tutorials/tutorial-three-javascript.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -179,7 +179,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -222,7 +222,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-objectivec.md
+++ b/site/tutorials/tutorial-three-objectivec.md
@@ -50,7 +50,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -160,7 +160,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -199,7 +199,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-php.md
+++ b/site/tutorials/tutorial-three-php.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -173,7 +173,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -216,7 +216,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-python.md
+++ b/site/tutorials/tutorial-three-python.md
@@ -73,7 +73,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -186,7 +186,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -230,7 +230,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-ruby.md
+++ b/site/tutorials/tutorial-three-ruby.md
@@ -66,7 +66,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -174,7 +174,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -216,7 +216,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-spring-amqp.md
+++ b/site/tutorials/tutorial-three-spring-amqp.md
@@ -65,7 +65,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -242,7 +242,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -288,7 +288,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-three-swift.md
+++ b/site/tutorials/tutorial-three-swift.md
@@ -50,7 +50,7 @@ Or should it get discarded. The rules for that are defined by the
 _exchange type_.
 
 <div class="diagram">
-  <img src="/img/tutorials/exchanges.png" height="110" />
+  <img src="../img/tutorials/exchanges.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -161,7 +161,7 @@ Bindings
 --------
 
 <div class="diagram">
-  <img src="/img/tutorials/bindings.png" height="90" />
+  <img src="../img/tutorials/bindings.png" height="90" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -204,7 +204,7 @@ Putting it all together
 -----------------------
 
 <div class="diagram">
-  <img src="/img/tutorials/python-three-overall.png" height="160" />
+  <img src="../img/tutorials/python-three-overall.png" height="160" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -369,7 +369,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-elixir.md
+++ b/site/tutorials/tutorial-two-elixir.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -327,7 +327,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -364,7 +364,7 @@ AMQP.Basic.qos(channel, prefetch_count: 1)
 > #### Note about queue size
 >
 > If all the workers are busy, your queue can fill up. You will want to keep an
-> eye on that, and maybe add more workers, or use [message TTL](/ttl.html).
+> eye on that, and maybe add more workers, or use [message TTL](../ttl.html).
 
 Putting it all together
 -----------------------

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -400,7 +400,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-java.md
+++ b/site/tutorials/tutorial-two-java.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -341,7 +341,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -338,7 +338,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-objectivec.md
+++ b/site/tutorials/tutorial-two-objectivec.md
@@ -6,7 +6,7 @@
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -308,7 +308,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -327,7 +327,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -27,7 +27,7 @@ As with other Python tutorials, we will use the [Pika](https://pypi.python.org/p
 [version 1.0.0](https://pika.readthedocs.io/en/stable/).
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -318,7 +318,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -355,7 +355,7 @@ channel.basic_qos(prefetch_count=1)
 > #### Note about queue size
 >
 > If all the workers are busy, your queue can fill up. You will want to keep an
-> eye on that, and maybe add more workers, or use [message TTL](/ttl.html).
+> eye on that, and maybe add more workers, or use [message TTL](../ttl.html).
 
 Putting it all together
 -----------------------

--- a/site/tutorials/tutorial-two-ruby.md
+++ b/site/tutorials/tutorial-two-ruby.md
@@ -22,7 +22,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -314,7 +314,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-spring-amqp.md
+++ b/site/tutorials/tutorial-two-spring-amqp.md
@@ -24,7 +24,7 @@ limitations under the License.
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -360,7 +360,7 @@ However, "Fair dispatch" is the default configuration for Spring AMQP. The
 set to 1 the behavior would be the round robin delivery as described above.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorial-two-swift.md
+++ b/site/tutorials/tutorial-two-swift.md
@@ -6,7 +6,7 @@
 <xi:include href="site/tutorials/tutorials-help.xml.inc"/>
 
 <div class="diagram">
-  <img src="/img/tutorials/python-two.png" height="110" />
+  <img src="../img/tutorials/python-two.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;
@@ -302,7 +302,7 @@ messages for a consumer. It just blindly dispatches every n-th message
 to the n-th consumer.
 
 <div class="diagram">
-  <img src="/img/tutorials/prefetch-count.png" height="110" />
+  <img src="../img/tutorials/prefetch-count.png" height="110" />
   <div class="diagram_source">
     digraph {
       bgcolor=transparent;

--- a/site/tutorials/tutorials-help.xml.inc
+++ b/site/tutorials/tutorials-help.xml.inc
@@ -18,8 +18,8 @@ limitations under the License.
   <div class="aside" style="margin-top: -10px;" xmlns="http://www.w3.org/1999/xhtml">
     <h3>Prerequisites</h3>
     <p>
-      This tutorial assumes RabbitMQ is <a href="/download.html">installed</a> and running
-      on <code>localhost</code> on the <a href="/networking.html#ports">standard port</a> (<code>5672</code>). In case you use
+      This tutorial assumes RabbitMQ is <a href="../download.html">installed</a> and running
+      on <code>localhost</code> on the <a href="../networking.html#ports">standard port</a> (<code>5672</code>). In case you use
       a different host, port or credentials, connections settings would require adjusting.
     </p>
 

--- a/site/tutorials/tutorials-intro.xml.inc
+++ b/site/tutorials/tutorials-intro.xml.inc
@@ -25,7 +25,7 @@
         A program that sends messages is a <em>producer</em> :
 
         <div class="diagram">
-          <img src="/img/tutorials/producer.png" height="50" />
+          <img src="../img/tutorials/producer.png" height="50" />
           <div class="diagram_source">
             digraph {
               bgcolor=transparent;
@@ -50,7 +50,7 @@
         This is how we represent a queue:
 
         <div class="diagram">
-         <img src="/img/tutorials/queue.png" height="90" />
+         <img src="../img/tutorials/queue.png" height="90" />
          <div class="diagram_source">
            digraph {
              bgcolor=transparent;
@@ -75,7 +75,7 @@
         A <em>consumer</em> is a program that mostly waits to receive messages:
 
         <div class="diagram">
-          <img src="/img/tutorials/consumer.png" height="50" />
+          <img src="../img/tutorials/consumer.png" height="50" />
           <div class="diagram_source">
           digraph {
             bgcolor=transparent;

--- a/site/tutorials/tutorials-menu.xml.inc
+++ b/site/tutorials/tutorials-menu.xml.inc
@@ -18,141 +18,141 @@ limitations under the License.
 <table id="tutorials" xmlns="http://www.w3.org/1999/xhtml">
   <tr>
   <td id="tutorial-one">
-    <h2><span class="tute-num">1</span> <a href="/tutorials/tutorial-one-python.html">"Hello World!"</a></h2>
+    <h2><span class="tute-num">1</span> <a href="./tutorial-one-python.html">"Hello World!"</a></h2>
     <p>
       The simplest thing that does <em>something</em>
     </p>
     <p><img src="../img/tutorials/python-one.png" width="180"  /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-one-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-one-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-one-spring-amqp.html">Spring AMQP</a></li>
-      <li><a href="/tutorials/tutorial-one-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-one-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-one-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-one-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-one-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-one-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-one-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-one-swift.html">Swift</a></li>
+      <li><a href="./tutorial-one-python.html">Python</a></li>
+      <li><a href="./tutorial-one-java.html">Java</a></li>
+      <li><a href="./tutorial-one-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorial-one-ruby.html">Ruby</a></li>
+      <li><a href="./tutorial-one-php.html">PHP</a></li>
+      <li><a href="./tutorial-one-dotnet.html">C#</a></li>
+      <li><a href="./tutorial-one-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorial-one-go.html">Go</a></li>
+      <li><a href="./tutorial-one-elixir.html">Elixir</a></li>
+      <li><a href="./tutorial-one-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorial-one-swift.html">Swift</a></li>
     </ul>
   </td>
 
   <td id="tutorial-two">
-    <h2><span class="tute-num">2</span> <a href="/tutorials/tutorial-two-python.html">Work queues</a></h2>
+    <h2><span class="tute-num">2</span> <a href="./tutorial-two-python.html">Work queues</a></h2>
     <p>
       Distributing tasks among workers (the <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html">competing consumers pattern</a>)
     </p>
     <p><img src="../img/tutorials/python-two.png" width="180" /></p>
     <ul>
-        <li><a href="/tutorials/tutorial-two-python.html">Python</a></li>
-        <li><a href="/tutorials/tutorial-two-java.html">Java</a></li>
-        <li><a href="/tutorials/tutorial-two-spring-amqp.html">Spring AMQP</a></li>
-        <li><a href="/tutorials/tutorial-two-ruby.html">Ruby</a></li>
-        <li><a href="/tutorials/tutorial-two-php.html">PHP</a></li>
-        <li><a href="/tutorials/tutorial-two-dotnet.html">C#</a></li>
-        <li><a href="/tutorials/tutorial-two-javascript.html">JavaScript</a></li>
-        <li><a href="/tutorials/tutorial-two-go.html">Go</a></li>
-        <li><a href="/tutorials/tutorial-two-elixir.html">Elixir</a></li>
-        <li><a href="/tutorials/tutorial-two-objectivec.html">Objective-C</a></li>
-        <li><a href="/tutorials/tutorial-two-swift.html">Swift</a></li>
+        <li><a href="./tutorial-two-python.html">Python</a></li>
+        <li><a href="./tutorial-two-java.html">Java</a></li>
+        <li><a href="./tutorial-two-spring-amqp.html">Spring AMQP</a></li>
+        <li><a href="./tutorial-two-ruby.html">Ruby</a></li>
+        <li><a href="./tutorial-two-php.html">PHP</a></li>
+        <li><a href="./tutorial-two-dotnet.html">C#</a></li>
+        <li><a href="./tutorial-two-javascript.html">JavaScript</a></li>
+        <li><a href="./tutorial-two-go.html">Go</a></li>
+        <li><a href="./tutorial-two-elixir.html">Elixir</a></li>
+        <li><a href="./tutorial-two-objectivec.html">Objective-C</a></li>
+        <li><a href="./tutorial-two-swift.html">Swift</a></li>
     </ul>
   </td>
 
   <td id="tutorial-three">
-    <h2><span class="tute-num">3</span> <a href="/tutorials/tutorial-three-python.html">Publish/Subscribe</a></h2>
+    <h2><span class="tute-num">3</span> <a href="./tutorial-three-python.html">Publish/Subscribe</a></h2>
     <p>
       Sending messages to many consumers at once
     </p>
     <p><img src="../img/tutorials/python-three.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-three-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-three-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-three-spring-amqp.html">Spring AMQP</a></li>
-      <li><a href="/tutorials/tutorial-three-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-three-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-three-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-three-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-three-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-three-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-three-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-three-swift.html">Swift</a></li>
+      <li><a href="./tutorial-three-python.html">Python</a></li>
+      <li><a href="./tutorial-three-java.html">Java</a></li>
+      <li><a href="./tutorial-three-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorial-three-ruby.html">Ruby</a></li>
+      <li><a href="./tutorial-three-php.html">PHP</a></li>
+      <li><a href="./tutorial-three-dotnet.html">C#</a></li>
+      <li><a href="./tutorial-three-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorial-three-go.html">Go</a></li>
+      <li><a href="./tutorial-three-elixir.html">Elixir</a></li>
+      <li><a href="./tutorial-three-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorial-three-swift.html">Swift</a></li>
     </ul>
   </td>
   </tr>
 
   <tr>
   <td id="tutorial-four">
-    <h2><span class="tute-num">4</span> <a href="/tutorials/tutorial-four-python.html">Routing</a></h2>
+    <h2><span class="tute-num">4</span> <a href="./tutorial-four-python.html">Routing</a></h2>
     <p>
       Receiving messages selectively
     </p>
     <p><img src="../img/tutorials/python-four.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-four-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-four-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-four-spring-amqp.html">Spring AMQP</a></li>
-      <li><a href="/tutorials/tutorial-four-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-four-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-four-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-four-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-four-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-four-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-four-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-four-swift.html">Swift</a></li>
+      <li><a href="./tutorial-four-python.html">Python</a></li>
+      <li><a href="./tutorial-four-java.html">Java</a></li>
+      <li><a href="./tutorial-four-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorial-four-ruby.html">Ruby</a></li>
+      <li><a href="./tutorial-four-php.html">PHP</a></li>
+      <li><a href="./tutorial-four-dotnet.html">C#</a></li>
+      <li><a href="./tutorial-four-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorial-four-go.html">Go</a></li>
+      <li><a href="./tutorial-four-elixir.html">Elixir</a></li>
+      <li><a href="./tutorial-four-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorial-four-swift.html">Swift</a></li>
     </ul>
   </td>
 
   <td id="tutorial-five">
-    <h2><span class="tute-num">5</span> <a href="/tutorials/tutorial-five-python.html">Topics</a></h2>
+    <h2><span class="tute-num">5</span> <a href="./tutorial-five-python.html">Topics</a></h2>
     <p>
       Receiving messages based on a pattern (topics)
     </p>
     <p><img src="../img/tutorials/python-five.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-five-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-five-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-five-spring-amqp.html">Spring AMQP</a></li>
-      <li><a href="/tutorials/tutorial-five-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-five-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-five-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-five-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-five-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-five-elixir.html">Elixir</a></li>
-      <li><a href="/tutorials/tutorial-five-objectivec.html">Objective-C</a></li>
-      <li><a href="/tutorials/tutorial-five-swift.html">Swift</a></li>
+      <li><a href="./tutorial-five-python.html">Python</a></li>
+      <li><a href="./tutorial-five-java.html">Java</a></li>
+      <li><a href="./tutorial-five-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorial-five-ruby.html">Ruby</a></li>
+      <li><a href="./tutorial-five-php.html">PHP</a></li>
+      <li><a href="./tutorial-five-dotnet.html">C#</a></li>
+      <li><a href="./tutorial-five-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorial-five-go.html">Go</a></li>
+      <li><a href="./tutorial-five-elixir.html">Elixir</a></li>
+      <li><a href="./tutorial-five-objectivec.html">Objective-C</a></li>
+      <li><a href="./tutorial-five-swift.html">Swift</a></li>
     </ul>
   </td>
 
   <td id="tutorial-six">
-    <h2><span class="tute-num">6</span> <a href="/tutorials/tutorial-six-python.html">RPC</a></h2>
+    <h2><span class="tute-num">6</span> <a href="./tutorial-six-python.html">RPC</a></h2>
     <p>
       <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html">Request/reply pattern</a> example
     </p>
     <p><img src="../img/tutorials/python-six.png" height="50" width="180" /></p>
     <ul>
-      <li><a href="/tutorials/tutorial-six-python.html">Python</a></li>
-      <li><a href="/tutorials/tutorial-six-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-six-spring-amqp.html">Spring AMQP</a></li>
-      <li><a href="/tutorials/tutorial-six-ruby.html">Ruby</a></li>
-      <li><a href="/tutorials/tutorial-six-php.html">PHP</a></li>
-      <li><a href="/tutorials/tutorial-six-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-six-javascript.html">JavaScript</a></li>
-      <li><a href="/tutorials/tutorial-six-go.html">Go</a></li>
-      <li><a href="/tutorials/tutorial-six-elixir.html">Elixir</a></li>
+      <li><a href="./tutorial-six-python.html">Python</a></li>
+      <li><a href="./tutorial-six-java.html">Java</a></li>
+      <li><a href="./tutorial-six-spring-amqp.html">Spring AMQP</a></li>
+      <li><a href="./tutorial-six-ruby.html">Ruby</a></li>
+      <li><a href="./tutorial-six-php.html">PHP</a></li>
+      <li><a href="./tutorial-six-dotnet.html">C#</a></li>
+      <li><a href="./tutorial-six-javascript.html">JavaScript</a></li>
+      <li><a href="./tutorial-six-go.html">Go</a></li>
+      <li><a href="./tutorial-six-elixir.html">Elixir</a></li>
     </ul>
   </td>
   </tr>
   <tr>
   <td id="tutorial-seven">
-    <h2><span class="tute-num">7</span> <a href="/tutorials/tutorial-seven-java.html">Publisher Confirms</a></h2>
+    <h2><span class="tute-num">7</span> <a href="./tutorial-seven-java.html">Publisher Confirms</a></h2>
     <p>
       Reliable publishing with publisher confirms
     </p>
     <ul>
-      <li><a href="/tutorials/tutorial-seven-java.html">Java</a></li>
-      <li><a href="/tutorials/tutorial-seven-dotnet.html">C#</a></li>
-      <li><a href="/tutorials/tutorial-seven-php.html">PHP</a></li>
+      <li><a href="./tutorial-seven-java.html">Java</a></li>
+      <li><a href="./tutorial-seven-dotnet.html">C#</a></li>
+      <li><a href="./tutorial-seven-php.html">PHP</a></li>
     </ul>
   </td>
   <td class="tutorial-empty"></td>

--- a/site/tutorials/tutorials-menu.xml.inc
+++ b/site/tutorials/tutorials-menu.xml.inc
@@ -22,7 +22,7 @@ limitations under the License.
     <p>
       The simplest thing that does <em>something</em>
     </p>
-    <p><img src="/img/tutorials/python-one.png" width="180"  /></p>
+    <p><img src="../img/tutorials/python-one.png" width="180"  /></p>
     <ul>
       <li><a href="/tutorials/tutorial-one-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-one-java.html">Java</a></li>
@@ -43,7 +43,7 @@ limitations under the License.
     <p>
       Distributing tasks among workers (the <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html">competing consumers pattern</a>)
     </p>
-    <p><img src="/img/tutorials/python-two.png" width="180" /></p>
+    <p><img src="../img/tutorials/python-two.png" width="180" /></p>
     <ul>
         <li><a href="/tutorials/tutorial-two-python.html">Python</a></li>
         <li><a href="/tutorials/tutorial-two-java.html">Java</a></li>
@@ -64,7 +64,7 @@ limitations under the License.
     <p>
       Sending messages to many consumers at once
     </p>
-    <p><img src="/img/tutorials/python-three.png" height="50" width="180" /></p>
+    <p><img src="../img/tutorials/python-three.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-three-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-three-java.html">Java</a></li>
@@ -87,7 +87,7 @@ limitations under the License.
     <p>
       Receiving messages selectively
     </p>
-    <p><img src="/img/tutorials/python-four.png" height="50" width="180" /></p>
+    <p><img src="../img/tutorials/python-four.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-four-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-four-java.html">Java</a></li>
@@ -108,7 +108,7 @@ limitations under the License.
     <p>
       Receiving messages based on a pattern (topics)
     </p>
-    <p><img src="/img/tutorials/python-five.png" height="50" width="180" /></p>
+    <p><img src="../img/tutorials/python-five.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-five-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-five-java.html">Java</a></li>
@@ -129,7 +129,7 @@ limitations under the License.
     <p>
       <a href="http://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html">Request/reply pattern</a> example
     </p>
-    <p><img src="/img/tutorials/python-six.png" height="50" width="180" /></p>
+    <p><img src="../img/tutorials/python-six.png" height="50" width="180" /></p>
     <ul>
       <li><a href="/tutorials/tutorial-six-python.html">Python</a></li>
       <li><a href="/tutorials/tutorial-six-java.html">Java</a></li>

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -73,13 +73,13 @@ Current release series upgrade compatibility with full stop upgrade:
 | 3.5.x    | 3.7.x  |
 | =< 3.4.x | 3.6.16 |
 
-`3.7.18` and later `3.7.x` versions support [rolling upgrades](#rolling-upgrades) to `3.8.x` using [feature flags](/feature-flags.html).
+`3.7.18` and later `3.7.x` versions support [rolling upgrades](#rolling-upgrades) to `3.8.x` using [feature flags](./feature-flags.html).
 
 
 ## <a id="rabbitmq-erlang-version-requirement" class="anchor" href="#rabbitmq-erlang-version-requirement">Erlang Version Requirements</a>
 
 We recommend that you upgrade Erlang together with RabbitMQ.
-Please refer to the [Erlang Version Requirements](/which-erlang.html) guide.
+Please refer to the [Erlang Version Requirements](./which-erlang.html) guide.
 
 
 ## <a id="unsupported-inplace-upgrade" class="anchor" href="#unsupported-inplace-upgrade">Features that Do Not Support In-place Upgrades</a>
@@ -424,7 +424,7 @@ during shutdown, which blocks subsequent upgrade steps:
 * [OTP-14441](https://bugs.erlang.org/browse/ERL-430): fixed in Erlang/OTP `19.3.6` and `20.0`
 * [OTP-14509](https://bugs.erlang.org/browse/ERL-448): fixed in Erlang/OTP `19.3.6.2` and `20.0.2`
 
-Please note that both issues affect old and [no longer supported version of Erlang](/which-erlang.html).
+Please note that both issues affect old and [no longer supported version of Erlang](./which-erlang.html).
 
 A node that suffered from the above bugs will fail to shut down and stop responding to inbound
 connections, including those of CLI tools. Such node's OS process has to be terminated
@@ -659,7 +659,7 @@ See the [Upgrading Multiple Nodes](#multiple-nodes-upgrade) section above.
 
 ### Assess Cluster Health
 
-Make sure nodes are healthy and there are no [network partition](/partitions.html) or [disk or memory alarms](/alarms.html) in effect.
+Make sure nodes are healthy and there are no [network partition](./partitions.html) or [disk or memory alarms](./alarms.html) in effect.
 
 RabbitMQ management UI, CLI tools or HTTP API can be used for
 assessing the health of the system.

--- a/site/uri-query-parameters.md
+++ b/site/uri-query-parameters.md
@@ -111,7 +111,7 @@ against the hostname `myhost`.
   <tr>
     <td><code>heartbeat</code></td>
     <td>
-      <a href="/heartbeats.html">Heartbeat</a> timeout value in seconds (an integer)
+      <a href="./heartbeats.html">Heartbeat</a> timeout value in seconds (an integer)
       to negotiate with the server.
     </td>
   </tr>

--- a/site/uri-query-parameters.md
+++ b/site/uri-query-parameters.md
@@ -130,7 +130,7 @@ against the hostname `myhost`.
   </tr>
 </table>
 
-[TLS options](/ssl.html) can also be specified globally using the
+[TLS options](./ssl.html) can also be specified globally using the
 `amqp_client.ssl_options` configuration key in the `rabbitmq.config` or
 `advanced.config` file in this manner:
 
@@ -149,4 +149,4 @@ against the hostname `myhost`.
 They will be merged with the TLS parameters from the URI (the latter will take
 precedence) and affect all outgoing RabbitMQ Erlang client connections on the
 node, including plugins that use the client internally (Federation, Shovel,
-etc). Please see the [TLS guide](/ssl.html) for details.
+etc). Please see the [TLS guide](./ssl.html) for details.

--- a/site/versions.md
+++ b/site/versions.md
@@ -23,8 +23,8 @@ This guide explains what release series of RabbitMQ are currently covered by
 general or extended support policies, which release series is coming next, and
 what series are no longer supported.
 
-For guidance on upgrades, see the [Upgrade](/upgrade.html) and [Blue/Green
-Deployment Upgrade](/blue-green-upgrade.html) guides.
+For guidance on upgrades, see the [Upgrade](./upgrade.html) and [Blue/Green
+Deployment Upgrade](./blue-green-upgrade.html) guides.
 
 ## <a id="currently-supported" class="anchor" href="#currently-supported">Currently Supported Release Series</a>
 
@@ -66,9 +66,9 @@ Deployment Upgrade](/blue-green-upgrade.html) guides.
   </tr>
 </table>
 
-<sup>1</sup> **General Support** means patch releases that are [produced regularly](/changelog.html) based on feedback from all users.
+<sup>1</sup> **General Support** means patch releases that are [produced regularly](./changelog.html) based on feedback from all users.
 
-<sup>2</sup> **Extended Support** means *security patches* and *high-severity issues* reported by users with a [commercial license](/contact.html#paid-support).
+<sup>2</sup> **Extended Support** means *security patches* and *high-severity issues* reported by users with a [commercial license](./contact.html#paid-support).
 
 
 ## <a id="" class="anchor" href="#next-release-series">Next Release Series</a>
@@ -151,7 +151,7 @@ As of 6 January 2022, the next release series has not been announced yet.
   </tr>
 </table>
 
-To learn more about individual releases, please see the [change log](/changelog.html).
+To learn more about individual releases, please see the [change log](./changelog.html).
 
 
 ## <a id="prior-to-v3x" class="anchor" href="#prior-to-v3x">Versions prior to v3.x</a>

--- a/site/vhosts.md
+++ b/site/vhosts.md
@@ -33,7 +33,7 @@ Virtual hosts provide logical grouping and separation of
 resources. Separation of physical resources is not a goal of virtual
 hosts and should be considered an implementation detail.
 
-For example, [resource permissions](/access-control.html) in RabbitMQ are
+For example, [resource permissions](./access-control.html) in RabbitMQ are
 scoped per virtual host. A user doesn't have global permissions, only
 permissions in one or more virtual hosts. User tags can be considered
 global permissions but they are an exception to the rule.
@@ -45,7 +45,7 @@ to clarify what virtual host(s) they apply to.
 
 A virtual host has a name. When an AMQP 0-9-1 client connects to
 RabbitMQ, it specifies a vhost name to connect to. If authentication
-succeeds and the username provided was [granted permissions](/access-control.html) to the
+succeeds and the username provided was [granted permissions](./access-control.html) to the
 vhost, connection is established.
 
 Connections to a vhost can only operate on exchanges, queues, bindings, and so on in
@@ -58,16 +58,16 @@ can involve vhosts in different clusters or the same cluster (or a single node).
 
 ## <a id="creating" class="anchor" href="#creating">Creating a Virtual Host</a>
 
-A virtual host can be created using CLI tools or an [HTTP API](/management.html) endpoint.
+A virtual host can be created using CLI tools or an [HTTP API](./management.html) endpoint.
 
-A newly created vhost will have a default set of [exchanges](/tutorials/amqp-concepts.html)
-but no other entities and no [user permissions](/access-control.html). For a user to be able to connect
+A newly created vhost will have a default set of [exchanges](./tutorials/amqp-concepts.html)
+but no other entities and no [user permissions](./access-control.html). For a user to be able to connect
 and use the virtual host, permissions to it must be [granted]() to every user that will use the vhost,
-e.g. using [rabbitmqctl set_permissions](/rabbitmqctl.8.html#set_permissions).
+e.g. using [rabbitmqctl set_permissions](./rabbitmqctl.8.html#set_permissions).
 
 ### Using CLI Tools
 
-A virtual host can be created using [rabbitmqctl](/cli.html)'s `add_vhost` command
+A virtual host can be created using [rabbitmqctl](./cli.html)'s `add_vhost` command
 which accepts virtual host name as the only mandatory argument.
 
 Here's an example that creates a virtual host named `qa1`:
@@ -78,7 +78,7 @@ rabbitmqctl add_vhost qa1
 
 ### Using HTTP API
 
-A virtual host can be created using the `PUT /api/vhosts/{name}` [HTTP API](/management.html) endpoint
+A virtual host can be created using the `PUT /api/vhosts/{name}` [HTTP API](./management.html) endpoint
 where `{name}` is the name of the virtual host
 
 Here's an example that uses [curl](https://curl.haxx.se/) to create a virtual host `vh1` by contacting
@@ -99,19 +99,19 @@ When a number of virtual hosts is created in a loop, CLI and HTTP API clients ca
 rate of virtual host creation and experience timeouts. If that's the case operation timeout should be increased
 and delays should be introduced between operations.
 
-[Definition export and import](/definitions.html) is the recommended
+[Definition export and import](./definitions.html) is the recommended
 way of pre-configuring many virtual hosts at deployment time.
 
 
 ## <a id="deleting" class="anchor" href="#deleting">Deleting a Virtual Host</a>
 
-A virtual host can be deleted using CLI tools or an [HTTP API](/management.html) endpoint.
+A virtual host can be deleted using CLI tools or an [HTTP API](./management.html) endpoint.
 
 Deleting a virtual host will permanently delete all entities (queues, exchanges, bindings, policies, permissions, etc) in it.
 
 ### Using CLI Tools
 
-A virtual host can be deleted using [rabbitmqctl](/cli.html)'s `delete_vhost` command
+A virtual host can be deleted using [rabbitmqctl](./cli.html)'s `delete_vhost` command
 which accepts virtual host name as the only mandatory argument.
 
 Here's an example that deletes a virtual host named `qa1`:
@@ -122,7 +122,7 @@ rabbitmqctl delete_vhost qa1
 
 ### Using HTTP API
 
-A virtual host can be deleted using the `DELETE /api/vhosts/{name}` [HTTP API](/management.html) endpoint
+A virtual host can be deleted using the `DELETE /api/vhosts/{name}` [HTTP API](./management.html) endpoint
 where `{name}` is the name of the virtual host
 
 Here's an example that uses [curl](https://curl.haxx.se/) to delete a virtual host `vh1` by contacting
@@ -136,7 +136,7 @@ curl -u userename:pa$sw0rD -X DELETE http://rabbitmq.local:15672/api/vhosts/vh1
 ## Virtual Hosts and STOMP
 
 Like AMQP 0-9-1, STOMP includes the [concept of virtual hosts](https://stomp.github.io/stomp-specification-1.2.html#CONNECT_or_STOMP_Frame). See
-the [STOMP guide](/stomp.html) for details.
+the [STOMP guide](./stomp.html) for details.
 
 
 ## Virtual Hosts and MQTT
@@ -145,7 +145,7 @@ Unlike AMQP 0-9-1 and STOMP, MQTT doesn't have the concept of virtual
 hosts. MQTT connections use a single RabbitMQ host by default. There
 are MQTT-specific convention and features that make it possible for
 clients to connect to a specific vhosts without any client library
-modifications. See the [MQTT guide](/mqtt.html) for details.
+modifications. See the [MQTT guide](./mqtt.html) for details.
 
 
 ## <a id="limits" class="anchor" href="#limits">Limits</a>
@@ -154,7 +154,7 @@ In some cases it is desirable to limit the maximum allowed number of queues
 or concurrent client connections in a vhost. As of RabbitMQ 3.7.0,
 this is possible via **per-vhost limits**.
 
-These limits can be configured using `rabbitmqctl` or [HTTP API](/management.html).
+These limits can be configured using `rabbitmqctl` or [HTTP API](./management.html).
 
 ### Configuring Limits Using rabbitmqctl
 

--- a/site/web-mqtt.md
+++ b/site/web-mqtt.md
@@ -19,17 +19,17 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 The Web MQTT plugin makes it possible to use
-[MQTT](/mqtt.html) over a WebSocket connection.
+[MQTT](./mqtt.html) over a WebSocket connection.
 
 The goal of this plugin is to enable MQTT messaging in Web applications.
 
-A similar plugin, [Web STOMP plugin](/web-stomp.html), makes it possible to use [STOMP](/stomp.html) over
+A similar plugin, [Web STOMP plugin](./web-stomp.html), makes it possible to use [STOMP](./stomp.html) over
 WebSockets.
 
 ## <a id="how-it-works" class="anchor" href="#how-it-works">How It Works</a>
 
 RabbitMQ Web MQTT plugin is rather simple. It takes the MQTT protocol,
-as provided by [RabbitMQ MQTT plugin](/mqtt.html) and exposes it using
+as provided by [RabbitMQ MQTT plugin](./mqtt.html) and exposes it using
 WebSockets.
 
 
@@ -37,7 +37,7 @@ WebSockets.
 
 `rabbitmq_web_mqtt` plugin ships with RabbitMQ.
 
-To enable the plugin run [rabbitmq-plugins](/man/rabbitmq-plugins.8.html):
+To enable the plugin run [rabbitmq-plugins](./man/rabbitmq-plugins.8.html):
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_web_mqtt
@@ -131,11 +131,11 @@ We encourage you to take a look [at the source code](https://github.com/rabbitmq
 
 When no configuration is specified the Web MQTT plugin will listen on
 all interfaces on port 15675 and have a default user login and password of
-`guest`/`guest`. Note that this user is only [allowed to connect from localhost](/access-control.html) by default.
+`guest`/`guest`. Note that this user is only [allowed to connect from localhost](./access-control.html) by default.
 We highly recommend creating a separate user for production systems.
 
 To change the listener port, edit your
-[Configuration file](/configure.html#configuration-files),
+[Configuration file](./configure.html#configuration-files),
 to contain a `port` variable for the `rabbitmq_web_mqtt` application.
 
 For example, a complete configuration file which changes the listener
@@ -150,7 +150,7 @@ See [RabbitMQ Networking guide](networking.html) for more information.
 
 ### <a id="tls" class="anchor" href="#tls">TLS (WSS)</a>
 
-The plugin supports WebSockets with TLS (WSS) connections. See [TLS guide](/ssl.html)
+The plugin supports WebSockets with TLS (WSS) connections. See [TLS guide](./ssl.html)
 to learn more about TLS support in RabbitMQ.
 
 TLS configuration parameters are provided in the `web_mqtt.ssl` section:
@@ -167,10 +167,10 @@ web_mqtt.ssl.keyfile    = /path/to/server_key.pem
 
 The TLS listener port, server certificate file, private key and CA certificate bundle are mandatory options.
 Password is also mandatory if the private key uses one.
-An extended list of TLS settings is largely identical to those [for the core server](/ssl.html).
+An extended list of TLS settings is largely identical to those [for the core server](./ssl.html).
 Full list of options accepted by this plugin can be found in [Ranch documentation](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_ssl/).
 
-A separate guide on [troubleshooting TLS](/troubleshooting-ssl.html) is also available.
+A separate guide on [troubleshooting TLS](./troubleshooting-ssl.html) is also available.
 
 
 #### <a id="tls-versions" class="anchor" href="#tls-versions">Enabled TLS Versions and Cipher Suites</a>
@@ -178,10 +178,10 @@ A separate guide on [troubleshooting TLS](/troubleshooting-ssl.html) is also ava
 It is possible to configure what TLS versions and cipher suites will be used by RabbitMQ. Note that not all
 suites will be available on all systems.
 
-RabbitMQ TLS guide has [a section on TLS versions](/ssl.html#disabling-tls-versions) and another one
-[on cipher suites](/ssl.html#cipher-suites). Below is an example
-in the [advanced config format](/configure.html#advanced-config-file) that configures cipher suites
-and a number of other [TLS options](/ssl.html) for the plugin:
+RabbitMQ TLS guide has [a section on TLS versions](./ssl.html#disabling-tls-versions) and another one
+[on cipher suites](./ssl.html#cipher-suites). Below is an example
+in the [advanced config format](./configure.html#advanced-config-file) that configures cipher suites
+and a number of other [TLS options](./ssl.html) for the plugin:
 
 <pre class="lang-ini">
 web_mqtt.ssl.port       = 15676
@@ -212,7 +212,7 @@ web_mqtt.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
 
 #### Troubleshooting TLS (WSS)
 
-See [RabbitMQ TLS](/ssl.html) and [TLS Troubleshooting](/troubleshooting-ssl.html) for additional
+See [RabbitMQ TLS](./ssl.html) and [TLS Troubleshooting](./troubleshooting-ssl.html) for additional
 information.
 
 ## <a id="proxy-protocol" class="anchor" href="#proxy-protocol">Proxy Protocol</a>
@@ -224,7 +224,7 @@ This feature is disabled by default, to enable it for MQTT clients:
 web_mqtt.proxy_protocol = true
 </pre>
 
-See the [Networking Guide](/networking.html#proxy-protocol) for more information
+See the [Networking Guide](./networking.html#proxy-protocol) for more information
 about the proxy protocol.
 
 ## <a id="advanced-options" class="anchor" href="#advanced-options">Advanced Options</a>

--- a/site/web-stomp.md
+++ b/site/web-stomp.md
@@ -210,7 +210,7 @@ default STOMP credentials are used. The credentials found
 in the CONNECT frame, if any, are ignored.
 
 This is an advanced feature that is only exposed via the [advanced configuration file](./configure.html#configuration-files)
-or the <a href="/configure.html#erlang-term-config-file">classic config format</a>:
+or the <a href="./configure.html#erlang-term-config-file">classic config format</a>:
 
 <pre class="lang-erlang">
 [

--- a/site/web-stomp.md
+++ b/site/web-stomp.md
@@ -19,25 +19,25 @@ limitations under the License.
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 The Web STOMP plugin makes it possible to use
-[STOMP](/stomp.html) over a WebSocket connection.
+[STOMP](./stomp.html) over a WebSocket connection.
 
 The goal of this plugin is to enable STOMP messaging in Web applications.
 
-A similar plugin, [Web MQTT plugin](/web-mqtt.html), makes it possible to use [MQTT](/mqtt.html) over
+A similar plugin, [Web MQTT plugin](./web-mqtt.html), makes it possible to use [MQTT](./mqtt.html) over
 WebSockets.
 
 ## <a id="how-it-works" class="anchor" href="#how-it-works">How It Works</a>
 
 RabbitMQ Web STOMP plugin is a minimalistic "bridge" between the STOMP protocol implementation
-provided by [RabbitMQ STOMP plugin](/stomp.html), and WebSocket clients.
+provided by [RabbitMQ STOMP plugin](./stomp.html), and WebSocket clients.
 
-RabbitMQ Web STOMP is fully compatible with the [RabbitMQ STOMP](/stomp.html) plugin.
+RabbitMQ Web STOMP is fully compatible with the [RabbitMQ STOMP](./stomp.html) plugin.
 
 ## <a id="enabling" class="anchor" href="#enabling">Enabling the Plugin</a>
 
 `rabbitmq_web_stomp` plugin ships with RabbitMQ.
 
-To enable the plugin run [rabbitmq-plugins](/man/rabbitmq-plugins.8.html):
+To enable the plugin run [rabbitmq-plugins](./man/rabbitmq-plugins.8.html):
 
 <pre class="lang-bash">
 rabbitmq-plugins enable rabbitmq_web_stomp
@@ -121,7 +121,7 @@ all interfaces on port 15674 and have a default user login/passcode of
 We highly recommend creating a separate user for production systems.
 
 To change the listener port, edit your
-[Advanced configuration file](/configure.html#configuration-files),
+[Advanced configuration file](./configure.html#configuration-files),
 to contain a `tcp_config` section with a `port` variable for the `rabbitmq_web_stomp` application.
 
 For example, a complete configuration file which changes the listener
@@ -138,7 +138,7 @@ for details about accepted parameters.
 
 ### <a id="tls" class="anchor" href="#tls">TLS (WSS)</a>
 
-The plugin supports WebSockets with TLS (WSS) connections. See [TLS guide](/ssl.html)
+The plugin supports WebSockets with TLS (WSS) connections. See [TLS guide](./ssl.html)
 to learn more about TLS support in RabbitMQ.
 
 TLS configuration parameters are provided in the `web_stomp.ssl` section:
@@ -154,7 +154,7 @@ web_stomp.ssl.password   = changeme
 
 The TLS listener port, server certificate file, private key and CA certificate bundle are mandatory options.
 Password is also mandatory if the private key uses one.
-An extended list of TLS settings is largely identical to those [for the core server](/ssl.html).
+An extended list of TLS settings is largely identical to those [for the core server](./ssl.html).
 Full list of options accepted by this plugin can be found in [Ranch documentation](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_ssl/).
 
 #### <a id="tls-versions" class="anchor" href="#tls-versions">Enabled TLS Versions and Cipher Suites</a>
@@ -162,10 +162,10 @@ Full list of options accepted by this plugin can be found in [Ranch documentatio
 It is possible to configure what TLS versions and cipher suites will be used by RabbitMQ. Note that not all
 suites will be available on all systems.
 
-RabbitMQ TLS guide has [a section on TLS versions](/ssl.html#disabling-tls-versions) and another one
-[on cipher suites](/ssl.html#cipher-suites). Below is an example
-in the [advanced config format](/configure.html#advanced-config-file) that configures cipher suites
-and a number of other [TLS options](/ssl.html) for the plugin:
+RabbitMQ TLS guide has [a section on TLS versions](./ssl.html#disabling-tls-versions) and another one
+[on cipher suites](./ssl.html#cipher-suites). Below is an example
+in the [advanced config format](./configure.html#advanced-config-file) that configures cipher suites
+and a number of other [TLS options](./ssl.html) for the plugin:
 
 <pre class="lang-ini">
 web_stomp.ssl.port       = 15673
@@ -196,7 +196,7 @@ web_stomp.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
 
 #### Troubleshooting TLS (WSS)
 
-See [RabbitMQ TLS](/ssl.html) and [TLS Troubleshooting](/troubleshooting-ssl.html) for additional
+See [RabbitMQ TLS](./ssl.html) and [TLS Troubleshooting](./troubleshooting-ssl.html) for additional
 information.
 
 
@@ -209,7 +209,7 @@ present, these credentials will be used. Otherwise, the
 default STOMP credentials are used. The credentials found
 in the CONNECT frame, if any, are ignored.
 
-This is an advanced feature that is only exposed via the [advanced configuration file](/configure.html#configuration-files)
+This is an advanced feature that is only exposed via the [advanced configuration file](./configure.html#configuration-files)
 or the <a href="/configure.html#erlang-term-config-file">classic config format</a>:
 
 <pre class="lang-erlang">
@@ -228,7 +228,7 @@ This feature is disabled by default, to enable it for clients:
 web_stomp.proxy_protocol = true
 </pre>
 
-See the [Networking Guide](/networking.html#proxy-protocol) for more information
+See the [Networking Guide](./networking.html#proxy-protocol) for more information
 about the proxy protocol.
 
 

--- a/site/which-erlang.md
+++ b/site/which-erlang.md
@@ -37,7 +37,7 @@ The table below provides an Erlang compatibility matrix of currently supported R
 For RabbitMQ releases that have reached end of life, see [Unsupported Series Compatibility Matrix](#eol-series).
 
 <table class="matrix">
-  <th><a href="/versions.html">RabbitMQ version</a></th>
+  <th><a href="./versions.html">RabbitMQ version</a></th>
   <th>Minimum required Erlang/OTP</th>
   <th>Maximum supported Erlang/OTP</th>
   <th>Notes</th>
@@ -363,7 +363,7 @@ source, including specific tags from GitHub, a much more pleasant experience.
 ### <a id="eol-series" class="anchor" href="#eol-series">Unsupported RabbitMQ Series</a>
 
 <table class="matrix">
-  <th><a href="/changelog.html">Unsupported RabbitMQ Series</a></th>
+  <th><a href="./changelog.html">Unsupported RabbitMQ Series</a></th>
   <th>Minimum required Erlang/OTP</th>
   <th>Maximum supported Erlang/OTP</th>
   <th>Notes</th>

--- a/site/which-erlang.md
+++ b/site/which-erlang.md
@@ -315,7 +315,7 @@ Most recent versions can be obtained from a number of sources:
 Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
 heavily sliced and diced into dozens of packages. In addition, unless the system
 has backport repositories enabled, the versions tend to be quite old.
-See [Debian and Ubuntu installation guide](/install-debian.html) for
+See [Debian and Ubuntu installation guide](./install-debian.html) for
 more information on the essential packages, dependencies, and alternative apt repositories.
 
 ## <a id="redhat" class="anchor" href="#redhat">Installing Erlang/OTP on RHEL, CentOS and Fedora</a>
@@ -324,7 +324,7 @@ There are multiple RPM packages available for Erlang/OTP. The recommended option
 the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
 It closely follows the latest Erlang/OTP patch release schedule.
 
-See [CentOS, RHEL and Fedora installation guide](/install-rpm.html) for more information on the available options.
+See [CentOS, RHEL and Fedora installation guide](./install-rpm.html) for more information on the available options.
 
 
 ## <a id="clusters" class="anchor" href="#clusters">Erlang Versions in Clusters</a>

--- a/site/windows-quirks.md
+++ b/site/windows-quirks.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Windows-specific Issues
 
-This guide is a companion to the main [Windows installation guide](/install-windows.html).
+This guide is a companion to the main [Windows installation guide](./install-windows.html).
 
 It documents known conditions and scenarios which can cause RabbitMQ Windows service
 or CLI tools to malfunction.
@@ -61,7 +61,7 @@ the version you wish RabbitMQ to use. If you must upgrade Erlang, use this proce
 .\rabbitmq-service.bat start
 </pre>
 
-If any environment variables have changed in the mean time, [Windows service reinstallation](/configure.html#rabbitmq-env-file-windows) would
+If any environment variables have changed in the mean time, [Windows service reinstallation](./configure.html#rabbitmq-env-file-windows) would
 also be necessary.
 
 
@@ -82,7 +82,7 @@ It expects input in UTF-8, but the console will typically use some other encodin
 One of these options can be used to mitigate:
 
  * Override `RABBITMQ_BASE` to point to a directory
-   that only has ASCII characters and [**re-install** the Windows service](/configure.html#rabbitmq-env-file-windows).
+   that only has ASCII characters and [**re-install** the Windows service](./configure.html#rabbitmq-env-file-windows).
  * Edit the file `rabbitmq-server.bat` and change the
    line `set TDP0=%~dp0` to `set TDP0=%~dps0`.
    This will use short paths (the infamous `C:\PROGRA~1`) everywhere.
@@ -90,7 +90,7 @@ One of these options can be used to mitigate:
 
 ## <a id="non-ascii-cli" class="anchor" href="#non-ascii-cli">CLI Tools Display or Parse non-ASCII Characters Incorrectly</a>
 
-Similarly, [RabbitMQ CLI tools](/cli.html) will expect command line
+Similarly, [RabbitMQ CLI tools](./cli.html) will expect command line
 parameters to be encoded in UTF-8, and display strings as
 UTF-8. The console will instead provide and expect some country-specific encoding.
 
@@ -98,18 +98,18 @@ UTF-8. The console will instead provide and expect some country-specific encodin
 
 One of these options can be used to mitigate:
 
- * Avoid using non-ASCII characters in RabbitMQ installation and [node directory](/relocate.html) paths
+ * Avoid using non-ASCII characters in RabbitMQ installation and [node directory](./relocate.html) paths
  * On recent versions of Windows, issue the command
    <pre class="lang-powershell">chcp 65001</pre> before using CLI tools to force
    the console to use UTF-8
- * Where possible, use the [management plugin](/management.html) instead of CLI tools.
+ * Where possible, use the [management plugin](./management.html) instead of CLI tools.
 
 
 ## <a id="cookie-location" class="anchor" href="#cookie-location">Installing as a non-administrator User Leaves `.erlang.cookie` in the Wrong Place</a>
 
-If RabbitMQ is installed using a non-administrative account, a [shared secret](/cli.html#erlang-cookie) file
+If RabbitMQ is installed using a non-administrative account, a [shared secret](./cli.html#erlang-cookie) file
 used by nodes and CLI tools will not be placed into a correct location,
-leading to [authentication failures](/cli.html#cli-authentication-failures) when `rabbitmqctl.bat`
+leading to [authentication failures](./cli.html#cli-authentication-failures) when `rabbitmqctl.bat`
 and other CLI tools are used.
 
 ### Mitigation
@@ -121,7 +121,7 @@ One of these options can be used to mitigate:
    from `%SystemRoot%` or `%SystemRoot%\system32\config\systemprofile`
    to `%HOMEDRIVE%%HOMEPATH%`.
 
-See [How CLI Tools Authenticate to Nodes (and Nodes to Each Other](/cli.html#erlang-cookie) in the CLI guide.
+See [How CLI Tools Authenticate to Nodes (and Nodes to Each Other](./cli.html#erlang-cookie) in the CLI guide.
 
 
 ## <a id="computername-vs-hostname" class="anchor" href="#computername-vs-hostname">COMPUTERNAME is different from HOSTNAME</a>


### PR DESCRIPTION
This is a batch of changes to ensure that markdown files use relative links to other files (other markdown files and image files), instead of using the absolute path from the root of the website. 

This change makes the docs source more portable/usable for building in other contexts, like for the Tanzu RabbitMQ site. It adds no content or functionality change to the existing open source rabbitmq site.