### PR TITLE
+"CLI Tools Show ANSI Character Sequences"

### DIFF
--- a/site/windows-quirks.md
+++ b/site/windows-quirks.md
@@ -1,3 +1,4 @@
+
 <!--
 Copyright (c) 2007-2022 VMware, Inc. or its affiliates.
 
@@ -104,6 +105,31 @@ One of these options can be used to mitigate:
    the console to use UTF-8
  * Where possible, use the [management plugin](./management.html) instead of CLI tools.
 
+## <a id="ansi-sequences" class="anchor" href="#ansi-sequences">CLI Tools Show ANSI Character Sequences</a>
+
+If this is occurring, output from rabbitmqctl will look like:
+
+    ←[1mUsage←[0m
+    
+    rabbitmqctl [--node <node>] [--timeout <timeout>] [--longnames] [--quiet] <command> [<command options>]
+    
+    Available commands:
+    
+    ←[1mHelp←[0m:
+    
+       autocomplete                  Provides command name autocomplete variants
+       help                          Displays usage information for a command
+       version                       Displays CLI tools version
+
+### Mitigation
+
+Two possible mitigations are:
+1. Pipe `rabbitmqctl.bat` output through `Out-Host`, with each command, like so:  `rabbitmqctl.bat | Out-Host`
+2. Globally enable VT/ANSI escape sequences in Command and PowerShell windows:
+	a.  in PowerShell: `Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1`
+	b. open a new console window for changes to take effect
+
+For further information, including caveats, read the Stack Overflow article: [Colored text output in PowerShell console using ANSI / VT100 codes](https://stackoverflow.com/questions/51680709/colored-text-output-in-powershell-console-using-ansi-vt100-codes)
 
 ## <a id="cookie-location" class="anchor" href="#cookie-location">Installing as a non-administrator User Leaves `.erlang.cookie` in the Wrong Place</a>
 


### PR DESCRIPTION
I've added a section on what ANSI sequence clutter look like, and how to configure Windows to display colors, rather than gobbledygook.

The contribution guidelines said to offer "why" for a contribution, so here's my why:
The reason is I want to save people the trouble of seeing something really strange (ANSI escape sequences), wondering why they are seeing it, getting discouraged, figuring out how to formulate what they are seeing in such a way that they can find the issue on the Internet, digging through bug trackers, seeing that the "bug" is fixed (?), wondering why it was "fixed" in 2019 but they're still seeing it, searching further, finding articles on ANSI escape sequences and how they relate to PowerShell, studying the mitigations, applying the mitigations, and then feeling guilty that they haven't saved others the effort themselves because it was something really annoying and not really anything to do with... ...using and enjoying RabbitMQ.
That a reason why to include this pull request.

I accidentally included a blank line at the start.  If you could chop off that one part of the changeset, it'll be a cleaner commit.  Not sure how to do that within github website interface.