### PR TITLE
Update stripped extended spec

### DIFF
--- a/site/resources/specs/amqp0-9-1.stripped.extended.xml
+++ b/site/resources/specs/amqp0-9-1.stripped.extended.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!--
      WARNING: Modified from the official 0-9-1 specification XML by
@@ -50,6 +50,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <constant name="frame-end" value="206"/>
   <constant name="reply-success" value="200"/>
   <constant name="content-too-large" value="311" class="soft-error"/>
+  <constant name="no-route" value="312" class="soft-error"/>
   <constant name="no-consumers" value="313" class="soft-error"/>
   <constant name="connection-forced" value="320" class="hard-error"/>
   <constant name="invalid-path" value="402" class="hard-error"/>
@@ -186,7 +187,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <method name="blocked" index="60">
       <chassis name="server" implement="MUST"/>
       <chassis name="client" implement="MUST"/>
-      <field name="reason" domain="shortstr" />
+      <field name="reason" domain="shortstr"/>
     </method>
     <method name="unblocked" index="61">
       <chassis name="server" implement="MUST"/>
@@ -195,8 +196,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <method name="update-secret" synchronous="1" index="70">
       <chassis name="client" implement="MUST"/>
       <response name="update-secret-ok"/>
-      <field name="new-secret" domain="longstr" />
-      <field name="reason" domain="shortstr" />
+      <field name="new-secret" domain="longstr"/>
+      <field name="reason" domain="shortstr"/>
     </method>
     <method name="update-secret-ok" synchronous="1" index="71">
       <chassis name="server" implement="MUST"/>


### PR DESCRIPTION
It has missing the constant for 'no-route' code 312. This constant is
present in the extended non-stripped version and it is supported by
RabbitMQ.
