### PR TITLE
Renames amqp.node to amqplib

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -105,8 +105,8 @@ Miscellaneous projects:
 
 ## <a id="node-dev" class="anchor" href="#node-dev">JavaScript and Node</a>
 
+ * [amqplib](https://github.com/amqp-node/amqplib): RabbitMQ (AMQP 0-9-1) client for Node.js
  * [amqp-client](https://github.com/cloudamqp/amqp-client.js): High performance client for both NodeJS and browsers (WebSocket), written in TypeScript
- * [amqp.node](https://github.com/squaremo/amqp.node): RabbitMQ (AMQP 0-9-1) client for Node.js
  * [rabbit.js](https://github.com/squaremo/rabbit.js): message patterns in node.js using RabbitMQ.
  * [rabbitmq-stream-js-client](https://github.com/coders51/rabbitmq-stream-js-client): RabbitMQ Stream NodeJS client.
  * [amqp-stats](https://github.com/timisbusy/node-amqp-stats): a node.js interface for RabbitMQ management statistics


### PR DESCRIPTION
It looks like that the original link for `amqp.node` redirects to `amqplib`. I was a bit confused at first, cause I didn't see `amqplib` mentioned on this page, even though the tutorials used it.