### PR TITLE
Update links for RabbitMQ plugins

### DIFF
--- a/site/plugins.md
+++ b/site/plugins.md
@@ -331,7 +331,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
 
         <ul>
           <li>
-            <a href="https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.9.x/README.md">README for this plugin</a>
+            <a href="https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_amqp1_0/README.md">README for this plugin</a>
           </li>
         </ul>
       </td>
@@ -356,7 +356,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
 
         <ul>
           <li>
-            <a href="https://github.com/rabbitmq/rabbitmq-auth-backend-http/blob/v3.9.x/README.md">README for this plugin</a>
+            <a href="https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_auth_backend_http/README.md">README for this plugin</a>
           </li>
         </ul>
       </td>
@@ -370,7 +370,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
 
         <ul>
           <li>
-            <a href="https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl/blob/v3.9.x/README.md">README for this plugin</a>
+            <a href="https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_auth_mechanism_ssl/README.md">README for this plugin</a>
           </li>
         </ul>
       </td>
@@ -383,7 +383,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
 
         <ul>
           <li>
-            <a href="https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange/blob/v3.9.x/README.md">README for this plugin</a>
+            <a href="https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_consistent_hash_exchange/README.md">README for this plugin</a>
           </li>
         </ul>
       </td>


### PR DESCRIPTION
The links for the following plugins were outdated:

* rabbitmq_amqp
* rabbitmq_auth_backend_http
* rabbitmq_auth_mechanism_ssl 
* rabbitmq_consistent_hash_exchange

I added a link to the coresponding README.md files in the `/deps/` folder of the main repository.