### PR TITLE
Simplified recommendations on running clients

### DIFF
--- a/site/tutorials/tutorial-one-dotnet.md
+++ b/site/tutorials/tutorial-one-dotnet.md
@@ -324,7 +324,7 @@ dotnet run
 
 
 The consumer will print the message it gets from the publisher via
-RabbitMQ. The consumer will keep running, waiting for messages (Use Ctrl-C to stop it), so try running
-the publisher from another terminal.
+RabbitMQ. The consumer will keep running, waiting for messages, so try restarting
+the publisher several times.
 
 Time to move on to [part 2](tutorial-two-dotnet.html) and build a simple _work queue_.


### PR DESCRIPTION
- Removed advice to close client with CTRL-C, as it closes on "enter" as printed by the client.
- Simplified advice on sending several messages, as there is not need for yet another terminal instance.