### PR TITLE
Update Go code examples to match the source code

### DIFF
--- a/site/tutorials/tutorial-five-go.md
+++ b/site/tutorials/tutorial-five-go.md
@@ -164,12 +164,12 @@ import (
         "os"
         "strings"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -238,12 +238,12 @@ import (
         "log"
         "os"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -304,7 +304,7 @@ func main() {
         )
         failOnError(err, "Failed to register a consumer")
 
-        forever := make(chan bool)
+        var forever chan struct{}
 
         go func() {
                 for d := range msgs {

--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -322,12 +322,12 @@ import (
         "os"
         "strings"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -396,12 +396,12 @@ import (
         "log"
         "os"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -462,7 +462,7 @@ func main() {
         )
         failOnError(err, "Failed to register a consumer")
 
-        forever := make(chan bool)
+        var forever chan struct{}
 
         go func() {
                 for d := range msgs {

--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -27,7 +27,7 @@ limitations under the License.
 In this part of the tutorial we'll write two small programs in Go; a
 producer that sends a single message, and a consumer that receives
 messages and prints them out.  We'll gloss over some of the detail in
-the [Go RabbitMQ](http://godoc.org/github.com/streadway/amqp) API, concentrating on this very simple thing just to get
+the [Go RabbitMQ](https://pkg.go.dev/github.com/rabbitmq/amqp091-go) API, concentrating on this very simple thing just to get
 started. It's a "Hello World" of messaging.
 
 In the diagram below, "P" is our producer and "C" is our consumer. The
@@ -49,7 +49,7 @@ on behalf of the consumer.
 > First, install amqp using `go get`:
 >
 > <pre class="lang-go">
-> go get github.com/streadway/amqp
+> go get github.com/rabbitmq/amqp091-go
 > </pre>
 
 Now we have amqp installed, we can write some
@@ -75,7 +75,7 @@ package main
 import (
   "log"
 
-  "github.com/streadway/amqp"
+  amqp "github.com/rabbitmq/amqp091-go"
 )
 </pre>
 
@@ -85,7 +85,7 @@ amqp call:
 <pre class="lang-go">
 func failOnError(err error, msg string) {
   if err != nil {
-    log.Fatalf("%s: %s", msg, err)
+    log.Panicf("%s: %s", msg, err)
   }
 }
 </pre>
@@ -134,6 +134,7 @@ err = ch.Publish(
     Body:        []byte(body),
   })
 failOnError(err, "Failed to publish a message")
+log.Printf(" [x] Sent %s\n", body)
 </pre>
 
 Declaring a queue is idempotent - it will only be created if it doesn't
@@ -172,12 +173,12 @@ package main
 import (
   "log"
 
-  "github.com/streadway/amqp"
+  amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
   if err != nil {
-    log.Fatalf("%s: %s", msg, err)
+    log.Panicf("%s: %s", msg, err)
   }
 }
 </pre>
@@ -226,7 +227,7 @@ msgs, err := ch.Consume(
 )
 failOnError(err, "Failed to register a consumer")
 
-forever := make(chan bool)
+var forever chan struct{}
 
 go func() {
   for d := range msgs {

--- a/site/tutorials/tutorial-six-go.md
+++ b/site/tutorials/tutorial-six-go.md
@@ -232,12 +232,12 @@ import (
         "log"
         "strconv"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -288,7 +288,7 @@ func main() {
         )
         failOnError(err, "Failed to register a consumer")
 
-        forever := make(chan bool)
+        var forever chan struct{}
 
         go func() {
                 for d := range msgs {
@@ -343,12 +343,12 @@ import (
         "strings"
         "time"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 

--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -189,7 +189,7 @@ even better - let the server choose a random queue name for us.
 Secondly, once we disconnect the consumer the queue should be
 automatically deleted.
 
-In the [amqp](http://godoc.org/github.com/streadway/amqp) client, when we supply queue name
+In the [amqp](https://pkg.go.dev/github.com/rabbitmq/amqp091-go) client, when we supply queue name
 as an empty string, we create a non-durable queue with a generated name:
 
 <pre class="lang-go">
@@ -313,12 +313,12 @@ import (
         "os"
         "strings"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -385,12 +385,12 @@ package main
 import (
         "log"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -444,7 +444,7 @@ func main() {
         )
         failOnError(err, "Failed to register a consumer")
 
-        forever := make(chan bool)
+        var forever chan struct{}
 
         go func() {
                 for d := range msgs {

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -121,7 +121,7 @@ msgs, err := ch.Consume(
 )
 failOnError(err, "Failed to register a consumer")
 
-forever := make(chan bool)
+var forever chan struct{}
 
 go func() {
   for d := range msgs {
@@ -260,7 +260,7 @@ msgs, err := ch.Consume(
 )
 failOnError(err, "Failed to register a consumer")
 
-forever := make(chan bool)
+var forever chan struct{}
 
 go func() {
   for d := range msgs {
@@ -457,12 +457,12 @@ import (
         "os"
         "strings"
 
-        "github.com/streadway/amqp"
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -520,14 +520,15 @@ package main
 
 import (
         "bytes"
-        "github.com/streadway/amqp"
         "log"
         "time"
+
+        amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {
         if err != nil {
-                log.Fatalf("%s: %s", msg, err)
+                log.Panicf("%s: %s", msg, err)
         }
 }
 
@@ -568,7 +569,7 @@ func main() {
         )
         failOnError(err, "Failed to register a consumer")
 
-        forever := make(chan bool)
+        var forever chan struct{}
 
         go func() {
                 for d := range msgs {
@@ -593,7 +594,7 @@ work queue. The durability options let the tasks survive even if
 RabbitMQ is restarted.
 
 For more information on `amqp.Channel` methods and message properties, you can browse the
-[amqp API reference](http://godoc.org/github.com/streadway/amqp).
+[amqp API reference](https://pkg.go.dev/github.com/rabbitmq/amqp091-go).
 
 Now we can move on to [tutorial 3](tutorial-three-go.html) and learn how
 to deliver the same message to many consumers.

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -557,7 +557,7 @@ to help with this:
 In most client libraries there is a way to react to a connection closure, for example:
 
 * [Pika](https://pika.readthedocs.io/en/0.10.0/modules/connection.html#pika.connection.Connection.add_on_close_callback) (Python)
-* [Go](https://godoc.org/github.com/streadway/amqp#Connection.NotifyClose)
+* [Go](https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Connection.NotifyClose)
 
 The recovery procedure for many applications follows the same steps:
 


### PR DESCRIPTION
Signed-off-by: Erdem Köse <erdemkose@gmail.com>

Code examples in the tutorials do not match the latest version of the source code. The changes in the three commits below are now reflected in the tutorials.

Besides, links to godoc.org are replaced with the current ones in pkg.go.dev since [they are already redirected to pkg.go.dev](https://go.dev/blog/godoc.org-redirect).

- https://github.com/rabbitmq/rabbitmq-tutorials/commit/52ca462906a6cd10e387e39074cee468f6bd2b47
- https://github.com/rabbitmq/rabbitmq-tutorials/commit/bd2c06f28f88cbc4a1ef85e7adaf95743110d83a
- https://github.com/rabbitmq/rabbitmq-tutorials/commit/98a3ff7c1f6a410e93533296a1f3327476cf1319