### PR TITLE
Removed unnecessary restore from C# tutorial one

### DIFF
--- a/site/tutorials/tutorial-one-dotnet.md
+++ b/site/tutorials/tutorial-one-dotnet.md
@@ -85,10 +85,8 @@ Then we add the client dependency.
 <pre class="lang-powershell">
 cd Send
 dotnet add package RabbitMQ.Client
-dotnet restore
 cd ../Receive
 dotnet add package RabbitMQ.Client
-dotnet restore
 </pre>
 
 Now we have the .NET project set up we can write some code.


### PR DESCRIPTION
Removed two instances of unnecessary "dotnet restore" from C# tutorial one. Restore is run by the preceding "dotnet add package".