### PR TITLE
Updating the redirecting links

### DIFF
--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -950,8 +950,7 @@ Note that this list is by no means complete.
     <tr>
       <td>New Relic</td>
       <td>
-        <a href="https://newrelic.com/plugins/vmware-29/95">NewRelic Plugins</a>,
-        <a href="https://github.com/pivotalsoftware/newrelic_pivotal_agent">GitHub</a>
+       <a href="https://newrelic.com/instant-observability/rabbitmq">NewRelic RabbitMQ monitoring</a>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Hey Team
There is a problem with this redirecting links so I am updating this.
We’d love to provide a smooth experience for RabbitMQ users who need to use monitoring solutions, such as New Relic.
Thank you for your consideration.