### PR TITLE
Update Quorum Queues documentation to reflect Queue TTL supported since version

### DIFF
--- a/site/quorum-queues.md
+++ b/site/quorum-queues.md
@@ -120,7 +120,7 @@ Some features are not currently supported by quorum queues.
 | Per message persistence | per message | always |
 | Membership changes | automatic | manual  |
 | [Message TTL (Time-To-Live)](./ttl.html) | yes | yes ([since 3.10](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-release-overview/)) |
-| [Queue TTL](./ttl.html#queue-ttl) | yes | yes |
+| [Queue TTL](./ttl.html#queue-ttl) | yes | yes ([since 3.8.10](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.10)) |
 | [Queue length limits](./maxlength.html) | yes | yes (except `x-overflow`: `reject-publish-dlx`) |
 | [Lazy behaviour](./lazy-queues.html) | yes | always (since 3.10) or through the [Memory Limit](#memory-limit) feature (before 3.10) |
 | [Message priority](./priority.html) | yes | no |


### PR DESCRIPTION
Quorum Queue Message TTL support was introduced in version `3.8.10` of `rabbitmq-server`. See:
- https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.10
- https://github.com/rabbitmq/rabbitmq-server/pull/2407

We discovered this when seeing errors for defining the `x-expires` parameter on a `3.8.9` cluster and coming across the above PR.

In this PR I have updated the documentation to indicate this, linking the GitHub release page (given there is no official blog post for this release). Let me know if there is a preference for this as I see not all versions are linked to release notes e.g. `3.10` in `Lazy behaviour`.