### PR TITLE
Update Go tutorials

### DIFF
--- a/site/tutorials/tutorial-five-go.md
+++ b/site/tutorials/tutorial-five-go.md
@@ -160,9 +160,11 @@ The code for `emit_log_topic.go`:
 package main
 
 import (
+        "context"
         "log"
         "os"
         "strings"
+        "time"
 
         amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -193,8 +195,11 @@ func main() {
         )
         failOnError(err, "Failed to declare an exchange")
 
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
         body := bodyFrom(os.Args)
-        err = ch.Publish(
+        err = ch.PublishWithContext(ctx,
                 "logs_topic",          // exchange
                 severityFrom(os.Args), // routing key
                 false, // mandatory

--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -218,8 +218,11 @@ err = ch.ExchangeDeclare(
 )
 failOnError(err, "Failed to declare an exchange")
 
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
 body := bodyFrom(os.Args)
-err = ch.Publish(
+err = ch.PublishWithContext(ctx,
   "logs_direct",         // exchange
   severityFrom(os.Args), // routing key
   false, // mandatory
@@ -318,9 +321,11 @@ The code for `emit_log_direct.go` script:
 package main
 
 import (
+        "context"
         "log"
         "os"
         "strings"
+        "time"
 
         amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -351,8 +356,11 @@ func main() {
         )
         failOnError(err, "Failed to declare an exchange")
 
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
         body := bodyFrom(os.Args)
-        err = ch.Publish(
+	    err = ch.PublishWithContext(ctx,
                 "logs_direct",         // exchange
                 severityFrom(os.Args), // routing key
                 false, // mandatory

--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -73,7 +73,9 @@ we need to import the library first:
 package main
 
 import (
+  "context"
   "log"
+  "time"
 
   amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -123,8 +125,11 @@ q, err := ch.QueueDeclare(
 )
 failOnError(err, "Failed to declare a queue")
 
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
 body := "Hello World!"
-err = ch.Publish(
+err = ch.PublishWithContext(ctx,
   "",     // exchange
   q.Name, // routing key
   false,  // mandatory

--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -129,7 +129,7 @@ queues it knows. And that's exactly what we need for our logger.
 > Recall how we published a message before:
 >
 > <pre class="lang-go">
-> err = ch.Publish(
+> err = ch.PublishWithContext(ctx,
 >   "",     // exchange
 >   q.Name, // routing key
 >   false,  // mandatory
@@ -156,8 +156,11 @@ err = ch.ExchangeDeclare(
 )
 failOnError(err, "Failed to declare an exchange")
 
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
 body := bodyFrom(os.Args)
-err = ch.Publish(
+err = ch.PublishWithContext(ctx,
   "logs", // exchange
   "",     // routing key
   false,  // mandatory
@@ -309,9 +312,11 @@ value is ignored for `fanout` exchanges. Here goes the code for
 package main
 
 import (
+        "context"
         "log"
         "os"
         "strings"
+        "time"
 
         amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -342,8 +347,11 @@ func main() {
         )
         failOnError(err, "Failed to declare an exchange")
 
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
         body := bodyFrom(os.Args)
-        err = ch.Publish(
+        err = ch.PublishWithContext(ctx,
                 "logs", // exchange
                 "",     // routing key
                 false,  // mandatory

--- a/site/tutorials/tutorial-two-go.md
+++ b/site/tutorials/tutorial-two-go.md
@@ -1,3 +1,4 @@
+
 <!--
 Copyright (c) 2007-2022 VMware, Inc. or its affiliates.
 
@@ -76,8 +77,11 @@ program will schedule tasks to our work queue, so let's name it
 `new_task.go`:
 
 <pre class="lang-go">
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
 body := bodyFrom(os.Args)
-err = ch.Publish(
+err = ch.PublishWithContext(ctx,
   "",           // exchange
   q.Name,       // routing key
   false,        // mandatory
@@ -360,7 +364,7 @@ even if RabbitMQ restarts. Now we need to mark our messages as persistent
 - by using the `amqp.Persistent` option `amqp.Publishing` takes.
 
 <pre class="lang-go">
-err = ch.Publish(
+err = ch.PublishWithContext(ctx,
   "",           // exchange
   q.Name,       // routing key
   false,        // mandatory
@@ -453,9 +457,11 @@ Final code of our `new_task.go` class:
 package main
 
 import (
+        "context"
         "log"
         "os"
         "strings"
+        "time"
 
         amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -485,8 +491,11 @@ func main() {
         )
         failOnError(err, "Failed to declare a queue")
 
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
         body := bodyFrom(os.Args)
-        err = ch.Publish(
+        err = ch.PublishWithContext(ctx,
                 "",           // exchange
                 q.Name,       // routing key
                 false,        // mandatory


### PR DESCRIPTION
Using `Channel.Publish` is deprecated. Tutorials should use updated API
`Channel.PublishWithContext`.

