### PR TITLE
Correct that QQ support customer priority

### DIFF
--- a/site/quorum-queues.md
+++ b/site/quorum-queues.md
@@ -304,10 +304,9 @@ Use [per-consumer QoS prefetch](./consumer-prefetch.html), which is the default 
 
 #### Priorities
 
-Quorum queues do not currently support [priorities](./priority.html), including [consumer priorities](./consumer-priority.html).
+Quorum queues support [consumer priorities](./consumer-priority.html), but not [message priorities](./priority.html).
 
-To achieve priority processing with Quorum Queues multiple queues should be used instead;
-one for each priority.
+To prioritize messages with Quorum Queues, use multiple queues; one for each priority.
 
 
 #### Poison Message Handling


### PR DESCRIPTION
Per 3.8.10 release notes:

> [Quorum queues](https://www.rabbitmq.com/quorum-queues.html) now support [consumer priority](https://www.rabbitmq.com/consumers.html#priority).
> GitHub issue: https://github.com/rabbitmq/rabbitmq-server/pull/2451