### PR TITLE
Update minimum required Erlang version matrix

### DIFF
--- a/site/which-erlang.md
+++ b/site/which-erlang.md
@@ -47,6 +47,33 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
     <td>
       <ul>
         <li>3.10.8</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>24.2</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>25.1</li>
+      </ul>
+    </td>
+    <td>
+      <ul class="notes">
+        <li>
+          Erlang 25 is the recommended series.
+        </li>
+        <li>
+          Erlang 23 support was discontinued on July 31st, 2022.
+        </li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <ul>
         <li>3.10.7</li>
         <li>3.10.6</li>
         <li>3.10.5</li>
@@ -58,7 +85,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
     </td>
     <td>
       <ul>
-        <li>24.2</li>
+        <li>23.2</li>
       </ul>
     </td>
     <td>
@@ -118,7 +145,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
     </td>
     <td>
       <ul>
-        <li>23.3</li>
+        <li>23.2</li>
       </ul>
     </td>
     <td>


### PR DESCRIPTION
This is based on what is enforced by `rabbit_prelaunch_erlang_compat.erl`.
(I did not modified unsupported 3.8.x versions, though OTP 21.3 was allowed up to 3.8.13)