### PR TITLE
Change master to main in urls point to rabbitmq-tutorials

### DIFF
--- a/site/tutorials/tutorial-five-dotnet.md
+++ b/site/tutorials/tutorial-five-dotnet.md
@@ -288,7 +288,7 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [EmitLogTopic.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/EmitLogTopic/EmitLogTopic.cs)
-and [ReceiveLogsTopic.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/ReceiveLogsTopic/ReceiveLogsTopic.cs))
+(Full source code for [EmitLogTopic.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/EmitLogTopic/EmitLogTopic.cs)
+and [ReceiveLogsTopic.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/ReceiveLogsTopic/ReceiveLogsTopic.cs))
 
 Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-dotnet.html).

--- a/site/tutorials/tutorial-five-elixir.md
+++ b/site/tutorials/tutorial-five-elixir.md
@@ -246,7 +246,7 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [emit_logs_topic.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/emit_log_topic.exs)
-and [receive_logs_topic.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/receive_logs_topic.exs))
+(Full source code for [emit_logs_topic.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/emit_log_topic.exs)
+and [receive_logs_topic.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/receive_logs_topic.exs))
 
 Move on to [tutorial 6](tutorial-six-elixir.html) to learn about *RPC*.

--- a/site/tutorials/tutorial-five-go.md
+++ b/site/tutorials/tutorial-five-go.md
@@ -356,8 +356,8 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [emit_log_topic.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/emit_log_topic.go)
-and [receive_logs_topic.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/receive_logs_topic.go))
+(Full source code for [emit_log_topic.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/emit_log_topic.go)
+and [receive_logs_topic.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/receive_logs_topic.go))
 
 Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-go.html)
 

--- a/site/tutorials/tutorial-five-java.md
+++ b/site/tutorials/tutorial-five-java.md
@@ -269,7 +269,7 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [EmitLogTopic.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/EmitLogTopic.java)
-and [ReceiveLogsTopic.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/ReceiveLogsTopic.java))
+(Full source code for [EmitLogTopic.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/EmitLogTopic.java)
+and [ReceiveLogsTopic.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/ReceiveLogsTopic.java))
 
 Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-java.html)

--- a/site/tutorials/tutorial-five-javascript.md
+++ b/site/tutorials/tutorial-five-javascript.md
@@ -272,8 +272,8 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [emit_log_topic.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/emit_log_topic.js)
-and [receive_logs_topic.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive_logs_topic.js))
+(Full source code for [emit_log_topic.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/emit_log_topic.js)
+and [receive_logs_topic.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/receive_logs_topic.js))
 
 Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-javascript.html)
 

--- a/site/tutorials/tutorial-five-objectivec.md
+++ b/site/tutorials/tutorial-five-objectivec.md
@@ -216,4 +216,4 @@ with more than two routing key parameters.
 
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
 [previous]:tutorial-four-objectivec.html
-[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/objective-c/tutorial5/tutorial5/ViewController.m
+[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/objective-c/tutorial5/tutorial5/ViewController.m

--- a/site/tutorials/tutorial-five-php.md
+++ b/site/tutorials/tutorial-five-php.md
@@ -258,7 +258,7 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [emit_log_topic.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/emit_log_topic.php)
-and [receive_logs_topic.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/receive_logs_topic.php))
+(Full source code for [emit_log_topic.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/emit_log_topic.php)
+and [receive_logs_topic.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/receive_logs_topic.php))
 
 Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-php.html)

--- a/site/tutorials/tutorial-five-python.md
+++ b/site/tutorials/tutorial-five-python.md
@@ -161,7 +161,7 @@ have two words: "`<facility>.<severity>`".
 The code is almost the same as in the
 [previous tutorial](tutorial-four-python.html).
 
-`emit_log_topic.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/emit_log_topic.py))
+`emit_log_topic.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/emit_log_topic.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python
@@ -182,7 +182,7 @@ print(" [x] Sent %r:%r" % (routing_key, message))
 connection.close()
 </pre>
 
-`receive_logs_topic.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/receive_logs_topic.py))
+`receive_logs_topic.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/receive_logs_topic.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python

--- a/site/tutorials/tutorial-five-ruby.md
+++ b/site/tutorials/tutorial-five-ruby.md
@@ -242,7 +242,7 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [emit_log_topic.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/emit_log_topic.rb)
-and [receive_logs_topic.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/receive_logs_topic.rb))
+(Full source code for [emit_log_topic.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/emit_log_topic.rb)
+and [receive_logs_topic.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/receive_logs_topic.rb))
 
 Next, find out how to do a round trip message as a remote procedure call in [tutorial 6](tutorial-six-ruby.html)

--- a/site/tutorials/tutorial-five-spring-amqp.md
+++ b/site/tutorials/tutorial-five-spring-amqp.md
@@ -380,9 +380,9 @@ Have fun playing with these programs. Note that the code doesn't make
 any assumption about the routing or binding keys, you may want to play
 with more than two routing key parameters.
 
-(Full source code for [Tut5Receiver.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Receiver.java)
-and [Tut5Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Sender.java).
-The configuration is in [Tut5Config.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Config.java). )
+(Full source code for [Tut5Receiver.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Receiver.java)
+and [Tut5Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Sender.java).
+The configuration is in [Tut5Config.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut5/Tut5Config.java). )
 
 Next, find out how to do a round trip message as a remote procedure call
 in [tutorial 6](tutorial-six-spring-amqp.html)

--- a/site/tutorials/tutorial-five-swift.md
+++ b/site/tutorials/tutorial-five-swift.md
@@ -210,4 +210,4 @@ with more than two routing key parameters.
 
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
 [previous]:tutorial-four-swift.html
-[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/swift/tutorial5/tutorial5/ViewController.swift
+[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/swift/tutorial5/tutorial5/ViewController.swift

--- a/site/tutorials/tutorial-four-dotnet.md
+++ b/site/tutorials/tutorial-four-dotnet.md
@@ -392,8 +392,8 @@ dotnet run error "Run. Run. Or it will explode."
 # => [x] Sent 'error':'Run. Run. Or it will explode.'
 </pre>
 
-(Full source code for [(EmitLogDirect.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/EmitLogDirect/EmitLogDirect.cs)
-and [(ReceiveLogsDirect.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/ReceiveLogsDirect/ReceiveLogsDirect.cs))
+(Full source code for [(EmitLogDirect.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/EmitLogDirect/EmitLogDirect.cs)
+and [(ReceiveLogsDirect.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/ReceiveLogsDirect/ReceiveLogsDirect.cs))
 
 Move on to [tutorial 5](tutorial-five-dotnet.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-elixir.md
+++ b/site/tutorials/tutorial-four-elixir.md
@@ -350,7 +350,7 @@ mix run emit_log_direct.exs --error "Run. Run. Or it will explode."
 # => [x] Sent '[error] Run. Run. Or it will explode.'
 </pre>
 
-(Full source code for [emit_log_direct.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/emit_log_direct.exs) and [receive_logs_direct.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/receive_logs_direct.exs))
+(Full source code for [emit_log_direct.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/emit_log_direct.exs) and [receive_logs_direct.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/receive_logs_direct.exs))
 
 Move on to [tutorial 5](tutorial-five-elixir.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -505,8 +505,8 @@ go run emit_log_direct.go error "Run. Run. Or it will explode."
 # => [x] Sent 'error':'Run. Run. Or it will explode.'
 </pre>
 
-(Full source code for [(emit_log_direct.go source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/emit_log_direct.go)
-and [(receive_logs_direct.go source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/receive_logs_direct.go))
+(Full source code for [(emit_log_direct.go source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/emit_log_direct.go)
+and [(receive_logs_direct.go source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/receive_logs_direct.go))
 
 Move on to [tutorial 5](tutorial-five-go.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-java.md
+++ b/site/tutorials/tutorial-four-java.md
@@ -351,8 +351,8 @@ java -cp $CP EmitLogDirect error "Run. Run. Or it will explode."
 # => [x] Sent 'error':'Run. Run. Or it will explode.'
 </pre>
 
-(Full source code for [(EmitLogDirect.java source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/EmitLogDirect.java)
-and [(ReceiveLogsDirect.java source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/ReceiveLogsDirect.java))
+(Full source code for [(EmitLogDirect.java source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/EmitLogDirect.java)
+and [(ReceiveLogsDirect.java source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/ReceiveLogsDirect.java))
 
 Move on to [tutorial 5](tutorial-five-java.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-javascript.md
+++ b/site/tutorials/tutorial-four-javascript.md
@@ -369,8 +369,8 @@ And, for example, to emit an `error` log message just type:
 </pre>
 
 
-(Full source code for [(emit_log_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/emit_log_direct.js)
-and [(receive_logs_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive_logs_direct.js))
+(Full source code for [(emit_log_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/emit_log_direct.js)
+and [(receive_logs_direct.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/receive_logs_direct.js))
 
 Move on to [tutorial 5](tutorial-five-javascript.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-objectivec.md
+++ b/site/tutorials/tutorial-four-objectivec.md
@@ -296,4 +296,4 @@ for messages based on a pattern.
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
 [previous]:tutorial-three-objectivec.html
 [next]:tutorial-five-objectivec.html
-[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/objective-c/tutorial4/tutorial4/ViewController.m
+[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/objective-c/tutorial4/tutorial4/ViewController.m

--- a/site/tutorials/tutorial-four-php.md
+++ b/site/tutorials/tutorial-four-php.md
@@ -348,8 +348,8 @@ php emit_log_direct.php error "Run. Run. Or it will explode."
 # => [x] Sent 'error':'Run. Run. Or it will explode.'
 </pre>
 
-(Full source code for [(emit_log_direct.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/emit_log_direct.php)
-and [(receive_logs_direct.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/receive_logs_direct.php))
+(Full source code for [(emit_log_direct.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/emit_log_direct.php)
+and [(receive_logs_direct.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/receive_logs_direct.php))
 
 
 Move on to [tutorial 5](tutorial-five-php.html) to find out how to listen

--- a/site/tutorials/tutorial-four-python.md
+++ b/site/tutorials/tutorial-four-python.md
@@ -269,7 +269,7 @@ Putting it all together
   </div>
 </div>
 
-`emit_log_direct.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/emit_log_direct.py))
+`emit_log_direct.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/emit_log_direct.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python
@@ -290,7 +290,7 @@ print(" [x] Sent %r:%r" % (severity, message))
 connection.close()
 </pre>
 
-`receive_logs_direct.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/receive_logs_direct.py))
+`receive_logs_direct.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/receive_logs_direct.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python

--- a/site/tutorials/tutorial-four-ruby.md
+++ b/site/tutorials/tutorial-four-ruby.md
@@ -333,8 +333,8 @@ ruby emit_log_direct.rb error "Run. Run. Or it will explode."
 # => [x] Sent 'error':'Run. Run. Or it will explode.'
 </pre>
 
-(Full source code for [(emit_log_direct.rb source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/emit_log_direct.rb)
-and [(receive_logs_direct.rb source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/receive_logs_direct.rb))
+(Full source code for [(emit_log_direct.rb source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/emit_log_direct.rb)
+and [(receive_logs_direct.rb source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/receive_logs_direct.rb))
 
 Move on to [tutorial 5](tutorial-five-ruby.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-spring-amqp.md
+++ b/site/tutorials/tutorial-four-spring-amqp.md
@@ -454,9 +454,9 @@ java -jar target/rabbitmq-tutorials.jar \
 </pre>
 
 
-Full source code for [Tut4Receiver.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Receiver.java)
-and [Tut4Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Sender.java).
-The configuration is in [Tut4Config.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Config.java).
+Full source code for [Tut4Receiver.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Receiver.java)
+and [Tut4Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Sender.java).
+The configuration is in [Tut4Config.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut4/Tut4Config.java).
 
 Move on to [tutorial 5](tutorial-five-spring-amqp.html) to find out how to listen
 for messages based on a pattern.

--- a/site/tutorials/tutorial-four-swift.md
+++ b/site/tutorials/tutorial-four-swift.md
@@ -288,4 +288,4 @@ for messages based on a pattern.
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
 [previous]:tutorial-three-swift.html
 [next]:tutorial-five-swift.html
-[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/swift/tutorial4/tutorial4/ViewController.swift
+[source]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/swift/tutorial4/tutorial4/ViewController.swift

--- a/site/tutorials/tutorial-one-dotnet.md
+++ b/site/tutorials/tutorial-one-dotnet.md
@@ -102,7 +102,7 @@ We'll call our message publisher (sender) `Send.cs` and our message consumer (re
 then exit.
 
 In
-[`Send.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/Send/Send.cs),
+[`Send.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/Send/Send.cs),
 we need to use some namespaces:
 
 <pre class="lang-csharp">
@@ -195,7 +195,7 @@ When the code above finishes running, the channel and the connection
 will be disposed. That's it for our publisher.
 
 [Here's the whole Send.cs
-class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/Send/Send.cs).
+class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/Send/Send.cs).
 
 > #### Sending doesn't work!
 >
@@ -219,7 +219,7 @@ keep the consumer running continuously to listen for messages and print them out
   <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
-The code (in [`Receive.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/Receive/Receive.cs)) has almost the same `using` statements as `Send`:
+The code (in [`Receive.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/Receive/Receive.cs)) has almost the same `using` statements as `Send`:
 
 <pre class="lang-csharp">
 using RabbitMQ.Client;
@@ -300,7 +300,7 @@ class Receive
 </pre>
 
 [Here's the whole Receive.cs
-class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/Receive/Receive.cs).
+class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/Receive/Receive.cs).
 
 ### Putting It All Together
 

--- a/site/tutorials/tutorial-one-elixir.md
+++ b/site/tutorials/tutorial-one-elixir.md
@@ -150,7 +150,7 @@ can do it by gently closing the connection.
 AMQP.Connection.close(connection)
 </pre>
 
-[Here's the whole send.exs script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/send.exs).
+[Here's the whole send.exs script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/send.exs).
 
 > #### Sending doesn't work!
 >

--- a/site/tutorials/tutorial-one-go.md
+++ b/site/tutorials/tutorial-one-go.md
@@ -66,7 +66,7 @@ We'll call our message publisher (sender) `send.go` and our message consumer (re
 then exit.
 
 In
-[`send.go`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/send.go),
+[`send.go`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/send.go),
 we need to import the library first:
 
 <pre class="lang-go">
@@ -146,7 +146,7 @@ Declaring a queue is idempotent - it will only be created if it doesn't
 exist already. The message content is a byte array, so you can encode
 whatever you like there.
 
-[Here's the whole send.go script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/send.go).
+[Here's the whole send.go script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/send.go).
 
 > #### Sending doesn't work!
 >
@@ -170,7 +170,7 @@ keep the consumer running to listen for messages and print them out.
   <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
-The code (in [`receive.go`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/receive.go)) has the same import and helper function as `send`:
+The code (in [`receive.go`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/receive.go)) has the same import and helper function as `send`:
 
 <pre class="lang-go">
 package main
@@ -244,7 +244,7 @@ log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
 &lt;-forever
 </pre>
 
-[Here's the whole receive.go script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/receive.go).
+[Here's the whole receive.go script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/receive.go).
 
 ### Putting it all together
 

--- a/site/tutorials/tutorial-one-java.md
+++ b/site/tutorials/tutorial-one-java.md
@@ -71,7 +71,7 @@ We'll call our message publisher (sender) `Send` and our message consumer (recei
 then exit.
 
 In
-[`Send.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/Send.java),
+[`Send.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/Send.java),
 we need some classes imported:
 
 <pre class="lang-java">
@@ -128,7 +128,7 @@ exist already. The message content is a byte array, so you can encode
 whatever you like there.
 
 [Here's the whole Send.java
-class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/Send.java).
+class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/Send.java).
 
 > #### Sending doesn't work!
 >
@@ -152,7 +152,7 @@ keep the consumer running to listen for messages and print them out.
   <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
-The code (in [`Recv.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/Recv.java)) has almost the same imports as `Send`:
+The code (in [`Recv.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/Recv.java)) has almost the same imports as `Send`:
 
 <pre class="lang-java">
 import com.rabbitmq.client.Channel;
@@ -210,7 +210,7 @@ channel.basicConsume(QUEUE_NAME, true, deliverCallback, consumerTag -> { });
 </pre>
 
 [Here's the whole Recv.java
-class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/Recv.java).
+class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/Recv.java).
 
 ### Putting it all together
 

--- a/site/tutorials/tutorial-one-javascript.md
+++ b/site/tutorials/tutorial-one-javascript.md
@@ -65,7 +65,7 @@ We'll call our message publisher (sender) `send.js` and our message consumer (re
 then exit.
 
 In
-[`send.js`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/send.js),
+[`send.js`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/send.js),
 we need to require the library first:
 
 <pre class="lang-javascript">
@@ -130,7 +130,7 @@ setTimeout(function() {
   }, 500);
 </pre>
 
-[Here's the whole send.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/send.js).
+[Here's the whole send.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/send.js).
 
 > #### Sending doesn't work!
 >
@@ -154,7 +154,7 @@ keep the consumer running to listen for messages and print them out.
   <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
-The code (in [`receive.js`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive.js)) has the same require as `send`:
+The code (in [`receive.js`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/receive.js)) has the same require as `send`:
 
 <pre class="lang-javascript">
 #!/usr/bin/env node
@@ -202,7 +202,7 @@ channel.consume(queue, function(msg) {
   });
 </pre>
 
-[Here's the whole receive.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive.js).
+[Here's the whole receive.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/receive.js).
 
 ### Putting it all together
 

--- a/site/tutorials/tutorial-one-objectivec.md
+++ b/site/tutorials/tutorial-one-objectivec.md
@@ -196,6 +196,6 @@ Hello World!
 Time to move on to [part 2](tutorial-two-objectivec.html) and build a simple _work queue_.
 
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
-[controller]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/objective-c/tutorial1/tutorial1/ViewController.m
+[controller]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/objective-c/tutorial1/tutorial1/ViewController.m
 [devtools]:http://rabbitmq.com/devtools.html
 [nslog]:https://developer.apple.com/library/ios/technotes/tn2347/_index.html

--- a/site/tutorials/tutorial-one-php.md
+++ b/site/tutorials/tutorial-one-php.md
@@ -83,7 +83,7 @@ We'll call our message publisher (sender) `send.php` and our message receiver
 then exit.
 
 In
-[`send.php`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/send.php),
+[`send.php`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/send.php),
 we need to include the library and `use` the necessary classes:
 
 <pre class="lang-php">
@@ -133,7 +133,7 @@ $connection->close();
 </pre>
 
 [Here's the whole send.php
-class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/send.php).
+class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/send.php).
 
 > #### Sending doesn't work!
 >
@@ -157,7 +157,7 @@ keep the receiver running to listen for messages and print them out.
   <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
-The code (in [`receive.php`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/receive.php)) has almost the same
+The code (in [`receive.php`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/receive.php)) has almost the same
 `include` and `use`s as `send`:
 
 <pre class="lang-php">
@@ -202,7 +202,7 @@ while ($channel->is_open()) {
 Our code will block while our `$channel` has callbacks. Whenever we receive a
 message our `$callback` function will be passed the received message.
 
-[Here's the whole receive.php class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/receive.php)
+[Here's the whole receive.php class](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/receive.php)
 
 ### Putting it all together
 

--- a/site/tutorials/tutorial-one-python.md
+++ b/site/tutorials/tutorial-one-python.md
@@ -258,7 +258,7 @@ if __name__ == '__main__':
 
 ### Putting it all together
 
-`send.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/send.py))
+`send.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/send.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python
@@ -275,7 +275,7 @@ print(" [x] Sent 'Hello World!'")
 connection.close()
 </pre>
 
-`receive.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/receive.py))
+`receive.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/receive.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python

--- a/site/tutorials/tutorial-one-ruby.md
+++ b/site/tutorials/tutorial-one-ruby.md
@@ -66,7 +66,7 @@ We'll call our message producer `send.rb` and our message consumer
 then exit.
 
 In
-[`send.rb`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/send.rb),
+[`send.rb`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/send.rb),
 we need to require the library first:
 
 <pre class="lang-ruby">
@@ -121,7 +121,7 @@ Lastly, we close the connection:
 connection.close
 </pre>
 
-[Here's the whole send.rb script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/send.rb).
+[Here's the whole send.rb script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/send.rb).
 
 > #### Sending doesn't work!
 >
@@ -145,7 +145,7 @@ keep the consumer running to listen for messages and print them out.
   <img src="../img/tutorials/receiving.png" alt="[|||] -> (C)" height="100" />
 </div>
 
-The code (in [`receive.rb`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/receive.rb)) has the same require as `send`:
+The code (in [`receive.rb`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/receive.rb)) has the same require as `send`:
 
 <pre class="lang-ruby">
 #!/usr/bin/env ruby
@@ -189,7 +189,7 @@ end
 `Bunny::Queue#subscribe` is used with the `:block` option that makes it
 block the calling thread (we don't want the script to finish running immediately!).
 
-[Here's the whole receive.rb script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/receive.rb).
+[Here's the whole receive.rb script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/receive.rb).
 
 ### Putting it all together
 

--- a/site/tutorials/tutorial-one-swift.md
+++ b/site/tutorials/tutorial-one-swift.md
@@ -200,5 +200,5 @@ Hello World!
 Time to move on to [part 2](tutorial-two-swift.html) and build a simple _work queue_.
 
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
-[controller]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/swift/tutorial1/tutorial1/ViewController.swift
+[controller]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/swift/tutorial1/tutorial1/ViewController.swift
 [devtools]:http://rabbitmq.com/devtools.html

--- a/site/tutorials/tutorial-seven-dotnet.md
+++ b/site/tutorials/tutorial-seven-dotnet.md
@@ -272,7 +272,7 @@ to the constraints in the application and in the overall system. Typical techniq
 
 ## Putting It All Together
 
-The [`PublisherConfirms.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/PublisherConfirms/PublisherConfirms.cs)
+The [`PublisherConfirms.cs`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/PublisherConfirms/PublisherConfirms.cs)
 class contains code for the techniques we covered. We can compile it, execute it as-is and
 see how they each perform:
 

--- a/site/tutorials/tutorial-seven-java.md
+++ b/site/tutorials/tutorial-seven-java.md
@@ -260,7 +260,7 @@ to the constraints in the application and in the overall system. Typical techniq
 
 ## Putting It All Together
 
-The [`PublisherConfirms.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/PublisherConfirms.java)
+The [`PublisherConfirms.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/PublisherConfirms.java)
 class contains code for the techniques we covered. We can compile it, execute it as-is and
 see how they each perform:
 

--- a/site/tutorials/tutorial-six-dotnet.md
+++ b/site/tutorials/tutorial-six-dotnet.md
@@ -227,7 +227,7 @@ We declare our fibonacci function. It assumes only valid positive integer input.
 and it's probably the slowest recursive implementation possible).
 
 
-The code for our RPC server [RPCServer.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/RPCServer/RPCServer.cs) looks like this:
+The code for our RPC server [RPCServer.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/RPCServer/RPCServer.cs) looks like this:
 
 <pre class="lang-csharp">
 using System;
@@ -315,7 +315,7 @@ The server code is rather straightforward:
     we do the work and send the response back.
 
 
-The code for our RPC client [RPCClient.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/RPCClient/RPCClient.cs):
+The code for our RPC client [RPCClient.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/RPCClient/RPCClient.cs):
 
 <pre class="lang-csharp">
 using System;
@@ -427,7 +427,7 @@ rpcClient.Close();
 </pre>
 
 Now is a good time to take a look at our full example source code (which includes basic exception handling) for
-[RPCClient.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/RPCClient/RPCClient.cs) and [RPCServer.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/RPCServer/RPCServer.cs).
+[RPCClient.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/RPCClient/RPCClient.cs) and [RPCServer.cs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/RPCServer/RPCServer.cs).
 
 
 Set up as usual (see [tutorial one](tutorial-one-dotnet.html)):

--- a/site/tutorials/tutorial-six-elixir.md
+++ b/site/tutorials/tutorial-six-elixir.md
@@ -372,4 +372,4 @@ complex (but important) problems, like:
 >If you want to experiment, you may find the [management UI](../management.html) useful for viewing the queues.
 >
 
-(Full source code for [rpc_client.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/rpc_client.exs) and [rpc_server.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/elixir/rpc_server.exs))
+(Full source code for [rpc_client.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/rpc_client.exs) and [rpc_server.exs](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/elixir/rpc_server.exs))

--- a/site/tutorials/tutorial-six-go.md
+++ b/site/tutorials/tutorial-six-go.md
@@ -226,7 +226,7 @@ We declare our fibonacci function. It assumes only valid positive integer input.
 (Don't expect this one to work for big numbers,
 and it's probably the slowest recursive implementation possible).
 
-The code for our RPC server [rpc_server.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/rpc_server.go) looks like this:
+The code for our RPC server [rpc_server.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/rpc_server.go) looks like this:
 
 <pre class="lang-go">
 package main
@@ -337,7 +337,7 @@ The server code is rather straightforward:
     from the queue. Then we enter the goroutine where we do the work and send the response back.
 
 
-The code for our RPC client [rpc_client.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/rpc_client.go):
+The code for our RPC client [rpc_client.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/rpc_client.go):
 
 <pre class="lang-go">
 package main
@@ -457,7 +457,7 @@ func bodyFrom(args []string) int {
 </pre>
 
 Now is a good time to take a look at our full example source code for
-[rpc_client.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/rpc_client.go) and [rpc_server.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/rpc_server.go).
+[rpc_client.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/rpc_client.go) and [rpc_server.go](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/rpc_server.go).
 
 
 Our RPC service is now ready. We can start the server:

--- a/site/tutorials/tutorial-six-java.md
+++ b/site/tutorials/tutorial-six-java.md
@@ -226,7 +226,7 @@ We declare our fibonacci function. It assumes only valid positive integer input.
 (Don't expect this one to work for big numbers,
 and it's probably the slowest recursive implementation possible).
 
-The code for our RPC server can be found here: [`RPCServer.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/RPCServer.java).
+The code for our RPC server can be found here: [`RPCServer.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/RPCServer.java).
 
 The server code is rather straightforward:
 
@@ -239,7 +239,7 @@ The server code is rather straightforward:
     form of an object (`DeliverCallback`) that will do the work and send the response back.
 
 
-The code for our RPC client can be found here: [`RPCClient.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/RPCClient.java).
+The code for our RPC client can be found here: [`RPCClient.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/RPCClient.java).
 
 The client code is slightly more involved:
 
@@ -264,7 +264,7 @@ The client code is slightly more involved:
 
 
 Now is a good time to take a look at our full example source code (which includes basic exception handling) for
-[RPCClient.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/RPCClient.java) and [RPCServer.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/java/RPCServer.java).
+[RPCClient.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/RPCClient.java) and [RPCServer.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java/RPCServer.java).
 
 Compile and set up the classpath as usual (see [tutorial one](tutorial-one-java.html)):
 

--- a/site/tutorials/tutorial-six-javascript.md
+++ b/site/tutorials/tutorial-six-javascript.md
@@ -209,7 +209,7 @@ We declare our fibonacci function. It assumes only valid positive integer input.
 and it's probably the slowest recursive implementation possible).
 
 
-The code for our RPC server [rpc_server.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/rpc_server.js) looks like this:
+The code for our RPC server [rpc_server.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/rpc_server.js) looks like this:
 
 <pre class="lang-javascript">
 #!/usr/bin/env node
@@ -267,7 +267,7 @@ The server code is rather straightforward:
     callback function where we do the work and send the response back.
 
 
-The code for our RPC client [rpc_client.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/rpc_client.js):
+The code for our RPC client [rpc_client.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/rpc_client.js):
 
 <pre class="lang-javascript">
 #!/usr/bin/env node
@@ -328,7 +328,7 @@ function generateUuid() {
 </pre>
 
 Now is a good time to take a look at our full example source code for
-[rpc_client.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/rpc_client.js) and [rpc_server.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/rpc_server.js).
+[rpc_client.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/rpc_client.js) and [rpc_server.js](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/rpc_server.js).
 
 
 Our RPC service is now ready. We can start the server:

--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -225,7 +225,7 @@ We declare our fibonacci function. It assumes only valid positive integer input.
 (Don't expect this one to work for big numbers,
 and it's probably the slowest recursive implementation possible).
 
-The code for our RPC server [rpc_server.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/rpc_server.php) looks like this:
+The code for our RPC server [rpc_server.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/rpc_server.php) looks like this:
 
 <pre class="lang-php">
 &lt;?php
@@ -291,7 +291,7 @@ The server code is rather straightforward:
   * We use `basic_consume` to access the queue. Then we enter the while loop in which
     we wait for request messages, do the work and send the response back.
 
-The code for our RPC client [rpc_client.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/rpc_client.php):
+The code for our RPC client [rpc_client.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/rpc_client.php):
 
 <pre class="lang-php">
 &lt;?php
@@ -371,7 +371,7 @@ echo ' [.] Got ', $response, "\n";
 </pre>
 
 Now is a good time to take a look at our full example source code for
-[rpc_client.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/rpc_client.php) and [rpc_server.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/rpc_server.php).
+[rpc_client.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/rpc_client.php) and [rpc_server.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/rpc_server.php).
 
 
 Our RPC service is now ready. We can start the server:

--- a/site/tutorials/tutorial-six-python.md
+++ b/site/tutorials/tutorial-six-python.md
@@ -214,7 +214,7 @@ Our RPC will work like this:
 Putting it all together
 -----------------------
 
-`rpc_server.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/rpc_server.py))
+`rpc_server.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/rpc_server.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python
@@ -270,7 +270,7 @@ The server code is rather straightforward:
     `prefetch_count` setting.
 
 
-`rpc_client.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/rpc_client.py))
+`rpc_client.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/rpc_client.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python

--- a/site/tutorials/tutorial-six-ruby.md
+++ b/site/tutorials/tutorial-six-ruby.md
@@ -221,7 +221,7 @@ We declare our fibonacci function. It assumes only valid positive integer input.
 and it's probably the slowest recursive implementation possible).
 
 
-The code for our RPC server [rpc_server.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/rpc_server.rb) looks like this:
+The code for our RPC server [rpc_server.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/rpc_server.rb) looks like this:
 
 <pre class="lang-ruby">
 #!/usr/bin/env ruby
@@ -298,7 +298,7 @@ The server code is rather straightforward:
     The consumer will wait for deliveries to be pushed to it, do the work and send the response back.
 
 
-The code for our RPC client [rpc_client.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/rpc_client.rb):
+The code for our RPC client [rpc_client.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/rpc_client.rb):
 
 <pre class="lang-ruby">
 #!/usr/bin/env ruby
@@ -375,7 +375,7 @@ client.stop
 
 
 Now is a good time to take a look at our full example source code (which includes basic exception handling) for
-[rpc_client.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/rpc_client.rb) and [rpc_server.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/ruby/rpc_server.rb).
+[rpc_client.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/rpc_client.rb) and [rpc_server.rb](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/ruby/rpc_server.rb).
 
 
 Our RPC service is now ready. We can start the server:

--- a/site/tutorials/tutorial-six-spring-amqp.md
+++ b/site/tutorials/tutorial-six-spring-amqp.md
@@ -208,7 +208,7 @@ We declare our Fibonacci function. It assumes only valid positive integer input.
 (Don't expect this one to work for big numbers,
 and it's probably the slowest recursive implementation possible).
 
-The code for our [`Tut6Config`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Config.java)
+The code for our [`Tut6Config`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Config.java)
 class looks like this:
 
 <pre class="lang-java">
@@ -282,7 +282,7 @@ The server code is rather straightforward:
   * Our Fibonacci method calls fib() with the payload parameter and returns
     the result
 
-The code for our RPC server [Tut6Server.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Server.java):
+The code for our RPC server [Tut6Server.java](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Server.java):
 
 <pre class="lang-java">
 package org.springframework.amqp.tutorials.tut6;
@@ -310,7 +310,7 @@ public class Tut6Server {
 
 
 
-The client code [Tut6Client](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Client.java)
+The client code [Tut6Client](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut6/Tut6Client.java)
 is as easy as the server:
 
   * We autowire the `RabbitTemplate` and the `DirectExchange` bean

--- a/site/tutorials/tutorial-three-dotnet.md
+++ b/site/tutorials/tutorial-three-dotnet.md
@@ -307,7 +307,7 @@ class EmitLog
 </pre>
 
 
-[(EmitLog.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/EmitLog/EmitLog.cs)
+[(EmitLog.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/EmitLog/EmitLog.cs)
 
 As you see, after establishing the connection we declared the
 exchange. This step is necessary as publishing to a non-existing
@@ -359,7 +359,7 @@ class ReceiveLogs
 }
 </pre>
 
-[(ReceiveLogs.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/ReceiveLogs/ReceiveLogs.cs)
+[(ReceiveLogs.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/ReceiveLogs/ReceiveLogs.cs)
 
 Follow the setup instructions from [tutorial one](tutorial-one-dotnet.html) to
 generate the `EmitLogs` and `ReceiveLogs` projects.

--- a/site/tutorials/tutorial-three-javascript.md
+++ b/site/tutorials/tutorial-three-javascript.md
@@ -291,7 +291,7 @@ amqp.connect('amqp://localhost', function(error0, connection) {
 });
 </pre>
 
-[(emit_log.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/emit_log.js)
+[(emit_log.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/emit_log.js)
 
 As you see, after establishing the connection we declared the
 exchange. This step is necessary as publishing to a non-existing
@@ -342,7 +342,7 @@ amqp.connect('amqp://localhost', function(error0, connection) {
 });
 </pre>
 
-[(receive_logs.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/receive_logs.js)
+[(receive_logs.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/receive_logs.js)
 
 
 If you want to save logs to a file, just open a console and type:

--- a/site/tutorials/tutorial-three-php.md
+++ b/site/tutorials/tutorial-three-php.md
@@ -280,7 +280,7 @@ $channel->close();
 $connection->close();
 </pre>
 
-[(emit_log.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/emit_log.php)
+[(emit_log.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/emit_log.php)
 
 As you see, after establishing the connection we declared the
 exchange. This step is necessary as publishing to a non-existing
@@ -322,7 +322,7 @@ $channel->close();
 $connection->close();
 </pre>
 
-[(receive_logs.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/receive_logs.php)
+[(receive_logs.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/receive_logs.php)
 
 
 If you want to save logs to a file, just open a console and type:

--- a/site/tutorials/tutorial-three-python.md
+++ b/site/tutorials/tutorial-three-python.md
@@ -268,7 +268,7 @@ we now want to publish messages to our `logs` exchange instead of the
 nameless one. We need to supply a `routing_key` when sending, but its
 value is ignored for `fanout` exchanges.
 
-`emit_log.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/emit_log.py))
+`emit_log.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/emit_log.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python
@@ -294,7 +294,7 @@ exchange is forbidden.
 The messages will be lost if no queue is bound to the exchange yet,
 but that's okay for us; if no consumer is listening yet we can safely discard the message.
 
-`receive_logs.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/receive_logs.py))
+`receive_logs.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/receive_logs.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python

--- a/site/tutorials/tutorial-three-spring-amqp.md
+++ b/site/tutorials/tutorial-three-spring-amqp.md
@@ -366,7 +366,7 @@ public class Tut3Sender {
 }
 </pre>
 
-[Tut3Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Sender.java)
+[Tut3Sender.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Sender.java)
 
 As you see, we leverage the beans from the `Tut3Config` file and
 autowire in the `RabbitTemplate` along with our configured
@@ -415,7 +415,7 @@ public class Tut3Receiver {
 }
 </pre>
 
-[Tut3Receiver.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Receiver.java)
+[Tut3Receiver.java source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/spring-amqp/src/main/java/org/springframework/amqp/tutorials/tut3/Tut3Receiver.java)
 
 Compile as before and we're ready to execute the fanout sender and receiver.
 

--- a/site/tutorials/tutorial-three-swift.md
+++ b/site/tutorials/tutorial-three-swift.md
@@ -275,7 +275,7 @@ q.subscribe({(_ message: RMQMessage) -> Void in
 })
 </pre>
 
-[(source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/swift/tutorial3/tutorial3/ViewController.swift)
+[(source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/swift/tutorial3/tutorial3/ViewController.swift)
 
 Using `rabbitmqctl list_bindings` you can verify that the code actually
 creates bindings and queues as we want. With two `receiveLogs`

--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -511,7 +511,7 @@ class NewTask
 }
 </pre>
 
-[(NewTask.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/dotnet/NewTask/NewTask.cs)
+[(NewTask.cs source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/dotnet/NewTask/NewTask.cs)
 
 
 Using message acknowledgments and `BasicQos` you can set up a

--- a/site/tutorials/tutorial-two-javascript.md
+++ b/site/tutorials/tutorial-two-javascript.md
@@ -413,7 +413,7 @@ amqp.connect('amqp://localhost', function(error0, connection) {
 });
 </pre>
 
-[(new_task.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/new_task.js)
+[(new_task.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/new_task.js)
 
 And our `worker.js`:
 
@@ -454,7 +454,7 @@ amqp.connect('amqp://localhost', function(error0, connection) {
 });
 </pre>
 
-[(worker.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/javascript-nodejs/src/worker.js)
+[(worker.js source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/worker.js)
 
 Using message acknowledgments and `prefetch` you can set up a
 work queue. The durability options let the tasks survive even if

--- a/site/tutorials/tutorial-two-objectivec.md
+++ b/site/tutorials/tutorial-two-objectivec.md
@@ -397,7 +397,7 @@ And our `workerNamed:`:
 }
 </pre>
 
-[(source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/objective-c/tutorial2/tutorial2/ViewController.m)
+[(source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/objective-c/tutorial2/tutorial2/ViewController.m)
 
 Using message acknowledgments and prefetch you can set up a
 work queue. The durability options let the tasks survive even if
@@ -408,4 +408,4 @@ to deliver the same message to many consumers.
 
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
 [previous]:tutorial-one-objectivec.html
-[previous-code]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/objective-c/tutorial1/tutorial1/ViewController.m
+[previous-code]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/objective-c/tutorial1/tutorial1/ViewController.m

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -401,7 +401,7 @@ $connection->close();
 </pre>
 
 
-[(new_task.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/php/new_task.php)
+[(new_task.php source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/php/new_task.php)
 
 And our `worker.php`:
 

--- a/site/tutorials/tutorial-two-python.md
+++ b/site/tutorials/tutorial-two-python.md
@@ -360,7 +360,7 @@ channel.basic_qos(prefetch_count=1)
 Putting it all together
 -----------------------
 
-`new_task.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/new_task.py))
+`new_task.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/new_task.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python
@@ -385,7 +385,7 @@ print(" [x] Sent %r" % message)
 connection.close()
 </pre>
 
-`worker.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/python/worker.py))
+`worker.py` ([source](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python/worker.py))
 
 <pre class="lang-python">
 #!/usr/bin/env python

--- a/site/tutorials/tutorial-two-swift.md
+++ b/site/tutorials/tutorial-two-swift.md
@@ -382,7 +382,7 @@ func workerNamed(_ name: String) {
 }
 </pre>
 
-[(source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/swift/tutorial2/tutorial2/ViewController.swift)
+[(source)](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/swift/tutorial2/tutorial2/ViewController.swift)
 
 Using message acknowledgments and prefetch you can set up a
 work queue. The durability options let the tasks survive even if
@@ -393,4 +393,4 @@ to deliver the same message to many consumers.
 
 [client]:https://github.com/rabbitmq/rabbitmq-objc-client
 [previous]:tutorial-one-swift.html
-[previous-code]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/swift/tutorial1/tutorial1/ViewController.swift
+[previous-code]:https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/swift/tutorial1/tutorial1/ViewController.swift


### PR DESCRIPTION
I updated many github urls point to rabbitmq-tutorials to match with the current url (main instead of master).

Example: 
https://github.com/rabbitmq/rabbitmq-tutorials/blob/master/go/emit_log.go
to
https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/emit_log.go