### PR TITLE
Add Kubernetes to list of supported deployment methods.

### DIFF
--- a/site/index.xml
+++ b/site/index.xml
@@ -109,7 +109,7 @@ limitations under the License.
                 <img src="./img/monitor.svg" height="62" width="71" alt="Developer Experience" title="Developer Experience" />
                 <h2>Developer Experience</h2>
                 <p>
-                  Deploy with <a href='/download.html'>BOSH, Chef, Docker and Puppet</a>. Develop cross-language messaging with favorite programming languages such as: Java, .NET, PHP, Python, JavaScript, Ruby, Go, <a href='/devtools.html'>and many others</a>.
+                  Deploy with <a href='/download.html'>Kubernetes, BOSH, Chef, Docker and Puppet</a>. Develop cross-language messaging with favorite programming languages such as: Java, .NET, PHP, Python, JavaScript, Ruby, Go, <a href='/devtools.html'>and many others</a>.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Kubernetes was absent from the list of supported deployment types on the homepage.