### PR TITLE
Updated instructions for creating NewTask.cs

### DIFF
--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -93,21 +93,21 @@ dotnet add package RabbitMQ.Client
 dotnet restore
 </pre>
 
+Copy the code from our old _Send.cs_ to _NewTask.cs_ and make the following modifications.
+
+Change the class name and add command line arguments to the _Main_ method:
 <pre class="lang-csharp">
-var message = GetMessage(args);
-var body = Encoding.UTF8.GetBytes(message);
-
-var properties = channel.CreateBasicProperties();
-properties.Persistent = true;
-
-channel.BasicPublish(exchange: "",
-                     routingKey: "task_queue",
-                     basicProperties: properties,
-                     body: body);
+class NewTask
+{
+    public static void Main(string[] args)
 </pre>
 
-Some help to get the message from the command line argument:
+Update the initialization of the _message_ variable:
+<pre class="lang-csharp">
+var message = GetMessage(args);
+</pre>
 
+Add the _GetMessage_ method to the end of the _NewTask_ class:
 <pre class="lang-csharp">
 private static string GetMessage(string[] args)
 {


### PR DESCRIPTION
Updated instructions for creating NewTask.cs, to make it a complete description on how to get there from the old Send.cs without adding code that is part of later stages of the turtorial.