### PR TITLE
Adding context to tcp_listen_options on keepalives & exit_on_close on configure page

### DIFF
--- a/site/configure.md
+++ b/site/configure.md
@@ -1072,22 +1072,36 @@ auth_mechanisms.2 = AMQPLAIN
   <tr>
     <td><code>tcp_listen_options</code></td>
     <td>
-      Default socket options. You probably don't want to
-      change this.
-
+      Default socket options. You may want to change these 
+      when you troubleshoot network issues.
       <p>
-        Default:
-
+        Default: 
 <pre class="lang-ini">
 tcp_listen_options.backlog = 128
 tcp_listen_options.nodelay = true
 tcp_listen_options.linger.on = true
 tcp_listen_options.linger.timeout = 0
-tcp_listen_options.exit_on_close = false
 </pre>
       </p>
+
+<br/>
+<pre class="lang-ini">
+tcp_listen_options.exit_on_close = false
+</pre>
+
+  Set `tcp_listen_options.exit_on_close` to `true` to have RabbitMQ immediately close sockets when
+  the client disconnects. This does not interfere with AMQP clients. <br/>
+
+<br/>
+<pre class="lang-ini">
+tcp_listen_options.keepalive = false</pre>
+<p>
+  Set `tcp_listen_options.keepalive` to `true` to enable TCP keepalives. These can potentially replace AMQP heartbeats. For more information, visit the <a href="networking.html">Networking</a> page. 
+  <br/>
+  </p>
     </td>
   </tr>
+  
   <tr>
     <td><code>hipe_compile</code></td>
     <td>


### PR DESCRIPTION
Adding context to tcp_listen_options on options keepalive & exit_on_close
https://www.rabbitmq.com/configure.html 


from issue https://github.com/rabbitmq/rabbitmq-website/issues/1412

proposed changes look:
![configure page update](https://user-images.githubusercontent.com/83782411/171511762-cba73905-c528-4183-a52a-ea39241a0bf7.png)

