### PR TITLE
Rabbitmq website - Remove restore

### DIFF
--- a/site/changelog.md
+++ b/site/changelog.md
@@ -39,6 +39,46 @@ published separately.
   </tr>
 
   <tr>
+    <td class="centre">3.10.5</td>
+    <td class="centre">6 June 2022</td>
+    <td>
+      <ul>
+        <li>Bug fixes</li>
+        <li>Debian package metadata update</li>
+      </ul>
+    </td>
+    <td class="centre">
+      <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.5">Release notes</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td class="centre">3.9.20</td>
+    <td class="centre">6 June 2022</td>
+    <td>
+      <ul>
+        <li>Debian package metadata update</li>
+      </ul>
+    </td>
+    <td class="centre">
+      <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.20">Release notes</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td class="centre">3.8.34</td>
+    <td class="centre">6 June 2022</td>
+    <td>
+      <ul>
+        <li>Debian package metadata update</li>
+      </ul>
+    </td>
+    <td class="centre">
+      <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.34">Release notes</a>
+    </td>
+  </tr>
+
+  <tr>
     <td class="centre">3.10.4</td>
     <td class="centre">1 June 2022</td>
     <td>

--- a/site/devtools.md
+++ b/site/devtools.md
@@ -83,6 +83,7 @@ Miscellaneous projects:
  * [pika](http://pypi.python.org/pypi/pika), a pure-Python AMQP 0-9-1 client ([source code](https://github.com/pika/pika),
    [API reference](http://readthedocs.org/docs/pika/en/latest/index.html))
  * [rstream](https://github.com/qweeze/rstream): RabbitMQ Stream Python client
+ * [rbfly](https://gitlab.com/wrobell/rbfly): RabbitMQ Stream Python client
  * [aio-pika](https://github.com/mosquito/aio-pika), a pure-Python AMQP 0-9-1 client built for Python 3 and asyncio ([source code](https://github.com/mosquito/aio-pika),
    [API reference](https://aio-pika.readthedocs.org/))
  * [Celery](http://docs.celeryproject.org/en/latest/), a distributed task queue for Django and pure Python

--- a/site/event-exchange.md
+++ b/site/event-exchange.md
@@ -20,14 +20,13 @@ limitations under the License.
 ## Overview
 
 Client connection, channels, queues, consumers, and other parts of the
-system naturally generate events. For example, when a connection is
+system [naturally generate events](logging.html#internal-events). For example, when a connection is
 accepted, authenticated and access to the target virtual host is
 authorised, it will emit an event of type `connection_created`. When a
 connection is closed or fails for any reason, a `connection_closed`
 event is emitted.
 
-
-Monitoring and auditing services can be interested in observing those
+[Monitoring](monitoring.html) and auditing services can be interested in observing those
 events. RabbitMQ has a minimalistic mechanism for event notifications
 that can be exposed to RabbitMQ clients with a plugin.
 

--- a/site/features.xml
+++ b/site/features.xml
@@ -86,7 +86,7 @@ limitations under the License.
           RabbitMQ supports <a href="quorum-queues.html">replicated queues</a>
           and <a href="stream.html">streams</a>. machines in a cluster, ensuring that even in the event of
           hardware failure, messages are safe as long as there is a majority
-          of cluster nodes onlnie.
+          of cluster nodes online.
         </p>
 
         <h3>Multi-protocol</h3>

--- a/site/index.xml
+++ b/site/index.xml
@@ -109,7 +109,7 @@ limitations under the License.
                 <img src="./img/monitor.svg" height="62" width="71" alt="Developer Experience" title="Developer Experience" />
                 <h2>Developer Experience</h2>
                 <p>
-                  Deploy with <a href='/download.html'>BOSH, Chef, Docker and Puppet</a>. Develop cross-language messaging with favorite programming languages such as: Java, .NET, PHP, Python, JavaScript, Ruby, Go, <a href='/devtools.html'>and many others</a>.
+                  Deploy with <a href='/download.html'>Kubernetes, BOSH, Chef, Docker and Puppet</a>. Develop cross-language messaging with favorite programming languages such as: Java, .NET, PHP, Python, JavaScript, Ruby, Go, <a href='/devtools.html'>and many others</a>.
                 </p>
               </div>
             </div>

--- a/site/java-client.md
+++ b/site/java-client.md
@@ -50,7 +50,7 @@ library.
 
 ### Latest Version
 
-The current release of the RabbitMQ Java client is `5.14.2`.
+The current release of the RabbitMQ Java client is `5.15.0`.
 
 ### Adding Library Dependency
 
@@ -63,7 +63,7 @@ If you're using Maven, add this dependency to the POM file of your project:
 &lt;dependency&gt;
   &lt;groupId&gt;com.rabbitmq&lt;/groupId&gt;
   &lt;artifactId&gt;amqp-client&lt;/artifactId&gt;
-  &lt;version&gt;5.14.2&lt;/version&gt;
+  &lt;version&gt;5.15.0&lt;/version&gt;
 &lt;/dependency&gt;
 </pre>
 
@@ -71,7 +71,7 @@ If using Gradle:
 
 <pre class="lang-groovy">
 dependencies {
-  compile 'com.rabbitmq:amqp-client:5.14.2'
+  compile 'com.rabbitmq:amqp-client:5.15.0'
 }
 </pre>
 
@@ -99,20 +99,20 @@ source.
   <tr>
     <td>Binary, compiled for JDK 8 (Android 7.0) or newer</td>
     <td>
-      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.14.2/amqp-client-5.14.2.jar">amqp-client-5.14.2.jar</a>
+      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.15.0/amqp-client-5.15.0.jar">amqp-client-5.15.0.jar</a>
     </td>
     <td>
-      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.14.2/amqp-client-5.14.2.jar.asc">Signature file</a>
+      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.15.0/amqp-client-5.15.0.jar.asc">Signature file</a>
     </td>
   </tr>
 
   <tr>
     <td>Source code</td>
     <td>
-      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.14.2/amqp-client-5.14.2-sources.jar">amqp-client-5.14.2-sources.jar</a>
+      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.15.0/amqp-client-5.15.0-sources.jar">amqp-client-5.15.0-sources.jar</a>
     </td>
     <td>
-      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.14.2/amqp-client-5.14.2-sources.jar.asc">Signature file</a>
+      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.15.0/amqp-client-5.15.0-sources.jar.asc">Signature file</a>
     </td>
   </tr>
 </table>
@@ -138,7 +138,7 @@ download it for off-line use:
   <tr>
     <td> A JAR file containing generated Javadoc documentation </td>
     <td>
-      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.14.2/amqp-client-5.14.2-javadoc.jar">amqp-client-5.14.2-javadoc.jar</a>
+      <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.15.0/amqp-client-5.15.0-javadoc.jar">amqp-client-5.15.0-javadoc.jar</a>
     </td>
     <td>
       <a href="https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.14.0/amqp-client-5.14.0-javadoc.jar.asc">Signature file</a>

--- a/site/jms-client.md
+++ b/site/jms-client.md
@@ -350,7 +350,7 @@ available:
 | `amqpRoutingKey`          |    No      | The routing key to use when publishing messages when an 'amqp' destination.                                                                                                                                                                   |
 | `amqpQueueName`           |    No      | Name of the RabbitMQ queue to receive messages from when an 'amqp' destination. This queue must exist when messages are received.                                                                                                                 |
 | `destinationName`         |    No      | Name of the JMS destination.                                                                                                                                                                                                                  |
-| `queueDeclareArguments`         |    No      | Arguments to use when declaring the AMQP queue. Use `key=value` pairs separated by commas for JNDI, e.g. `x-queue-type=quorum`.|
+<!-- | `queueDeclareArguments`         |    No      | Arguments to use when declaring the AMQP queue. Use `key=value` pairs separated by commas for JNDI, e.g. `x-queue-type=quorum`.| -->
 
 ## <a id="logging" class="anchor" href="#logging">Configuring Logging for the JMS Client</a>
 

--- a/site/kubernetes/operator/configure-operator-defaults.md
+++ b/site/kubernetes/operator/configure-operator-defaults.md
@@ -84,6 +84,17 @@ Comma-separated list of imagePullSecrets to set by default on all RabbitmqCluste
 New RabbitmqCluster Pods have no imagePullSecrets by default
 </td>
 </tr>
+<tr>
+<td>
+ENABLE_DEBUG_PPROF
+</td>
+<td>
+The default value is false because this variable should NOT be used in production. When it is set to true, it exposes a set of debug endpoints on the Operator Pod's metrics port for CPU and [memory profiling of the Operator with pprof](./debug-operator.md#operator-resource-usage-profiling).
+</td>
+<td>
+The pprof debug endpoint will not be exposed on the Operator Pod.
+</td>
+</tr>
 </table>
 
 -----

--- a/site/kubernetes/operator/debug-operator.md
+++ b/site/kubernetes/operator/debug-operator.md
@@ -1,0 +1,110 @@
+<!--
+Copyright (c) 2020-2021 VMware, Inc. or its affiliates.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Debugging the RabbitMQ Kubernetes Operators
+
+## <a id="overview" class="anchor" href="#overview">Overview</a>
+
+This guide covers how to debug a running instance of the RabbitMQ Kubernetes Operators.
+
+## <a id="operator-resource-usage-profiling" class="anchor" href="#operator-resource-usage-profiling">Profiling CPU / memory usage of the Operator Pods</a>
+
+<p class="box-warning">
+<b>N.B.:</b> It is not recommended to try these steps on a production system.
+</p>
+
+The RabbitMQ Operators are all able to expose CPU & memory profiling data through the [pprof tool](https://github.com/google/pprof/blob/main/doc/README.md).
+If you are seeing high resource consumption on one of your Operator Pods, you can access this data by enabling this feature.
+
+Patch the Operator Pod you would like to profile with the `ENABLE_DEBUG_PPROF` environment variable set to `True`. For example, for the Cluster Operator:
+<pre class="lang-bash">
+$ kubectl -n rabbitmq-system set env deployment/rabbitmq-cluster-operator ENABLE_DEBUG_PPROF=True
+deployment.apps/rabbitmq-cluster-operator env updated
+</pre>
+
+Port-forward to the Operator Pod using kubectl. You will want to forward to the metrics port on the Operator Pod, which
+by default is <code>9782</code> for the RabbitMQ Cluster Operator, and <code>8080</code> for the other operators.
+<pre class="lang-bash">
+$ kubectl -n rabbitmq-system port-forward deployment/rabbitmq-cluster-operator 9782
+Forwarding from 127.0.0.1:9782 -> 9782
+Forwarding from [::1]:9782 -> 9782
+</pre>
+
+In a separate terminal, you can now use <code>go tool pprof</code> to profile the Operator Pod. For example, to analyse
+memory allocations in the Pod:
+
+<pre class="lang-bash">
+$ go tool pprof "localhost:9782/debug/pprof/heap"
+Fetching profile over HTTP from http://localhost:9782/debug/pprof/heap
+Saved profile in /home/pprof/pprof.manager.alloc_objects.alloc_space.inuse_objects.inuse_space.001.pb.gz
+</pre>
+
+This opens a browser window to visualise the memory allocations in the profile.
+For more information on how to use pprof, see https://github.com/google/pprof/blob/main/doc/README.md
+
+The profiles exposed by the Operators are listed below.
+
+<table>
+<thead>
+  <tr>
+    <th>Path<br></th>
+    <th>Profile Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>/debug/pprof</td>
+    <td>A list of all profiles available on the system</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/allocs</td>
+    <td>A sampling of all past memory allocations</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/block</td>
+    <td>Stack traces that led to blocking on synchronization primitives</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/cmdline</td>
+    <td>The command line invocation of the current program</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/goroutine</td>
+    <td>Stack traces of all current goroutines</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/heap</td>
+    <td>A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample, e.g. /debug/pprof/heap?gc=1</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/mutex</td>
+    <td>Stack traces of holders of contended mutexes</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/profile</td>
+    <td>CPU profile. You can specify the duration in the seconds GET parameter, e.g. /debug/pprof/profile?seconds=5</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/threadcreate</td>
+    <td>Stack traces that led to the creation of new OS threads</td>
+  </tr>
+  <tr>
+    <td>/debug/pprof/trace</td>
+    <td>A trace of execution of the current program. You can specify the duration in the seconds GET parameter, e.g. /debug/pprof/trace?seconds=5</td>
+  </tr>
+</tbody>
+</table>

--- a/site/logging.md
+++ b/site/logging.md
@@ -659,7 +659,7 @@ rabbitmq-diagnostics consume_event_stream | jq
 </pre>
 
 The events can also be exposed to applications for [consumption](./consumers.html)
-with a plugin, [rabbitmq-event-exchange](https://github.com/rabbitmq/rabbitmq-event-exchange/).
+with [a plugin](event-exchange.html).
 
 Events are published as messages with blank bodies. All event metadata is stored in
 message metadata (properties, headers).

--- a/site/news.xml
+++ b/site/news.xml
@@ -36,6 +36,109 @@ limitations under the License.
     -->
 
     <doc:item>
+      <doc:date iso="2022-06-06T14:00:00+00:00">6 June 2022</doc:date>
+      <doc:title>RabbitMQ 3.10.5 release</doc:title>
+      <doc:link>https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.5</doc:link>
+      <doc:text>
+        <p>
+          The RabbitMQ team is pleased to announce the release of RabbitMQ 3.10.5,
+          a maintenance release in the <a href="https://blog.rabbitmq.com/tags/v3.10.x/">RabbitMQ 3.10.x</a> series.
+        </p>
+        <p>
+          This is a maintenance release that contains bug fixes and usability improvements.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
+        </p>
+        <p>
+          This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and supports Erlang 24 and <a href="https://www.erlang.org/blog/my-otp-25-highlights/">Erlang 25</a>.
+        </p>
+        <p>
+          Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
+          <a href="https://cloudsmith.io/~rabbitmq/repos/rabbitmq-server/packages/">Cloudsmith</a>, or <a href="https://packagecloud.io/rabbitmq">Package Cloud</a>.
+          See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
+        </p>
+        <p>
+          We encourage all users of earlier versions of RabbitMQ to upgrade to this latest release.
+        </p>
+        <p>
+          As always, we welcome any questions, bug reports, and other feedback
+          on this release, as well as general suggestions for features and
+          enhancements in future releases. Contact us via the
+          <a href="https://groups.google.com/forum/#!forum/rabbitmq-users">rabbitmq-users</a>
+          Google group or <a href="https://rabbitmq-slack.herokuapp.com/">RabbitMQ community Slack</a>.
+        </p>
+      </doc:text>
+    </doc:item>
+
+    <doc:item>
+      <doc:date iso="2022-06-06T14:00:00+00:00">6 June 2022</doc:date>
+      <doc:title>RabbitMQ 3.9.20 release</doc:title>
+      <doc:link>https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.20</doc:link>
+      <doc:text>
+        <p>
+          The RabbitMQ team is pleased to announce the release of RabbitMQ 3.9.20.
+        </p>
+        <p>
+          This is a maintenance release.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
+        </p>
+        <p>
+          This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
+          <a href="https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/">supports Erlang 24</a>,
+          including recently released Erlang 24.3.
+        </p>
+        <p>
+          Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
+          <a href="https://cloudsmith.io/~rabbitmq/repos/rabbitmq-server/packages/">Cloudsmith</a>, or <a href="https://packagecloud.io/rabbitmq">Package Cloud</a>.
+          See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
+        </p>
+        <p>
+          We encourage all users of earlier versions of RabbitMQ to upgrade to this latest release.
+        </p>
+        <p>
+          As always, we welcome any questions, bug reports, and other feedback
+          on this release, as well as general suggestions for features and
+          enhancements in future releases. Contact us via the
+          <a href="https://groups.google.com/forum/#!forum/rabbitmq-users">rabbitmq-users</a>
+          Google group or <a href="https://rabbitmq-slack.herokuapp.com/">RabbitMQ community Slack</a>.
+        </p>
+      </doc:text>
+    </doc:item>
+
+    <doc:item>
+      <doc:date iso="2022-06-06T14:00:00+00:00">6 June 2022</doc:date>
+      <doc:title>RabbitMQ 3.8.34 release</doc:title>
+      <doc:link>https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.34</doc:link>
+      <doc:text>
+        <p>
+          The RabbitMQ team is pleased to announce the release of RabbitMQ 3.8.34.
+        </p>
+        <p>
+          This is a maintenance release.
+          Release notes can be found <a href="./changelog.html">in the change log</a>.
+        </p>
+        <p>
+          This release <a href="which-erlang.html">requires Erlang/OTP 23.2</a> and
+          <a href="https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/">supports Erlang 24</a>.
+        </p>
+        <p>
+          Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
+          <a href="https://cloudsmith.io/~rabbitmq/repos/rabbitmq-server/packages/">Cloudsmith</a>, or <a href="https://packagecloud.io/rabbitmq">Package Cloud</a>.
+          See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
+        </p>
+        <p>
+          We encourage all users of earlier 3.8.x versions of RabbitMQ to upgrade to this latest release.
+        </p>
+        <p>
+          As always, we welcome any questions, bug reports, and other feedback
+          on this release, as well as general suggestions for features and
+          enhancements in future releases. Contact us via the
+          <a href="https://groups.google.com/forum/#!forum/rabbitmq-users">rabbitmq-users</a>
+          Google group or <a href="https://rabbitmq-slack.herokuapp.com/">RabbitMQ community Slack</a>.
+        </p>
+      </doc:text>
+    </doc:item>
+
+    <doc:item>
       <doc:date iso="2022-06-01T14:00:00+00:00">1 June 2022</doc:date>
       <doc:title>RabbitMQ 3.10.4 release</doc:title>
       <doc:link>https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.4</doc:link>

--- a/site/protocols.md
+++ b/site/protocols.md
@@ -87,3 +87,8 @@ RabbitMQ can transmit messages over HTTP in three ways:
    simple HTTP API to send and receive messages. This is primarily
    intended for diagnostic purposes but can be used for low volume
    messaging without [reliable delivery](reliability.html).
+
+## <a id="rabbitmq-streams" class="anchor" href="#rabbitmq-streams">RabbitMQ Streams</a>
+
+The [RabbitMQ Streams protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.10.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc) allows communicating with [streams](./streams.html).
+RabbitMQ supports the streams protocol via a [plugin](./stream.html).

--- a/site/rabbit.ent
+++ b/site/rabbit.ent
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<!ENTITY version-java-client "5.14.2">
+<!ENTITY version-java-client "5.15.0">
 <!ENTITY version-dotnet-client "6.3.0">
 <!ENTITY version-server "3.10.5">
 <!ENTITY version-server-series "v3.10.x">

--- a/site/rabbit.ent
+++ b/site/rabbit.ent
@@ -18,10 +18,10 @@ limitations under the License.
 
 <!ENTITY version-java-client "5.14.2">
 <!ENTITY version-dotnet-client "6.3.0">
-<!ENTITY version-server "3.10.4">
+<!ENTITY version-server "3.10.5">
 <!ENTITY version-server-series "v3.10.x">
-<!ENTITY version-erlang-client "3.10.4">
-<!ENTITY version-server-tag "v3.10.4">
+<!ENTITY version-erlang-client "3.10.5">
+<!ENTITY version-server-tag "v3.10.5">
 
 <!ENTITY serverDebMinorVersion "1">
 <!ENTITY serverRPMMinorVersion "1">

--- a/site/stream.md
+++ b/site/stream.md
@@ -22,17 +22,15 @@ limitations under the License.
 Streams are a new persistent and replicated data structure _in RabbitMQ 3.9_ which models
 an append-only log with non-destructive consumer semantics.
 They can be used as a regular AMQP 0.9.1 queue or through a
-[dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.9.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
+[dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.10.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
 plugin and associated client(s).
 
 This page covers the Stream plugin, which allows to interact with streams using this
-[new binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.9.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc).
+[new binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.10.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc).
 For an overview of the concepts and the ways to operate streams, please see the
 [guide on RabbitMQ streams](streams.html).
 
-The current known client libraries for the stream protocol are the
-[RabbitMQ Stream Java Client](https://github.com/rabbitmq/rabbitmq-stream-java-client)
-and the [RabbitMQ Stream Go Client](https://github.com/rabbitmq/rabbitmq-stream-go-client).
+Client libraries for the stream protocol are available on several platforms: [Java](https://github.com/rabbitmq/rabbitmq-stream-java-client), [Go](https://github.com/rabbitmq/rabbitmq-stream-go-client), [.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client), Python ([rbly](https://gitlab.com/wrobell/rbfly), [rstream](https://pypi.org/project/rstream/)), [Erlang](https://gitlab.com/evnu/lake), [Elixir](https://github.com/VictorGaiva/rabbitmq-stream), [Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client).
 
 ## <a id="enabling-plugin" class="anchor" href="#enabling-plugin">Enabling the Plugin</a>
 

--- a/site/streams.md
+++ b/site/streams.md
@@ -22,7 +22,7 @@ limitations under the License.
 Streams are a new persistent and replicated data structure _in RabbitMQ 3.9_ which models
 an append-only log with non-destructive consumer semantics.
 They can be used via a RabbitMQ client library as if  it was a queue or through a
-[dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.9.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
+[dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.10.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
 plugin and associated client(s). The latter option is recommended as it
 provides access to all stream-specific features and offers best possible throughput (performance).
 

--- a/site/tutorials/tutorial-one-dotnet.md
+++ b/site/tutorials/tutorial-one-dotnet.md
@@ -85,10 +85,8 @@ Then we add the client dependency.
 <pre class="lang-powershell">
 cd Send
 dotnet add package RabbitMQ.Client
-dotnet restore
 cd ../Receive
 dotnet add package RabbitMQ.Client
-dotnet restore
 </pre>
 
 Now we have the .NET project set up we can write some code.

--- a/site/tutorials/tutorial-six-python.md
+++ b/site/tutorials/tutorial-six-python.md
@@ -294,6 +294,9 @@ class FibonacciRpcClient(object):
             on_message_callback=self.on_response,
             auto_ack=True)
 
+        self.response = None
+        self.corr_id = None
+
     def on_response(self, ch, method, props, body):
         if self.corr_id == props.correlation_id:
             self.response = body
@@ -309,8 +312,7 @@ class FibonacciRpcClient(object):
                 correlation_id=self.corr_id,
             ),
             body=str(n))
-        while self.response is None:
-            self.connection.process_data_events()
+        self.connection.process_data_events(time_limit=None)
         return int(self.response)
 
 

--- a/site/versions.md
+++ b/site/versions.md
@@ -49,7 +49,7 @@ Deployment Upgrade](./blue-green-upgrade.html) guides.
 
   <tr>
     <td>3.9</td>
-    <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.19" target="_blank">3.9.19</a></td>
+    <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.20" target="_blank">3.9.20</a></td>
     <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.0" target="_blank">26 July 2021</a></td>
     <td></td>
     <td></td>
@@ -58,7 +58,7 @@ Deployment Upgrade](./blue-green-upgrade.html) guides.
 
   <tr>
     <td>3.8</td>
-    <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.33" target="_blank">3.8.33</a></td>
+    <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.34" target="_blank">3.8.34</a></td>
     <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.0" target="_blank">1 October 2019</a></td>
     <td>31 January 2022</td>
     <td>31 July 2022</td>

--- a/site/which-erlang.md
+++ b/site/which-erlang.md
@@ -45,6 +45,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
   <tr>
     <td>
       <ul>
+        <li>3.10.5</li>
         <li>3.10.4</li>
         <li>3.10.2</li>
         <li>3.10.1</li>
@@ -78,6 +79,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
   <tr>
     <td>
       <ul>
+        <li>3.9.20</li>
         <li>3.9.19</li>
         <li>3.9.18</li>
         <li>3.9.17</li>
@@ -149,6 +151,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
   <tr>
     <td>
       <ul>
+        <li>3.8.34</li>
         <li>3.8.33</li>
         <li>3.8.32</li>
         <li>3.8.31</li>


### PR DESCRIPTION
Removed unnecessary "dotnet restore" from C# tutorial one. Restore is run automatically by the preceding "dotnet add package".