### PR TITLE
`time_limit` of `process_data_events` is set to `None`

### DIFF
--- a/site/tutorials/tutorial-six-python.md
+++ b/site/tutorials/tutorial-six-python.md
@@ -294,6 +294,9 @@ class FibonacciRpcClient(object):
             on_message_callback=self.on_response,
             auto_ack=True)
 
+        self.response = None
+        self.corr_id = None
+
     def on_response(self, ch, method, props, body):
         if self.corr_id == props.correlation_id:
             self.response = body
@@ -309,8 +312,7 @@ class FibonacciRpcClient(object):
                 correlation_id=self.corr_id,
             ),
             body=str(n))
-        while self.response is None:
-            self.connection.process_data_events()
+        self.connection.process_data_events(time_limit=None)
         return int(self.response)
 
 


### PR DESCRIPTION
Calling `connection.process_data_events` in loop, uses 100% CPU until response is returned, and this makes problem if server does not response.
Passing None to `process_data_events`, blocks until I/O produces actionable events.