### PR TITLE
Specify the version since consumer acknowledgment timeout is enforced

### DIFF
--- a/site/consumers.md
+++ b/site/consumers.md
@@ -385,7 +385,7 @@ See [.NET client guide](./dotnet-api-guide.html#basic-get) for examples.
 
 ## <a id="acknowledgement-timeout" class="anchor" href="#acknowledgement-timeout">Delivery Acknowledgement Timeout</a>
 
-In modern RabbitMQ versions, a timeout is enforced on consumer delivery acknowledgement.
+Since [version `3.8.0`](./changelog.html), a timeout is enforced on consumer delivery acknowledgement.
 This helps detect buggy (stuck) consumers that never acknowledge deliveries.
 Such consumers can affect node's on disk data compaction and potentially drive
 nodes out of disk space.


### PR DESCRIPTION
It's unclear whether "modern versions" include 3.7.x, so better specify the exact version. Which as I can tell was 3.8.0, and the change was added in [04e4d0b](https://github.com/rabbitmq/rabbitmq-server/commit/04e4d0b5ba486abb16e873b4d3df6e8792b009e6).