### PR TITLE
Updating the RabbitMQ monitoring tool name

### DIFF
--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -950,7 +950,7 @@ Note that this list is by no means complete.
     <tr>
       <td>New Relic</td>
       <td>
-       <a href="https://newrelic.com/instant-observability/rabbitmq">NewRelic RabbitMQ monitoring</a>
+       <a href="https://newrelic.com/instant-observability/rabbitmq">New Relic RabbitMQ monitoring</a>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Hey Team 
I just need to update the name of the rabbitMQ monitoring i.e, New Relic tool name as per the Official website guidelines
Thank you for the consideration