### PR TITLE
Fix broken (empty) xrefs in markdown source files

### DIFF
--- a/site/admin-guide.md
+++ b/site/admin-guide.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 RabbitMQ ships in a state where it can be used straight away in
 simple cases such as development and QA environments - just
-start the server, [enable]() the necessary plugins and it's ready to go.
+start the server, [enable](./plugins.html#ways-to-enable-plugins) the necessary plugins and it's ready to go.
 
 This guide provides a table of contents of documentation oriented at RabbitMQ operators.
 For a complete documentation ToC that includes developer-oriented guides,

--- a/site/erlang-client-user-guide.md
+++ b/site/erlang-client-user-guide.md
@@ -261,7 +261,7 @@ set to an `#amqp_params_direct` record:
 </pre>
 
 Credentials are optional for direct connections, since Erlang
-distribution relies on [a shared secret](), the Erlang cookie, for authentication.
+distribution relies on [a shared secret](./clustering.html#erlang-cookie), the Erlang cookie, for authentication.
 
 If a username and password are provided then they will be used for authentication and
 made available to authentication backends.

--- a/site/memory-use.md
+++ b/site/memory-use.md
@@ -245,7 +245,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>plugins</td>
     <td>Plugins</td>
     <td>
-      Plugins such as <a href="./shovel.html">Shovel</a>, <a href="./federation.html">Federation</a>, or protocol implementations such as <a href="">STOMP</a>
+      Plugins such as <a href="./shovel.html">Shovel</a>, <a href="./federation.html">Federation</a>, or protocol implementations such as <a href="./stomp.html">STOMP</a>
       can accumulate messages in memory.
     </td>
   </tr>

--- a/site/oauth2-examples.md
+++ b/site/oauth2-examples.md
@@ -145,7 +145,7 @@ make curl url=http://localhost:15672/api/overview client_id=mgt_api_client secre
 
 In this scenario, an application connects to RabbitMQ presenting a JWT Token as a credential.
 The application we are going to use is [PerfTest](https://github.com/rabbitmq/rabbitmq-perf-test) which is not an OAuth 2.0 aware application.
-OAuth 2.0-aware application is covered in [scenario four]().
+OAuth 2.0-aware application is covered in [scenario four](#scenario-4).
 
 Instead we are launching the application with a token that we have previously obtained from UAA. This is just to probe AMQP access with a JWT Token. Needless to say that the application should instead obtain the JWT Token prior to connecting to RabbitMQ and it should also be able to refresh it before reconnecting. RabbitMQ validates the token before accepting it. If the token has expired, RabbitMQ will reject the connection.
 

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -484,7 +484,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
         Only of use when using <code>rabbitmq_shovel</code> in
         conjunction with <code>rabbitmq_management</code>. In a
         heterogeneous cluster this should be installed on the same
-        nodes as <a href="">RabbitMQ management plugin</a>.
+        nodes as <a href="./plugins.html">RabbitMQ management plugin</a>.
       </td>
     </tr>
 

--- a/site/shovel.md
+++ b/site/shovel.md
@@ -41,7 +41,7 @@ or vice versa.
 
 A shovel behaves like a well-written client application, which
 connects to its source and destination, consumes and republishes messages,
-and uses [acknowledgements]() on both ends to cope with failures.
+and uses [acknowledgements](./confirms.html) on both ends to cope with failures.
 
 A Shovel uses [Erlang AMQP 0-9-1](https://www.rabbitmq.com/erlang-client-user-guide.html)
 and [Erlang AMQP 1.0](https://github.com/rabbitmq/rabbitmq-amqp1.0-client) clients under the hood.

--- a/site/vhosts.md
+++ b/site/vhosts.md
@@ -62,7 +62,7 @@ A virtual host can be created using CLI tools or an [HTTP API](./management.html
 
 A newly created vhost will have a default set of [exchanges](./tutorials/amqp-concepts.html)
 but no other entities and no [user permissions](./access-control.html). For a user to be able to connect
-and use the virtual host, permissions to it must be [granted]() to every user that will use the vhost,
+and use the virtual host, permissions to it must be [granted](./access-control.html) to every user that will use the vhost,
 e.g. using [rabbitmqctl set_permissions](./rabbitmqctl.8.html#set_permissions).
 
 ### Using CLI Tools


### PR DESCRIPTION
Markdown files had a number of empty xrefs (both markdown format and html format) that were causing problems. This PR adds targets to the empty links.