### PR TITLE
update rabbitmqctl to use inclusive info keys

### DIFF
--- a/site/ha.md
+++ b/site/ha.md
@@ -240,7 +240,7 @@ It is possible to list queue leader and mirrors using `rabbitmqctl list_queues`.
 example we also display queue policy since it's highly relevant:
 
 <pre class="lang-bash">
-rabbitmqctl list_queues name policy pid slave_pids
+rabbitmqctl list_queues name policy pid mirror_pids
 
 # =&gt; Timeout: 60.0 seconds ...
 # =&gt; Listing queues for vhost / ...
@@ -679,7 +679,7 @@ a common scenario with lazy queues, for example.
 To see mirror status (whether they are synchronised), use:
 
 <pre class="lang-bash">
-rabbitmqctl list_queues name slave_pids synchronised_slave_pids
+rabbitmqctl list_queues name mirror_pids synchronised_mirror_pids
 </pre>
 
 It is possible to manually synchronise a queue:

--- a/site/man/README.md
+++ b/site/man/README.md
@@ -7,8 +7,8 @@ They are converted to HTML using `mandoc`:
 
 ``` shell
 # from rabbitmq/rabbitmq-server
-gmake docs
-ls docs/*.html
+bazel build //deps/rabbit:web-manpages
+tar xf bazel-bin/deps/rabbit/web-manpages.tar
 ```
 
 ## Contributions

--- a/site/man/rabbitmqctl.8.html
+++ b/site/man/rabbitmqctl.8.html
@@ -1,1139 +1,1025 @@
 <div class="manual-text">
-<h2 class="Sh" title="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h2>
-<code class="Nm" title="Nm">rabbitmqctl</code> &#x2014;
-<div class="Nd" title="Nd">tool for managing RabbitMQ nodes</div>
-<h2 class="Sh" title="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h2>
+<section class="Sh">
+<h2 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h2>
+<p class="Pp"><code class="Nm">rabbitmqctl</code> &#x2014; <span class="Nd">tool
+    for managing RabbitMQ nodes</span></p>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h2>
 <table class="Nm">
   <tr>
-    <td><code class="Nm" title="Nm">rabbitmqctl</code></td>
-    <td>[<div class="Op"><code class="Fl" title="Fl">-q</code></div>]
-      [<div class="Op"><code class="Fl" title="Fl">-s</code></div>]
-      [<div class="Op"><code class="Fl" title="Fl">-l</code></div>]
-      [<div class="Op"><code class="Fl" title="Fl">-n</code>
-      <var class="Ar" title="Ar">node</var></div>]
-      [<div class="Op"><code class="Fl" title="Fl">-t</code>
-      <var class="Ar" title="Ar">timeout</var></div>]
-      <var class="Ar" title="Ar">command</var>
-      [<div class="Op"><var class="Ar" title="Ar">command_options</var></div>]</td>
+    <td><code class="Nm">rabbitmqctl</code></td>
+    <td>[<code class="Fl">-q</code>] [<code class="Fl">-s</code>]
+      [<code class="Fl">-l</code>] [<code class="Fl">-n</code>
+      <var class="Ar">node</var>] [<code class="Fl">-t</code>
+      <var class="Ar">timeout</var>] <var class="Ar">command</var>
+      [<var class="Ar">command_options</var>]</td>
   </tr>
 </table>
-<h2 class="Sh" title="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h2>
-RabbitMQ is an open source multi-protocol messaging broker.
-<div class="Pp"></div>
-<code class="Nm" title="Nm">rabbitmqctl</code> is the main command line tool for
-  managing a RabbitMQ server node, together with
-  <code class="Cm" title="Cm">rabbitmq-diagnostics</code> ,
-  <code class="Cm" title="Cm">rabbitmq-upgrade</code> , and others.
-<div class="Pp"></div>
-It performs all actions by connecting to the target RabbitMQ node on a dedicated
-  CLI tool communication port and authenticating using a shared secret (known as
-  the cookie file).
-<div class="Pp"></div>
-Diagnostic information is displayed if connection failed, the target node was
-  not running, or <code class="Nm" title="Nm">rabbitmqctl</code> could not
-  authenticate to the target node successfully. To learn more, see the
-  <a class="Lk" title="Lk" href="https://www.rabbitmq.com/cli.html">RabbitMQ CLI
-  Tools guide</a> and
-  <a class="Lk" title="Lk" href="https://www.rabbitmq.com/networking.html">RabbitMQ
-  Networking guide</a>
-<h2 class="Sh" title="Sh" id="OPTIONS"><a class="permalink" href="#OPTIONS">OPTIONS</a></h2>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h2>
+<p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
+<p class="Pp"><code class="Nm">rabbitmqctl</code> is the main command line tool
+    for managing a RabbitMQ server node, together with
+    <code class="Cm">rabbitmq-diagnostics</code> ,
+    <code class="Cm">rabbitmq-upgrade</code> , and others.</p>
+<p class="Pp">It performs all actions by connecting to the target RabbitMQ node
+    on a dedicated CLI tool communication port and authenticating using a shared
+    secret (known as the cookie file).</p>
+<p class="Pp">Diagnostic information is displayed if connection failed, the
+    target node was not running, or <code class="Nm">rabbitmqctl</code> could
+    not authenticate to the target node successfully.</p>
+<p class="Pp">To learn more, see the
+    <a class="Lk" href="https://rabbitmq.com/cli.html">RabbitMQ CLI Tools
+    guide</a></p>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="OPTIONS"><a class="permalink" href="#OPTIONS">OPTIONS</a></h2>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#n"><code class="Fl" title="Fl" id="n">-n</code></a>
-    <var class="Ar" title="Ar">node</var></dt>
-  <dd>Default node is
-      &quot;<var class="Ar" title="Ar">rabbit@target-hostname</var>&quot;,
-      where <var class="Ar" title="Ar">target-hostname</var> is the local host.
-      On a host named &quot;myserver.example.com&quot;, the node name will
-      usually be &quot;rabbit@myserver&quot; (unless
-      <code class="Ev" title="Ev">RABBITMQ_NODENAME</code> has been overridden).
-      The output of &quot;hostname -s&quot; is usually the correct suffix to
-      use after the &quot;@&quot; sign. See
-      <a class="Xr" title="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>
-      for details of configuring a RabbitMQ node.</dd>
-  <dt><a class="permalink" href="#q"><code class="Fl" title="Fl" id="q">-q</code></a>,
-    <code class="Fl" title="Fl">--quiet</code></dt>
+  <dt id="n"><a class="permalink" href="#n"><code class="Fl">-n</code></a>
+    <var class="Ar">node</var></dt>
+  <dd>Default node is &quot;<var class="Ar">rabbit@target-hostname</var>&quot;,
+      where <var class="Ar">target-hostname</var> is the local host. On a host
+      named &quot;myserver.example.com&quot;, the node name will usually be
+      &quot;rabbit@myserver&quot; (unless
+      <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output
+      of &quot;hostname -s&quot; is usually the correct suffix to use after the
+      &quot;@&quot; sign. See
+      <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for
+      details of configuring a RabbitMQ node.</dd>
+  <dt id="q"><a class="permalink" href="#q"><code class="Fl">-q</code></a>,
+    <code class="Fl">--quiet</code></dt>
   <dd>Quiet output mode is selected. Informational messages are reduced when
       quiet mode is in effect.</dd>
-  <dt><a class="permalink" href="#s"><code class="Fl" title="Fl" id="s">-s</code></a>,
-    <code class="Fl" title="Fl">--silent</code></dt>
+  <dt id="s"><a class="permalink" href="#s"><code class="Fl">-s</code></a>,
+    <code class="Fl">--silent</code></dt>
   <dd>Silent output mode is selected. Informational messages are reduced and
       table headers are suppressed when silent mode is in effect.</dd>
-  <dt><a class="permalink" href="#-no-table-headers"><code class="Fl" title="Fl" id="-no-table-headers">--no-table-headers</code></a></dt>
+  <dt id="no-table-headers"><a class="permalink" href="#no-table-headers"><code class="Fl">--no-table-headers</code></a></dt>
   <dd>Do not output headers for tabular data.</dd>
-  <dt><a class="permalink" href="#-dry-run"><code class="Fl" title="Fl" id="-dry-run">--dry-run</code></a></dt>
+  <dt id="dry-run"><a class="permalink" href="#dry-run"><code class="Fl">--dry-run</code></a></dt>
   <dd>Do not run the command. Only print information message.</dd>
-  <dt><a class="permalink" href="#t"><code class="Fl" title="Fl" id="t">-t</code></a>
-    <var class="Ar" title="Ar">timeout</var>,
-    <code class="Fl" title="Fl">--timeout</code>
-    <var class="Ar" title="Ar">timeout</var></dt>
+  <dt id="t"><a class="permalink" href="#t"><code class="Fl">-t</code></a>
+    <var class="Ar">timeout</var>, <code class="Fl">--timeout</code>
+    <var class="Ar">timeout</var></dt>
   <dd>Operation timeout in seconds. Not all commands support timeouts. Default
-      is <code class="Cm" title="Cm">infinity</code>.</dd>
-  <dt><a class="permalink" href="#l"><code class="Fl" title="Fl" id="l">-l</code></a>,
-    <code class="Fl" title="Fl">--longnames</code></dt>
+      is <code class="Cm">infinity</code>.</dd>
+  <dt id="l"><a class="permalink" href="#l"><code class="Fl">-l</code></a>,
+    <code class="Fl">--longnames</code></dt>
   <dd>Must be specified when the cluster is configured to use long (FQDN) node
       names. To learn more, see the
-      <a class="Lk" title="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
+      <a class="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
       Clustering guide</a></dd>
-  <dt><a class="permalink" href="#-erlang-cookie"><code class="Fl" title="Fl" id="-erlang-cookie">--erlang-cookie</code></a>
-    <var class="Ar" title="Ar">cookie</var></dt>
+  <dt id="erlang-cookie"><a class="permalink" href="#erlang-cookie"><code class="Fl">--erlang-cookie</code></a>
+    <var class="Ar">cookie</var></dt>
   <dd>Shared secret to use to authenticate to the target node. Prefer using a
-      local file or the
-      <code class="Ev" title="Ev">RABBITMQ_ERLANG_COOKIE</code> environment
-      variable instead of specifying this option on the command line. To learn
-      more, see the
-      <a class="Lk" title="Lk" href="https://www.rabbitmq.com/cli.html">RabbitMQ
-      CLI Tools guide</a></dd>
+      local file or the <code class="Ev">RABBITMQ_ERLANG_COOKIE</code>
+      environment variable instead of specifying this option on the command
+      line. To learn more, see the
+      <a class="Lk" href="https://www.rabbitmq.com/cli.html">RabbitMQ CLI Tools
+      guide</a></dd>
 </dl>
-<h2 class="Sh" title="Sh" id="COMMANDS"><a class="permalink" href="#COMMANDS">COMMANDS</a></h2>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="COMMANDS"><a class="permalink" href="#COMMANDS">COMMANDS</a></h2>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#help"><code class="Cm" title="Cm" id="help">help</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-l</code></div>]
-    [<div class="Op"><var class="Ar" title="Ar">command_name</var></div>]</dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Cm">help</code></a>
+    [<code class="Fl">-l</code>] [<var class="Ar">command_name</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Prints usage for all available commands.
+    <p class="Pp">Prints usage for all available commands.</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#l_2"><code class="Fl" title="Fl" id="l_2">-l</code></a>,
-        <code class="Fl" title="Fl">--list-commands</code></dt>
+      <dt id="l~2"><a class="permalink" href="#l~2"><code class="Fl">-l</code></a>,
+        <code class="Fl">--list-commands</code></dt>
       <dd>List command usages only, without parameter explanation.</dd>
-      <dt><var class="Ar" title="Ar">command_name</var></dt>
+      <dt><var class="Ar">command_name</var></dt>
       <dd>Prints usage for the specified command.</dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#version"><code class="Cm" title="Cm" id="version">version</code></a></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Cm">version</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Displays CLI tools version</dd>
+    <p class="Pp">Displays CLI tools version</p>
+  </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Nodes"><a class="permalink" href="#Nodes">Nodes</a></h3>
+<section class="Ss">
+<h3 class="Ss" id="Nodes"><a class="permalink" href="#Nodes">Nodes</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#await_startup"><code class="Cm" title="Cm" id="await_startup">await_startup</code></a></dt>
+  <dt id="await_startup"><a class="permalink" href="#await_startup"><code class="Cm">await_startup</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Waits for the RabbitMQ application to start on the target node
-    <div class="Pp"></div>
-    For example, to wait for the RabbitMQ application to start:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Waits for the RabbitMQ application to start on the target
+      node</p>
+    <p class="Pp">For example, to wait for the RabbitMQ application to
+      start:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       await_startup</code></div>
   </dd>
-  <dt><a class="permalink" href="#reset"><code class="Cm" title="Cm" id="reset">reset</code></a></dt>
+  <dt id="reset"><a class="permalink" href="#reset"><code class="Cm">reset</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Returns a RabbitMQ node to its virgin state.
-    <div class="Pp"></div>
-    Removes the node from any cluster it belongs to, removes all data from the
-      management database, such as configured users and vhosts, and deletes all
-      persistent messages.
-    <div class="Pp"></div>
-    For <code class="Cm" title="Cm">reset</code> and
-      <code class="Cm" title="Cm">force_reset</code> to succeed the RabbitMQ
-      application must have been stopped, e.g. with
-      <code class="Cm" title="Cm">stop_app</code>.
-    <div class="Pp"></div>
-    For example, to reset the RabbitMQ node:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl reset</code></div>
+    <p class="Pp">Returns a RabbitMQ node to its virgin state.</p>
+    <p class="Pp">Removes the node from any cluster it belongs to, removes all
+        data from the management database, such as configured users and vhosts,
+        and deletes all persistent messages.</p>
+    <p class="Pp">For <code class="Cm">reset</code> and
+        <code class="Cm">force_reset</code> to succeed the RabbitMQ application
+        must have been stopped, e.g. with <code class="Cm">stop_app</code>.</p>
+    <p class="Pp">For example, to reset the RabbitMQ node:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl reset</code></div>
   </dd>
-  <dt><a class="permalink" href="#rotate_logs"><code class="Cm" title="Cm" id="rotate_logs">rotate_logs</code></a></dt>
+  <dt id="rotate_logs"><a class="permalink" href="#rotate_logs"><code class="Cm">rotate_logs</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Instructs the RabbitMQ node to perform internal log rotation.
-    <div class="Pp"></div>
-    Log rotation is performed according to the logging settings specified in the
-      configuration file. The rotation operation is asynchronous, there is no
-      guarantee that it has completed when this command returns.
-    <div class="Pp"></div>
-    Note that there is no need to call this command in case of external log
-      rotation (e.g. from logrotate(8)).
-    <div class="Pp"></div>
-    For example, to initial log rotation:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Instructs the RabbitMQ node to perform internal log
+      rotation.</p>
+    <p class="Pp">Log rotation is performed according to the logging settings
+        specified in the configuration file. The rotation operation is
+        asynchronous, there is no guarantee that it has completed when this
+        command returns.</p>
+    <p class="Pp">Note that there is no need to call this command in case of
+        external log rotation (e.g. from logrotate(8)).</p>
+    <p class="Pp">For example, to initial log rotation:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       rotate_logs</code></div>
   </dd>
-  <dt><a class="permalink" href="#shutdown"><code class="Cm" title="Cm" id="shutdown">shutdown</code></a></dt>
+  <dt id="shutdown"><a class="permalink" href="#shutdown"><code class="Cm">shutdown</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Shuts down the node, both RabbitMQ and its runtime. The command is blocking
-      and will return after the runtime process exits. If RabbitMQ fails to
-      stop, it will return a non-zero exit code. This command infers the OS PID
-      of the target node and therefore can only be used to shut down nodes
-      running on the same host (or broadly speaking, in the same operating
-      system, e.g. in the same VM or container)
-    <div class="Pp"></div>
-    Unlike the stop command, the shutdown command:
+    <p class="Pp">Shuts down the node, both RabbitMQ and its runtime. The
+        command is blocking and will return after the runtime process exits. If
+        RabbitMQ fails to stop, it will return a non-zero exit code. This
+        command infers the OS PID of the target node and therefore can only be
+        used to shut down nodes running on the same host (or broadly speaking,
+        in the same operating system, e.g. in the same VM or container)</p>
+    <p class="Pp">Unlike the stop command, the shutdown command:</p>
     <ul class="Bl-bullet">
-      <li>does not require a <var class="Ar" title="Ar">pid_file</var> to wait
-          for the runtime process to exit</li>
+      <li>does not require a <var class="Ar">pid_file</var> to wait for the
+          runtime process to exit</li>
       <li>returns a non-zero exit code if RabbitMQ node is not running</li>
     </ul>
-    <div class="Pp"></div>
-    For example, this will shut down a locally running RabbitMQ node with
-      default node name:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl shutdown</code></div>
+    <p class="Pp">For example, this will shut down a locally running RabbitMQ
+        node with default node name:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl shutdown</code></div>
   </dd>
-  <dt><a class="permalink" href="#start_app"><code class="Cm" title="Cm" id="start_app">start_app</code></a></dt>
+  <dt id="start_app"><a class="permalink" href="#start_app"><code class="Cm">start_app</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Starts the RabbitMQ application.
-    <div class="Pp"></div>
-    This command is typically run after performing other management actions that
-      required the RabbitMQ application to be stopped, e.g.
-      <code class="Cm" title="Cm">reset</code>.
-    <div class="Pp"></div>
-    For example, to instruct the RabbitMQ node to start the RabbitMQ
-      application:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Starts the RabbitMQ application.</p>
+    <p class="Pp">This command is typically run after performing other
+        management actions that required the RabbitMQ application to be stopped,
+        e.g. <code class="Cm">reset</code>.</p>
+    <p class="Pp">For example, to instruct the RabbitMQ node to start the
+        RabbitMQ application:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       start_app</code></div>
   </dd>
-  <dt><a class="permalink" href="#stop"><code class="Cm" title="Cm" id="stop">stop</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">pid_file</var></div>]</dt>
+  <dt id="stop"><a class="permalink" href="#stop"><code class="Cm">stop</code></a>
+    [<var class="Ar">pid_file</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Stops the Erlang node on which RabbitMQ is running. To restart the node
-      follow the instructions for &quot;Running the Server&quot; in the
-      <a class="Lk" title="Lk" href="https://rabbitmq.com/download.html">installation
-      guide</a>.
-    <div class="Pp"></div>
-    If a <var class="Ar" title="Ar">pid_file</var> is specified, also waits for
-      the process specified there to terminate. See the description of the
-      <code class="Cm" title="Cm">wait</code> command for details on this file.
-    <div class="Pp"></div>
-    For example, to instruct the RabbitMQ node to terminate:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl stop</code></div>
+    <p class="Pp">Stops the Erlang node on which RabbitMQ is running. To restart
+        the node follow the instructions for &quot;Running the Server&quot; in
+        the <a class="Lk" href="https://rabbitmq.com/download.html">installation
+        guide</a>.</p>
+    <p class="Pp">If a <var class="Ar">pid_file</var> is specified, also waits
+        for the process specified there to terminate. See the description of the
+        <code class="Cm">wait</code> command for details on this file.</p>
+    <p class="Pp">For example, to instruct the RabbitMQ node to terminate:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl stop</code></div>
   </dd>
-  <dt><a class="permalink" href="#stop_app"><code class="Cm" title="Cm" id="stop_app">stop_app</code></a></dt>
+  <dt id="stop_app"><a class="permalink" href="#stop_app"><code class="Cm">stop_app</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Stops the RabbitMQ application, leaving the runtime (Erlang VM) running.
-    <div class="Pp"></div>
-    This command is typically run prior to performing other management actions
-      that require the RabbitMQ application to be stopped, e.g.
-      <code class="Cm" title="Cm">reset</code>.
-    <div class="Pp"></div>
-    For example, to instruct the RabbitMQ node to stop the RabbitMQ application:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl stop_app</code></div>
+    <p class="Pp">Stops the RabbitMQ application, leaving the runtime (Erlang
+        VM) running.</p>
+    <p class="Pp">This command is typically run prior to performing other
+        management actions that require the RabbitMQ application to be stopped,
+        e.g. <code class="Cm">reset</code>.</p>
+    <p class="Pp">For example, to instruct the RabbitMQ node to stop the
+        RabbitMQ application:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl stop_app</code></div>
   </dd>
-  <dt><a class="permalink" href="#wait"><code class="Cm" title="Cm" id="wait">wait</code></a>
-    <var class="Ar" title="Ar">pid_file</var>,
-    <code class="Cm" title="Cm">wait</code>
-    <code class="Fl" title="Fl">--pid</code>
-    <var class="Ar" title="Ar">pid</var></dt>
+  <dt id="wait"><a class="permalink" href="#wait"><code class="Cm">wait</code></a>
+    <var class="Ar">pid_file</var>, <code class="Cm">wait</code>
+    <code class="Fl">--pid</code> <var class="Ar">pid</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Waits for the RabbitMQ application to start.
-    <div class="Pp"></div>
-    This command will wait for the RabbitMQ application to start at the node. It
-      will wait for the pid file to be created if
-      <var class="Ar" title="Ar">pidfile</var> is specified, then for a process
-      with a pid specified in the pid file or the
-      <code class="Fl" title="Fl">--pid</code> argument, and then for the
-      RabbitMQ application to start in that process. It will fail if the process
-      terminates without starting the RabbitMQ application.
-    <div class="Pp"></div>
-    If the specified pidfile is not created or erlang node is not started within
-      <code class="Fl" title="Fl">--timeout</code> the command will fail.
-      Default timeout is 10 seconds.
-    <div class="Pp"></div>
-    A suitable pid file is created by the
-      <a class="Xr" title="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>
-      script. By default this is located in the Mnesia directory. Modify the
-      <code class="Ev" title="Ev">RABBITMQ_PID_FILE</code> environment variable
-      to change the location.
-    <div class="Pp"></div>
-    For example, this command will return when the RabbitMQ node has started up:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl wait
+    <p class="Pp">Waits for the RabbitMQ application to start.</p>
+    <p class="Pp">This command will wait for the RabbitMQ application to start
+        at the node. It will wait for the pid file to be created if
+        <var class="Ar">pidfile</var> is specified, then for a process with a
+        pid specified in the pid file or the <code class="Fl">--pid</code>
+        argument, and then for the RabbitMQ application to start in that
+        process. It will fail if the process terminates without starting the
+        RabbitMQ application.</p>
+    <p class="Pp">If the specified pidfile is not created or erlang node is not
+        started within <code class="Fl">--timeout</code> the command will fail.
+        Default timeout is 10 seconds.</p>
+    <p class="Pp">A suitable pid file is created by the
+        <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>
+        script. By default this is located in the Mnesia directory. Modify the
+        <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change
+        the location.</p>
+    <p class="Pp">For example, this command will return when the RabbitMQ node
+        has started up:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl wait
       /var/run/rabbitmq/pid</code></div>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Cluster_management"><a class="permalink" href="#Cluster_management">Cluster
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Cluster_management"><a class="permalink" href="#Cluster_management">Cluster
   management</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#await_online_nodes"><code class="Cm" title="Cm" id="await_online_nodes">await_online_nodes</code></a>
-    <var class="Ar" title="Ar">count</var></dt>
+  <dt id="await_online_nodes"><a class="permalink" href="#await_online_nodes"><code class="Cm">await_online_nodes</code></a>
+    <var class="Ar">count</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Waits for <var class="Ar" title="Ar">count</var> nodes to join the cluster
-    <div class="Pp"></div>
-    For example, to wait for two RabbitMQ nodes to start:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl await_online_nodes
+    <p class="Pp">Waits for <var class="Ar">count</var> nodes to join the
+        cluster</p>
+    <p class="Pp">For example, to wait for two RabbitMQ nodes to start:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl await_online_nodes
       2</code></div>
   </dd>
-  <dt><a class="permalink" href="#change_cluster_node_type"><code class="Cm" title="Cm" id="change_cluster_node_type">change_cluster_node_type</code></a>
-    <var class="Ar" title="Ar">type</var></dt>
+  <dt id="change_cluster_node_type"><a class="permalink" href="#change_cluster_node_type"><code class="Cm">change_cluster_node_type</code></a>
+    <var class="Ar">type</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Changes the type of the cluster node.
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">type</var> must be one of the following:
+    <p class="Pp">Changes the type of the cluster node.</p>
+    <p class="Pp">The <var class="Ar">type</var> must be one of the
+      following:</p>
     <ul class="Bl-bullet Bl-compact">
-      <li><a class="permalink" href="#disc"><code class="Cm" title="Cm" id="disc">disc</code></a></li>
-      <li><a class="permalink" href="#ram"><code class="Cm" title="Cm" id="ram">ram</code></a></li>
+      <li id="disc"><a class="permalink" href="#disc"><code class="Cm">disc</code></a></li>
+      <li id="ram"><a class="permalink" href="#ram"><code class="Cm">ram</code></a></li>
     </ul>
-    <div class="Pp"></div>
-    The node must be stopped for this operation to succeed, and when turning a
-      node into a RAM node the node must not be the only disc node in the
-      cluster.
-    <div class="Pp"></div>
-    For example, this command will turn a RAM node into a disc node:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">The node must be stopped for this operation to succeed, and
+        when turning a node into a RAM node the node must not be the only disc
+        node in the cluster.</p>
+    <p class="Pp">For example, this command will turn a RAM node into a disc
+        node:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       change_cluster_node_type disc</code></div>
   </dd>
-  <dt><a class="permalink" href="#cluster_status"><code class="Cm" title="Cm" id="cluster_status">cluster_status</code></a></dt>
+  <dt id="cluster_status"><a class="permalink" href="#cluster_status"><code class="Cm">cluster_status</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Displays all the nodes in the cluster grouped by node type, together with
-      the currently running nodes.
-    <div class="Pp"></div>
-    For example, this command displays the nodes in the cluster:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Displays all the nodes in the cluster grouped by node type,
+        together with the currently running nodes.</p>
+    <p class="Pp">For example, this command displays the nodes in the
+      cluster:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       cluster_status</code></div>
   </dd>
-  <dt><a class="permalink" href="#force_boot"><code class="Cm" title="Cm" id="force_boot">force_boot</code></a></dt>
+  <dt id="force_boot"><a class="permalink" href="#force_boot"><code class="Cm">force_boot</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Ensures that the node will start next time, even if it was not the last to
-      shut down.
-    <div class="Pp"></div>
-    Normally when you shut down a RabbitMQ cluster altogether, the first node
-      you restart should be the last one to go down, since it may have seen
-      things happen that other nodes did not. But sometimes that's not possible:
-      for instance if the entire cluster loses power then all nodes may think
-      they were not the last to shut down.
-    <div class="Pp"></div>
-    In such a case you can invoke <code class="Cm" title="Cm">force_boot</code>
-      while the node is down. This will tell the node to unconditionally start
-      next time you ask it to. If any changes happened to the cluster after this
-      node shut down, they will be lost.
-    <div class="Pp"></div>
-    If the last node to go down is permanently lost then you should use
-      <code class="Cm" title="Cm">forget_cluster_node</code>
-      <code class="Fl" title="Fl">--offline</code> in preference to this
-      command, as it will ensure that mirrored queues which had their leader
-      replica on the lost node get promoted.
-    <div class="Pp"></div>
-    For example, this will force the node not to wait for other nodes next time
-      it is started:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Ensures that the node will start next time, even if it was not
+        the last to shut down.</p>
+    <p class="Pp">Normally when you shut down a RabbitMQ cluster altogether, the
+        first node you restart should be the last one to go down, since it may
+        have seen things happen that other nodes did not. But sometimes that's
+        not possible: for instance if the entire cluster loses power then all
+        nodes may think they were not the last to shut down.</p>
+    <p class="Pp">In such a case you can invoke
+        <code class="Cm">force_boot</code> while the node is down. This will
+        tell the node to unconditionally start next time you ask it to. If any
+        changes happened to the cluster after this node shut down, they will be
+        lost.</p>
+    <p class="Pp">If the last node to go down is permanently lost then you
+        should use <code class="Cm">forget_cluster_node</code>
+        <code class="Fl">--offline</code> in preference to this command, as it
+        will ensure that mirrored queues which had their leader replica on the
+        lost node get promoted.</p>
+    <p class="Pp">For example, this will force the node not to wait for other
+        nodes next time it is started:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       force_boot</code></div>
   </dd>
-  <dt><a class="permalink" href="#force_reset"><code class="Cm" title="Cm" id="force_reset">force_reset</code></a></dt>
+  <dt id="force_reset"><a class="permalink" href="#force_reset"><code class="Cm">force_reset</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Forcefully returns a RabbitMQ node to its virgin state.
-    <div class="Pp"></div>
-    The <code class="Cm" title="Cm">force_reset</code> command differs from
-      <code class="Cm" title="Cm">reset</code> in that it resets the node
-      unconditionally, regardless of the current management database state and
-      cluster configuration. It should only be used as a last resort if the
-      database or cluster configuration has been corrupted.
-    <div class="Pp"></div>
-    For <code class="Cm" title="Cm">reset</code> and
-      <code class="Cm" title="Cm">force_reset</code> to succeed the RabbitMQ
-      application must have been stopped, e.g. with
-      <code class="Cm" title="Cm">stop_app</code>.
-    <div class="Pp"></div>
-    For example, to reset the RabbitMQ node:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Forcefully returns a RabbitMQ node to its virgin state.</p>
+    <p class="Pp">The <code class="Cm">force_reset</code> command differs from
+        <code class="Cm">reset</code> in that it resets the node
+        unconditionally, regardless of the current management database state and
+        cluster configuration. It should only be used as a last resort if the
+        database or cluster configuration has been corrupted.</p>
+    <p class="Pp">For <code class="Cm">reset</code> and
+        <code class="Cm">force_reset</code> to succeed the RabbitMQ application
+        must have been stopped, e.g. with <code class="Cm">stop_app</code>.</p>
+    <p class="Pp">For example, to reset the RabbitMQ node:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       force_reset</code></div>
   </dd>
-  <dt><a class="permalink" href="#forget_cluster_node"><code class="Cm" title="Cm" id="forget_cluster_node">forget_cluster_node</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">--offline</code></div>]</dt>
+  <dt id="forget_cluster_node"><a class="permalink" href="#forget_cluster_node"><code class="Cm">forget_cluster_node</code></a>
+    [<code class="Fl">--offline</code>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#-offline"><code class="Fl" title="Fl" id="-offline">--offline</code></a></dt>
+      <dt id="offline"><a class="permalink" href="#offline"><code class="Fl">--offline</code></a></dt>
       <dd>Enables node removal from an offline node. This is only useful in the
           situation where all the nodes are offline and the last node to go down
           cannot be brought online, thus preventing the whole cluster from
           starting. It should not be used in any other circumstances since it
           can lead to inconsistencies.</dd>
     </dl>
-    <div class="Pp"></div>
-    Removes a cluster node remotely. The node that is being removed must be
-      offline, while the node we are removing from must be online, except when
-      using the <code class="Fl" title="Fl">--offline</code> flag.
-    <div class="Pp"></div>
-    When using the <code class="Fl" title="Fl">--offline</code> flag ,
-      <code class="Nm" title="Nm">rabbitmqctl</code> will not attempt to connect
-      to a node as normal; instead it will temporarily become the node in order
-      to make the change. This is useful if the node cannot be started normally.
-      In this case the node will become the canonical source for cluster
-      metadata (e.g. which queues exist), even if it was not before. Therefore
-      you should use this command on the latest node to shut down if at all
-      possible.
-    <div class="Pp"></div>
-    For example, this command will remove the node
-      &quot;rabbit@stringer&quot; from the node
-      &quot;hare@mcnulty&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl -n hare@mcnulty
+    <p class="Pp">Removes a cluster node remotely. The node that is being
+        removed must be offline, while the node we are removing from must be
+        online, except when using the <code class="Fl">--offline</code>
+      flag.</p>
+    <p class="Pp">When using the <code class="Fl">--offline</code> flag ,
+        <code class="Nm">rabbitmqctl</code> will not attempt to connect to a
+        node as normal; instead it will temporarily become the node in order to
+        make the change. This is useful if the node cannot be started normally.
+        In this case the node will become the canonical source for cluster
+        metadata (e.g. which queues exist), even if it was not before. Therefore
+        you should use this command on the latest node to shut down if at all
+        possible.</p>
+    <p class="Pp">For example, this command will remove the node
+        &quot;rabbit@stringer&quot; from the node &quot;hare@mcnulty&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl -n hare@mcnulty
       forget_cluster_node rabbit@stringer</code></div>
   </dd>
-  <dt><a class="permalink" href="#join_cluster"><code class="Cm" title="Cm" id="join_cluster">join_cluster</code></a>
-    <var class="Ar" title="Ar">seed-node</var>
-    [<div class="Op"><code class="Fl" title="Fl">--ram</code></div>]</dt>
+  <dt id="join_cluster"><a class="permalink" href="#join_cluster"><code class="Cm">join_cluster</code></a>
+    <var class="Ar">seed-node</var> [<code class="Fl">--ram</code>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">seed-node</var></dt>
+      <dt><var class="Ar">seed-node</var></dt>
       <dd>Existing cluster member (seed node) to cluster with.</dd>
-      <dt><a class="permalink" href="#-ram"><code class="Fl" title="Fl" id="-ram">--ram</code></a></dt>
+      <dt id="ram~2"><a class="permalink" href="#ram~2"><code class="Fl">--ram</code></a></dt>
       <dd>If provided, the node will join the cluster as a RAM node. RAM node
           use is discouraged. Use only if you understand why exactly you need to
           use them.</dd>
     </dl>
-    <div class="Pp"></div>
-    Instructs the node to become a member of the cluster that the specified node
-      is in. Before clustering, the node is reset, so be careful when using this
-      command. For this command to succeed the RabbitMQ application must have
-      been stopped, e.g. with <code class="Cm" title="Cm">stop_app</code>.
-    <div class="Pp"></div>
-    Cluster nodes can be of two types: disc or RAM. Disc nodes replicate data in
-      RAM and on disc, thus providing redundancy in the event of node failure
-      and recovery from global events such as power failure across all nodes.
-      RAM nodes replicate data in RAM only (with the exception of queue
-      contents, which can reside on disc if the queue is persistent or too big
-      to fit in memory) and are mainly used for scalability. RAM nodes are more
-      performant only when managing resources (e.g. adding/removing queues,
-      exchanges, or bindings). A cluster must always have at least one disc
-      node, and usually should have more than one.
-    <div class="Pp"></div>
-    The node will be a disc node by default. If you wish to create a RAM node,
-      provide the <code class="Fl" title="Fl">--ram</code> flag.
-    <div class="Pp"></div>
-    After executing the <code class="Cm" title="Cm">join_cluster</code> command,
-      whenever the RabbitMQ application is started on the current node it will
-      attempt to connect to the nodes that were in the cluster when the node
-      went down.
-    <div class="Pp"></div>
-    To leave a cluster, <code class="Cm" title="Cm">reset</code> the node. You
-      can also remove nodes remotely with the
-      <code class="Cm" title="Cm">forget_cluster_node</code> command.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ node to join the cluster
-      that &quot;hare@elena&quot; is part of, as a ram node:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl join_cluster
+    <p class="Pp">Instructs the node to become a member of the cluster that the
+        specified node is in. Before clustering, the node is reset, so be
+        careful when using this command. For this command to succeed the
+        RabbitMQ application must have been stopped, e.g. with
+        <code class="Cm">stop_app</code>.</p>
+    <p class="Pp">Cluster nodes can be of two types: disc or RAM. Disc nodes
+        replicate data in RAM and on disc, thus providing redundancy in the
+        event of node failure and recovery from global events such as power
+        failure across all nodes. RAM nodes replicate data in RAM only (with the
+        exception of queue contents, which can reside on disc if the queue is
+        persistent or too big to fit in memory) and are mainly used for
+        scalability. RAM nodes are more performant only when managing resources
+        (e.g. adding/removing queues, exchanges, or bindings). A cluster must
+        always have at least one disc node, and usually should have more than
+        one.</p>
+    <p class="Pp">The node will be a disc node by default. If you wish to create
+        a RAM node, provide the <code class="Fl">--ram</code> flag.</p>
+    <p class="Pp">After executing the <code class="Cm">join_cluster</code>
+        command, whenever the RabbitMQ application is started on the current
+        node it will attempt to connect to the nodes that were in the cluster
+        when the node went down.</p>
+    <p class="Pp">To leave a cluster, <code class="Cm">reset</code> the node.
+        You can also remove nodes remotely with the
+        <code class="Cm">forget_cluster_node</code> command.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ node to join
+        the cluster that &quot;hare@elena&quot; is part of, as a ram node:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl join_cluster
       hare@elena --ram</code></div>
-    <div class="Pp"></div>
-    To learn more, see the
-      <a class="Lk" title="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
-      Clustering guide</a>.</dd>
-  <dt><a class="permalink" href="#rename_cluster_node"><code class="Cm" title="Cm" id="rename_cluster_node">rename_cluster_node</code></a>
-    <var class="Ar" title="Ar">oldnode1</var>
-    <var class="Ar" title="Ar">newnode1</var>
-    [<div class="Op"><var class="Ar" title="Ar">oldnode2</var>
-    <var class="Ar" title="Ar">newnode2 ...</var></div>]</dt>
+    <p class="Pp">To learn more, see the
+        <a class="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
+        Clustering guide</a>.</p>
+  </dd>
+  <dt id="rename_cluster_node"><a class="permalink" href="#rename_cluster_node"><code class="Cm">rename_cluster_node</code></a>
+    <var class="Ar">oldnode1</var> <var class="Ar">newnode1</var>
+    [<var class="Ar">oldnode2</var> <var class="Ar">newnode2 ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Supports renaming of cluster nodes in the local database.
-    <div class="Pp"></div>
-    This subcommand causes <code class="Nm" title="Nm">rabbitmqctl</code> to
-      temporarily become the node in order to make the change. The local cluster
-      node must therefore be completely stopped; other nodes can be online or
-      offline.
-    <div class="Pp"></div>
-    This subcommand takes an even number of arguments, in pairs representing the
-      old and new names for nodes. You must specify the old and new names for
-      this node and for any other nodes that are stopped and being renamed at
-      the same time.
-    <div class="Pp"></div>
-    It is possible to stop all nodes and rename them all simultaneously (in
-      which case old and new names for all nodes must be given to every node) or
-      stop and rename nodes one at a time (in which case each node only needs to
-      be told how its own name is changing).
-    <div class="Pp"></div>
-    For example, this command will rename the node
-      &quot;rabbit@misshelpful&quot; to the node
-      &quot;rabbit@cordelia&quot;
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl rename_cluster_node
+    <p class="Pp">Supports renaming of cluster nodes in the local database.</p>
+    <p class="Pp">This subcommand causes <code class="Nm">rabbitmqctl</code> to
+        temporarily become the node in order to make the change. The local
+        cluster node must therefore be completely stopped; other nodes can be
+        online or offline.</p>
+    <p class="Pp">This subcommand takes an even number of arguments, in pairs
+        representing the old and new names for nodes. You must specify the old
+        and new names for this node and for any other nodes that are stopped and
+        being renamed at the same time.</p>
+    <p class="Pp">It is possible to stop all nodes and rename them all
+        simultaneously (in which case old and new names for all nodes must be
+        given to every node) or stop and rename nodes one at a time (in which
+        case each node only needs to be told how its own name is changing).</p>
+    <p class="Pp">For example, this command will rename the node
+        &quot;rabbit@misshelpful&quot; to the node
+      &quot;rabbit@cordelia&quot;</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl rename_cluster_node
       rabbit@misshelpful rabbit@cordelia</code></div>
-    <div class="Pp"></div>
-    Note that this command only changes the local database. It may also be
-      necessary to rename the local database directories, and to configure the
-      new node name. For example:
-    <div class="Pp"></div>
+    <p class="Pp">Note that this command only changes the local database. It may
+        also be necessary to rename the local database directories, and to
+        configure the new node name. For example:</p>
+    <p class="Pp"></p>
     <ol class="Bl-enum Bl-compact">
       <li>Stop the node:
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl stop
+        <p class="Pp"></p>
+        <div class=00><code class="Li">rabbitmqctl stop
           rabbit@misshelpful</code></div>
-        <div class="Pp"></div>
+        <p class="Pp"></p>
       </li>
       <li>Rename the node in the local database:
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+        <p class="Pp"></p>
+        <div class=00><code class="Li">rabbitmqctl
           rename_cluster_node rabbit@misshelpful rabbit@cordelia</code></div>
-        <div class="Pp"></div>
+        <p class="Pp"></p>
       </li>
       <li>Rename the local database directories (note, you do not need to do
           this if you have set the RABBITMQ_MNESIA_DIR environment variable):
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash">
-        <pre class="Li">
-mv \ 
-  /var/lib/rabbitmq/mnesia/rabbit\@misshelpful \ 
-  /var/lib/rabbitmq/mnesia/rabbit\@cordelia 
-mv \ 
-  /var/lib/rabbitmq/mnesia/rabbit\@misshelpful-rename \ 
-  /var/lib/rabbitmq/mnesia/rabbit\@cordelia-rename 
-mv \ 
-  /var/lib/rabbitmq/mnesia/rabbit\@misshelpful-plugins-expand \ 
+        <p class="Pp"></p>
+        <div class=00>
+        <pre>
+mv \
+  /var/lib/rabbitmq/mnesia/rabbit\@misshelpful \
+  /var/lib/rabbitmq/mnesia/rabbit\@cordelia
+mv \
+  /var/lib/rabbitmq/mnesia/rabbit\@misshelpful-rename \
+  /var/lib/rabbitmq/mnesia/rabbit\@cordelia-rename
+mv \
+  /var/lib/rabbitmq/mnesia/rabbit\@misshelpful-plugins-expand \
   /var/lib/rabbitmq/mnesia/rabbit\@cordelia-plugins-expand
         </pre>
         </div>
-        <div class="Pp"></div>
+        <p class="Pp"></p>
       </li>
       <li>If node name is configured e.g. using
-          <var class="Ar" title="Ar">/etc/rabbitmq/rabbitmq-env.conf</var> it
-          has also be updated there.
-        <div class="Pp"></div>
+          <var class="Ar">/etc/rabbitmq/rabbitmq-env.conf</var> it has also be
+          updated there.
+        <p class="Pp"></p>
       </li>
       <li>Start the node when ready</li>
     </ol>
   </dd>
-  <dt><a class="permalink" href="#update_cluster_nodes"><code class="Cm" title="Cm" id="update_cluster_nodes">update_cluster_nodes</code></a>
-    <var class="Ar" title="Ar">clusternode</var></dt>
+  <dt id="update_cluster_nodes"><a class="permalink" href="#update_cluster_nodes"><code class="Cm">update_cluster_nodes</code></a>
+    <var class="Ar">clusternode</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">clusternode</var></dt>
+      <dt><var class="Ar">clusternode</var></dt>
       <dd>The node to consult for up-to-date information.</dd>
     </dl>
-    <div class="Pp"></div>
-    Instructs an already clustered node to contact
-      <var class="Ar" title="Ar">clusternode</var> to cluster when booting up.
-      This is different from <code class="Cm" title="Cm">join_cluster</code>
-      since it does not join any cluster - it checks that the node is already in
-      a cluster with <var class="Ar" title="Ar">clusternode</var>.
-    <div class="Pp"></div>
-    The need for this command is motivated by the fact that clusters can change
-      while a node is offline. Consider a situation where node
-      <var class="Va" title="Va">rabbit@A</var> and
-      <var class="Va" title="Va">rabbit@B</var> are clustered.
-      <var class="Va" title="Va">rabbit@A</var> goes down,
-      <var class="Va" title="Va">rabbit@C</var> clusters with
-      <var class="Va" title="Va">rabbit@B</var>, and then
-      <var class="Va" title="Va">rabbit@B</var> leaves the cluster. When
-      <var class="Va" title="Va">rabbit@A</var> starts back up, it'll try to
-      contact <var class="Va" title="Va">rabbit@B</var>, but this will fail
-      since <var class="Va" title="Va">rabbit@B</var> is not in the cluster
-      anymore. The following command will rename node
-      <var class="Va" title="Va">rabbit@B</var> to
-      <var class="Va" title="Va">rabbit@C</var> on node
-      <var class="Va" title="Va">rabbitA</var>
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">update_cluster_nodes -n
-      <var class="Va" title="Va">rabbit@A</var>
-      <var class="Va" title="Va">rabbit@B</var>
-      <var class="Va" title="Va">rabbit@C</var></code></div>
-    <div class="Pp"></div>
-    To learn more, see the
-      <a class="Lk" title="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
-      Clustering guide</a></dd>
+    <p class="Pp">Instructs an already clustered node to contact
+        <var class="Ar">clusternode</var> to cluster when booting up. This is
+        different from <code class="Cm">join_cluster</code> since it does not
+        join any cluster - it checks that the node is already in a cluster with
+        <var class="Ar">clusternode</var>.</p>
+    <p class="Pp">The need for this command is motivated by the fact that
+        clusters can change while a node is offline. Consider a situation where
+        node <var class="Va">rabbit@A</var> and <var class="Va">rabbit@B</var>
+        are clustered. <var class="Va">rabbit@A</var> goes down,
+        <var class="Va">rabbit@C</var> clusters with
+        <var class="Va">rabbit@B</var>, and then <var class="Va">rabbit@B</var>
+        leaves the cluster. When <var class="Va">rabbit@A</var> starts back up,
+        it'll try to contact <var class="Va">rabbit@B</var>, but this will fail
+        since <var class="Va">rabbit@B</var> is not in the cluster anymore. The
+        following command will rename node <var class="Va">rabbit@B</var> to
+        <var class="Va">rabbit@C</var> on node <var class="Va">rabbitA</var></p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">update_cluster_nodes -n
+      <var class="Va">rabbit@A</var> <var class="Va">rabbit@B</var>
+      <var class="Va">rabbit@C</var></code></div>
+    <p class="Pp">To learn more, see the
+        <a class="Lk" href="https://www.rabbitmq.com/clustering.html">RabbitMQ
+        Clustering guide</a></p>
+  </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Replication"><a class="permalink" href="#Replication">Replication</a></h3>
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Replication"><a class="permalink" href="#Replication">Replication</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#sync_queue"><code class="Cm" title="Cm" id="sync_queue">sync_queue</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">queue</var></dt>
+  <dt id="sync_queue"><a class="permalink" href="#sync_queue"><code class="Cm">sync_queue</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">queue</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">queue</var></dt>
+      <dt><var class="Ar">queue</var></dt>
       <dd>The name of the queue to synchronise.</dd>
     </dl>
-    <div class="Pp"></div>
-    Instructs a mirrored queue with unsynchronised mirrors (follower replicas)
-      to synchronise them. The queue will block while synchronisation takes
-      place (all publishers to and consumers using the queue will block or
-      temporarily see no activity). This command can only be used with mirrored
-      queues. To learn more, see the
-      <a class="Lk" title="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ
-      Mirroring guide</a>
-    <div class="Pp"></div>
-    Note that queues with unsynchronised replicas and active consumers will
-      become synchronised eventually (assuming that consumers make progress).
-      This command is primarily useful for queues which do not have active
-      consumers.</dd>
-  <dt><a class="permalink" href="#cancel_sync_queue"><code class="Cm" title="Cm" id="cancel_sync_queue">cancel_sync_queue</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">queue</var></dt>
+    <p class="Pp">Instructs a mirrored queue with unsynchronised mirrors
+        (follower replicas) to synchronise them. The queue will block while
+        synchronisation takes place (all publishers to and consumers using the
+        queue will block or temporarily see no activity). This command can only
+        be used with mirrored queues. To learn more, see the
+        <a class="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ Mirroring
+        guide</a></p>
+    <p class="Pp">Note that queues with unsynchronised replicas and active
+        consumers will become synchronised eventually (assuming that consumers
+        make progress). This command is primarily useful for queues which do not
+        have active consumers.</p>
+  </dd>
+  <dt id="cancel_sync_queue"><a class="permalink" href="#cancel_sync_queue"><code class="Cm">cancel_sync_queue</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">queue</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">queue</var></dt>
+      <dt><var class="Ar">queue</var></dt>
       <dd>The name of the queue to cancel synchronisation for.</dd>
     </dl>
-    <div class="Pp"></div>
-    Instructs a synchronising mirrored queue to stop synchronising itself.</dd>
+    <p class="Pp">Instructs a synchronising mirrored queue to stop synchronising
+        itself.</p>
+  </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="User_Management"><a class="permalink" href="#User_Management">User
+</section>
+<section class="Ss">
+<h3 class="Ss" id="User_Management"><a class="permalink" href="#User_Management">User
   Management</a></h3>
-Note that all user management commands
-  <code class="Nm" title="Nm">rabbitmqctl</code> only can manage users in the
-  internal RabbitMQ database. Users from any alternative authentication backends
-  such as LDAP cannot be inspected or managed with those commands.
-  <code class="Nm" title="Nm">rabbitmqctl</code>.
+<p class="Pp">Note that all user management commands
+    <code class="Nm">rabbitmqctl</code> only can manage users in the internal
+    RabbitMQ database. Users from any alternative authentication backends such
+    as LDAP cannot be inspected or managed with those commands.
+    <code class="Nm">rabbitmqctl</code>.</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#add_user"><code class="Cm" title="Cm" id="add_user">add_user</code></a>
-    <var class="Ar" title="Ar">username</var>
-    <var class="Ar" title="Ar">password</var></dt>
+  <dt id="add_user"><a class="permalink" href="#add_user"><code class="Cm">add_user</code></a>
+    <var class="Ar">username</var> <var class="Ar">password</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user to create.</dd>
-      <dt><var class="Ar" title="Ar">password</var></dt>
+      <dt><var class="Ar">password</var></dt>
       <dd>The password the created user will use to log in to the broker.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to create a
-      (non-administrative) user named &quot;janeway&quot; with (initial)
-      password &quot;changeit&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl add_user janeway
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        create a (non-administrative) user named &quot;janeway&quot; with
+        (initial) password &quot;changeit&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl add_user janeway
       changeit</code></div>
   </dd>
-  <dt><a class="permalink" href="#authenticate_user"><code class="Cm" title="Cm" id="authenticate_user">authenticate_user</code></a>
-    <var class="Ar" title="Ar">username</var>
-    <var class="Ar" title="Ar">password</var></dt>
+  <dt id="authenticate_user"><a class="permalink" href="#authenticate_user"><code class="Cm">authenticate_user</code></a>
+    <var class="Ar">username</var> <var class="Ar">password</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user.</dd>
-      <dt><var class="Ar" title="Ar">password</var></dt>
+      <dt><var class="Ar">password</var></dt>
       <dd>The password of the user.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to authenticate the
-      user named &quot;janeway&quot; with password &quot;verifyit&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl authenticate_user
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        authenticate the user named &quot;janeway&quot; with password
+        &quot;verifyit&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl authenticate_user
       janeway verifyit</code></div>
   </dd>
-  <dt><a class="permalink" href="#change_password"><code class="Cm" title="Cm" id="change_password">change_password</code></a>
-    <var class="Ar" title="Ar">username</var>
-    <var class="Ar" title="Ar">newpassword</var></dt>
+  <dt id="change_password"><a class="permalink" href="#change_password"><code class="Cm">change_password</code></a>
+    <var class="Ar">username</var> <var class="Ar">newpassword</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user whose password is to be changed.</dd>
-      <dt><var class="Ar" title="Ar">newpassword</var></dt>
+      <dt><var class="Ar">newpassword</var></dt>
       <dd>The new password for the user.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to change the
-      password for the user named &quot;janeway&quot; to
-      &quot;newpass&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl change_password
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        change the password for the user named &quot;janeway&quot; to
+        &quot;newpass&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl change_password
       janeway newpass</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_password"><code class="Cm" title="Cm" id="clear_password">clear_password</code></a>
-    <var class="Ar" title="Ar">username</var></dt>
+  <dt id="clear_password"><a class="permalink" href="#clear_password"><code class="Cm">clear_password</code></a>
+    <var class="Ar">username</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user whose password is to be cleared.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to clear the
-      password for the user named &quot;janeway&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_password
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        clear the password for the user named &quot;janeway&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_password
       janeway</code></div>
-    <div class="Pp"></div>
-    This user now cannot log in with a password (but may be able to through e.g.
-      SASL EXTERNAL if configured).</dd>
-  <dt><a class="permalink" href="#delete_user"><code class="Cm" title="Cm" id="delete_user">delete_user</code></a>
-    <var class="Ar" title="Ar">username</var></dt>
+    <p class="Pp">This user now cannot log in with a password (but may be able
+        to through e.g. SASL EXTERNAL if configured).</p>
+  </dd>
+  <dt id="delete_user"><a class="permalink" href="#delete_user"><code class="Cm">delete_user</code></a>
+    <var class="Ar">username</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user to delete.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to delete the user
-      named &quot;janeway&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl delete_user
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        delete the user named &quot;janeway&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl delete_user
       janeway</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_users"><code class="Cm" title="Cm" id="list_users">list_users</code></a></dt>
+  <dt id="list_users"><a class="permalink" href="#list_users"><code class="Cm">list_users</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Lists users. Each result row will contain the user name followed by a list
-      of the tags set for that user.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all users:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists users. Each result row will contain the user name
+        followed by a list of the tags set for that user.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all users:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_users</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_user_tags"><code class="Cm" title="Cm" id="set_user_tags">set_user_tags</code></a>
-    <var class="Ar" title="Ar">username</var>
-    [<div class="Op"><var class="Ar" title="Ar">tag ...</var></div>]</dt>
+  <dt id="set_user_tags"><a class="permalink" href="#set_user_tags"><code class="Cm">set_user_tags</code></a>
+    <var class="Ar">username</var> [<var class="Ar">tag ...</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user whose tags are to be set.</dd>
-      <dt><var class="Ar" title="Ar">tag</var></dt>
+      <dt><var class="Ar">tag</var></dt>
       <dd>Zero, one or more tags to set. Any existing tags will be removed.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to ensure the user
-      named &quot;janeway&quot; is an administrator:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_user_tags janeway
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        ensure the user named &quot;janeway&quot; is an administrator:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_user_tags janeway
       administrator</code></div>
-    <div class="Pp"></div>
-    This has no effect when the user authenticates using a messaging protocol,
-      but can be used to permit the user to manage users, virtual hosts and
-      permissions when the user logs in via some other means (for example with
-      the management plugin).
-    <div class="Pp"></div>
-    This command instructs the RabbitMQ broker to remove any tags from the user
-      named &quot;janeway&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_user_tags
+    <p class="Pp">This has no effect when the user authenticates using a
+        messaging protocol, but can be used to permit the user to manage users,
+        virtual hosts and permissions when the user logs in via some other means
+        (for example with the management plugin).</p>
+    <p class="Pp">This command instructs the RabbitMQ broker to remove any tags
+        from the user named &quot;janeway&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_user_tags
       janeway</code></div>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Access_control"><a class="permalink" href="#Access_control">Access
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Access_control"><a class="permalink" href="#Access_control">Access
   control</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#clear_permissions"><code class="Cm" title="Cm" id="clear_permissions">clear_permissions</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">username</var></dt>
+  <dt id="clear_permissions"><a class="permalink" href="#clear_permissions"><code class="Cm">clear_permissions</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">username</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host to which to deny the user access,
           defaulting to &quot;/&quot;.</dd>
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user to deny access to the specified virtual
         host.</dd>
     </dl>
-    <div class="Pp"></div>
-    Sets user permissions.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to deny the user
-      named &quot;janeway&quot; access to the virtual host called
-      &quot;my-vhost&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_permissions -p
+    <p class="Pp">Sets user permissions.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        deny the user named &quot;janeway&quot; access to the virtual host
+        called &quot;my-vhost&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_permissions -p
       my-vhost janeway</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_topic_permissions"><code class="Cm" title="Cm" id="clear_topic_permissions">clear_topic_permissions</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">username</var>
-    [<div class="Op"><var class="Ar" title="Ar">exchange</var></div>]</dt>
+  <dt id="clear_topic_permissions"><a class="permalink" href="#clear_topic_permissions"><code class="Cm">clear_topic_permissions</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">username</var> [<var class="Ar">exchange</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host to which to clear the topic permissions,
           defaulting to &quot;/&quot;.</dd>
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user to clear topic permissions to the specified
           virtual host.</dd>
-      <dt><var class="Ar" title="Ar">exchange</var></dt>
+      <dt><var class="Ar">exchange</var></dt>
       <dd>The name of the topic exchange to clear topic permissions, defaulting
           to all the topic exchanges the given user has topic permissions
         for.</dd>
     </dl>
-    <div class="Pp"></div>
-    Clear user topic permissions.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to remove topic
-      permissions for user named &quot;janeway&quot; for the topic exchange
-      &quot;amq.topic&quot; in the virtual host called
-      &quot;my-vhost&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Clear user topic permissions.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        remove topic permissions for user named &quot;janeway&quot; for the
+        topic exchange &quot;amq.topic&quot; in the virtual host called
+        &quot;my-vhost&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       clear_topic_permissions -p my-vhost janeway amq.topic</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_permissions"><code class="Cm" title="Cm" id="list_permissions">list_permissions</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="list_permissions"><a class="permalink" href="#list_permissions"><code class="Cm">list_permissions</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host for which to list the users that have
           been granted access to it, and their permissions. Defaults to
           &quot;/&quot;.</dd>
     </dl>
-    <div class="Pp"></div>
-    Lists permissions in a virtual host.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all the
-      users which have been granted access to the virtual host called
-      &quot;my-vhost&quot;, and the permissions they have for operations on
-      resources in that virtual host. Note that an empty string means no
-      permissions granted:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_permissions -p
+    <p class="Pp">Lists permissions in a virtual host.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all the users which have been granted access to the virtual host
+        called &quot;my-vhost&quot;, and the permissions they have for
+        operations on resources in that virtual host. Note that an empty string
+        means no permissions granted:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_permissions -p
       my-vhost</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_topic_permissions"><code class="Cm" title="Cm" id="list_topic_permissions">list_topic_permissions</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="list_topic_permissions"><a class="permalink" href="#list_topic_permissions"><code class="Cm">list_topic_permissions</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host for which to list the users topic
           permissions. Defaults to &quot;/&quot;.</dd>
     </dl>
-    <div class="Pp"></div>
-    Lists topic permissions in a virtual host.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all the
-      users which have been granted topic permissions in the virtual host called
-      &quot;my-vhost:&quot;
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists topic permissions in a virtual host.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all the users which have been granted topic permissions in the
+        virtual host called &quot;my-vhost:&quot;</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_topic_permissions -p my-vhost</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_user_permissions"><code class="Cm" title="Cm" id="list_user_permissions">list_user_permissions</code></a>
-    <var class="Ar" title="Ar">username</var></dt>
+  <dt id="list_user_permissions"><a class="permalink" href="#list_user_permissions"><code class="Cm">list_user_permissions</code></a>
+    <var class="Ar">username</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user for which to list the permissions.</dd>
     </dl>
-    <div class="Pp"></div>
-    Lists user permissions.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all the
-      virtual hosts to which the user named &quot;janeway&quot; has been
-      granted access, and the permissions the user has for operations on
-      resources in these virtual hosts:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_user_permissions
+    <p class="Pp">Lists user permissions.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all the virtual hosts to which the user named &quot;janeway&quot;
+        has been granted access, and the permissions the user has for operations
+        on resources in these virtual hosts:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_user_permissions
       janeway</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_user_topic_permissions"><code class="Cm" title="Cm" id="list_user_topic_permissions">list_user_topic_permissions</code></a>
-    <var class="Ar" title="Ar">username</var></dt>
+  <dt id="list_user_topic_permissions"><a class="permalink" href="#list_user_topic_permissions"><code class="Cm">list_user_topic_permissions</code></a>
+    <var class="Ar">username</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user for which to list the topic permissions.</dd>
     </dl>
-    <div class="Pp"></div>
-    Lists user topic permissions.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all the
-      virtual hosts to which the user named &quot;janeway&quot; has been
-      granted access, and the topic permissions the user has in these virtual
-      hosts:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists user topic permissions.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all the virtual hosts to which the user named &quot;janeway&quot;
+        has been granted access, and the topic permissions the user has in these
+        virtual hosts:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_user_topic_permissions janeway</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_vhosts"><code class="Cm" title="Cm" id="list_vhosts">list_vhosts</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">vhostinfoitem
-    ...</var></div>]</dt>
+  <dt id="list_vhosts"><a class="permalink" href="#list_vhosts"><code class="Cm">list_vhosts</code></a>
+    [<var class="Ar">vhostinfoitem ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists virtual hosts.
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">vhostinfoitem</var> parameter is used to
-      indicate which virtual host information items to include in the results.
-      The column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">vhostinfoitem</var> can take any value from the
-      list that follows:
+    <p class="Pp">Lists virtual hosts.</p>
+    <p class="Pp">The <var class="Ar">vhostinfoitem</var> parameter is used to
+        indicate which virtual host information items to include in the results.
+        The column order in the results will match the order of the parameters.
+        <var class="Ar">vhostinfoitem</var> can take any value from the list
+        that follows:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#name"><code class="Cm" title="Cm" id="name">name</code></a></dt>
+      <dt id="name"><a class="permalink" href="#name"><code class="Cm">name</code></a></dt>
       <dd>The name of the virtual host with non-ASCII characters escaped as in
           C.</dd>
-      <dt><a class="permalink" href="#tracing"><code class="Cm" title="Cm" id="tracing">tracing</code></a></dt>
+      <dt id="tracing"><a class="permalink" href="#tracing"><code class="Cm">tracing</code></a></dt>
       <dd>Whether tracing is enabled for this virtual host.</dd>
-      <dt><a class="permalink" href="#default_queue_type"><code class="Cm" title="Cm" id="default_queue_type">default_queue_type</code></a></dt>
+      <dt id="default_queue_type"><a class="permalink" href="#default_queue_type"><code class="Cm">default_queue_type</code></a></dt>
       <dd>Default queue type for this vhost.</dd>
-      <dt><a class="permalink" href="#description"><code class="Cm" title="Cm" id="description">description</code></a></dt>
+      <dt id="description"><a class="permalink" href="#description"><code class="Cm">description</code></a></dt>
       <dd>Virtual host description.</dd>
-      <dt><a class="permalink" href="#tags"><code class="Cm" title="Cm" id="tags">tags</code></a></dt>
+      <dt id="tags"><a class="permalink" href="#tags"><code class="Cm">tags</code></a></dt>
       <dd>Virtual host tags.</dd>
-      <dt><a class="permalink" href="#cluster_state"><code class="Cm" title="Cm" id="cluster_state">cluster_state</code></a></dt>
+      <dt id="cluster_state"><a class="permalink" href="#cluster_state"><code class="Cm">cluster_state</code></a></dt>
       <dd>Virtual host state: nodedown, running, stopped.</dd>
     </dl>
-    <div class="Pp"></div>
-    If no <var class="Ar" title="Ar">vhostinfoitem</var> are specified then the
-      vhost name is displayed.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all virtual
-      hosts:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_vhosts name
+    <p class="Pp">If no <var class="Ar">vhostinfoitem</var> are specified then
+        the vhost name is displayed.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all virtual hosts:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_vhosts name
       tracing</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_permissions"><code class="Cm" title="Cm" id="set_permissions">set_permissions</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">user</var> <var class="Ar" title="Ar">conf</var>
-    <var class="Ar" title="Ar">write</var>
-    <var class="Ar" title="Ar">read</var></dt>
+  <dt id="set_permissions"><a class="permalink" href="#set_permissions"><code class="Cm">set_permissions</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">user</var> <var class="Ar">conf</var>
+    <var class="Ar">write</var> <var class="Ar">read</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host to which to grant the user access,
           defaulting to &quot;/&quot;.</dd>
-      <dt><var class="Ar" title="Ar">user</var></dt>
+      <dt><var class="Ar">user</var></dt>
       <dd>The name of the user to grant access to the specified virtual
         host.</dd>
-      <dt><var class="Ar" title="Ar">conf</var></dt>
+      <dt><var class="Ar">conf</var></dt>
       <dd>A regular expression matching resource names for which the user is
           granted configure permissions.</dd>
-      <dt><var class="Ar" title="Ar">write</var></dt>
+      <dt><var class="Ar">write</var></dt>
       <dd>A regular expression matching resource names for which the user is
           granted write permissions.</dd>
-      <dt><var class="Ar" title="Ar">read</var></dt>
+      <dt><var class="Ar">read</var></dt>
       <dd>A regular expression matching resource names for which the user is
           granted read permissions.</dd>
     </dl>
-    <div class="Pp"></div>
-    Sets user permissions.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to grant the user
-      named &quot;janeway&quot; access to the virtual host called
-      &quot;my-vhost&quot;, with configure permissions on all resources
-      whose names starts with &quot;janeway-&quot;, and write and read
-      permissions on all resources:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_permissions -p
+    <p class="Pp">Sets user permissions.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        grant the user named &quot;janeway&quot; access to the virtual host
+        called &quot;my-vhost&quot;, with configure permissions on all resources
+        whose names starts with &quot;janeway-&quot;, and write and read
+        permissions on all resources:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_permissions -p
       my-vhost janeway &quot;^janeway-.*&quot; &quot;.*&quot;
       &quot;.*&quot;</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_topic_permissions"><code class="Cm" title="Cm" id="set_topic_permissions">set_topic_permissions</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">user</var>
-    <var class="Ar" title="Ar">exchange</var>
-    <var class="Ar" title="Ar">write</var>
-    <var class="Ar" title="Ar">read</var></dt>
+  <dt id="set_topic_permissions"><a class="permalink" href="#set_topic_permissions"><code class="Cm">set_topic_permissions</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">user</var> <var class="Ar">exchange</var>
+    <var class="Ar">write</var> <var class="Ar">read</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host to which to grant the user access,
           defaulting to &quot;/&quot;.</dd>
-      <dt><var class="Ar" title="Ar">user</var></dt>
+      <dt><var class="Ar">user</var></dt>
       <dd>The name of the user the permissions apply to in the target virtual
           host.</dd>
-      <dt><var class="Ar" title="Ar">exchange</var></dt>
+      <dt><var class="Ar">exchange</var></dt>
       <dd>The name of the topic exchange the authorisation check will be applied
           to.</dd>
-      <dt><var class="Ar" title="Ar">write</var></dt>
+      <dt><var class="Ar">write</var></dt>
       <dd>A regular expression matching the routing key of the published
           message.</dd>
-      <dt><var class="Ar" title="Ar">read</var></dt>
+      <dt><var class="Ar">read</var></dt>
       <dd>A regular expression matching the routing key of the consumed
         message.</dd>
     </dl>
-    <div class="Pp"></div>
-    Sets user topic permissions.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to let the user
-      named &quot;janeway&quot; publish and consume messages going through
-      the &quot;amp.topic&quot; exchange of the &quot;my-vhost&quot;
-      virtual host with a routing key starting with &quot;janeway-&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_topic_permissions
+    <p class="Pp">Sets user topic permissions.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to let
+        the user named &quot;janeway&quot; publish and consume messages going
+        through the &quot;amp.topic&quot; exchange of the &quot;my-vhost&quot;
+        virtual host with a routing key starting with &quot;janeway-&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_topic_permissions
       -p my-vhost janeway amq.topic &quot;^janeway-.*&quot;
       &quot;^janeway-.*&quot;</code></div>
-    <div class="Pp"></div>
-    Topic permissions support variable expansion for the following variables:
-      username, vhost, and client_id. Note that client_id is expanded only when
-      using MQTT. The previous example could be made more generic by using
-      &quot;^{username}-.*&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_topic_permissions
+    <p class="Pp">Topic permissions support variable expansion for the following
+        variables: username, vhost, and client_id. Note that client_id is
+        expanded only when using MQTT. The previous example could be made more
+        generic by using &quot;^{username}-.*&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_topic_permissions
       -p my-vhost janeway amq.topic &quot;^{username}-.*&quot;
       &quot;^{username}-.*&quot;</code></div>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Monitoring,_observability_and_health_checks"><a class="permalink" href="#Monitoring,_observability_and_health_checks">Monitoring,
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Monitoring,_observability_and_health_checks"><a class="permalink" href="#Monitoring,_observability_and_health_checks">Monitoring,
   observability and health checks</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#environment"><code class="Cm" title="Cm" id="environment">environment</code></a></dt>
+  <dt id="environment"><a class="permalink" href="#environment"><code class="Cm">environment</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Displays the name and value of each variable in the application environment
-      for each running application.</dd>
-  <dt><a class="permalink" href="#list_bindings"><code class="Cm" title="Cm" id="list_bindings">list_bindings</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><var class="Ar" title="Ar">bindinginfoitem
-    ...</var></div>]</dt>
+    <p class="Pp">Displays the name and value of each variable in the
+        application environment for each running application.</p>
+  </dd>
+  <dt id="list_bindings"><a class="permalink" href="#list_bindings"><code class="Cm">list_bindings</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<var class="Ar">bindinginfoitem ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Returns binding details. By default the bindings for the &quot;/&quot;
-      virtual host are returned. The <code class="Fl" title="Fl">-p</code> flag
-      can be used to override this default.
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">bindinginfoitem</var> parameter is used to
-      indicate which binding information items to include in the results. The
-      column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">bindinginfoitem</var> can take any value from
-      the list that follows:
+    <p class="Pp">Returns binding details. By default the bindings for the
+        &quot;/&quot; virtual host are returned. The <code class="Fl">-p</code>
+        flag can be used to override this default.</p>
+    <p class="Pp">The <var class="Ar">bindinginfoitem</var> parameter is used to
+        indicate which binding information items to include in the results. The
+        column order in the results will match the order of the parameters.
+        <var class="Ar">bindinginfoitem</var> can take any value from the list
+        that follows:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#source_name"><code class="Cm" title="Cm" id="source_name">source_name</code></a></dt>
+      <dt id="source_name"><a class="permalink" href="#source_name"><code class="Cm">source_name</code></a></dt>
       <dd>The name of the source of messages to which the binding is attached.
           With non-ASCII characters escaped as in C.</dd>
-      <dt><a class="permalink" href="#source_kind"><code class="Cm" title="Cm" id="source_kind">source_kind</code></a></dt>
+      <dt id="source_kind"><a class="permalink" href="#source_kind"><code class="Cm">source_kind</code></a></dt>
       <dd>The kind of the source of messages to which the binding is attached.
           Currently always exchange. With non-ASCII characters escaped as in
         C.</dd>
-      <dt><a class="permalink" href="#destination_name"><code class="Cm" title="Cm" id="destination_name">destination_name</code></a></dt>
+      <dt id="destination_name"><a class="permalink" href="#destination_name"><code class="Cm">destination_name</code></a></dt>
       <dd>The name of the destination of messages to which the binding is
           attached. With non-ASCII characters escaped as in C.</dd>
-      <dt><a class="permalink" href="#destination_kind"><code class="Cm" title="Cm" id="destination_kind">destination_kind</code></a></dt>
+      <dt id="destination_kind"><a class="permalink" href="#destination_kind"><code class="Cm">destination_kind</code></a></dt>
       <dd>The kind of the destination of messages to which the binding is
           attached. With non-ASCII characters escaped as in C.</dd>
-      <dt><a class="permalink" href="#routing_key"><code class="Cm" title="Cm" id="routing_key">routing_key</code></a></dt>
+      <dt id="routing_key"><a class="permalink" href="#routing_key"><code class="Cm">routing_key</code></a></dt>
       <dd>The binding's routing key, with non-ASCII characters escaped as in
         C.</dd>
-      <dt><a class="permalink" href="#arguments"><code class="Cm" title="Cm" id="arguments">arguments</code></a></dt>
+      <dt id="arguments"><a class="permalink" href="#arguments"><code class="Cm">arguments</code></a></dt>
       <dd>The binding's arguments.</dd>
     </dl>
-    <div class="Pp"></div>
-    If no <var class="Ar" title="Ar">bindinginfoitem</var> are specified then
-      all above items are displayed.
-    <div class="Pp"></div>
-    For example, this command displays the exchange name and queue name of the
-      bindings in the virtual host named &quot;my-vhost&quot;
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_bindings -p
+    <p class="Pp">If no <var class="Ar">bindinginfoitem</var> are specified then
+        all above items are displayed.</p>
+    <p class="Pp">For example, this command displays the exchange name and queue
+        name of the bindings in the virtual host named &quot;my-vhost&quot;</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_bindings -p
       my-vhost exchange_name queue_name</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_channels"><code class="Cm" title="Cm" id="list_channels">list_channels</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">channelinfoitem
-    ...</var></div>]</dt>
+  <dt id="list_channels"><a class="permalink" href="#list_channels"><code class="Cm">list_channels</code></a>
+    [<var class="Ar">channelinfoitem ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Returns information on all current channels, the logical containers
-      executing most AMQP commands. This includes channels that are part of
-      ordinary AMQP connections, and channels created by various plug-ins and
-      other extensions.
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">channelinfoitem</var> parameter is used to
-      indicate which channel information items to include in the results. The
-      column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">channelinfoitem</var> can take any value from
-      the list that follows:
+    <p class="Pp">Returns information on all current channels, the logical
+        containers executing most AMQP commands. This includes channels that are
+        part of ordinary AMQP connections, and channels created by various
+        plug-ins and other extensions.</p>
+    <p class="Pp">The <var class="Ar">channelinfoitem</var> parameter is used to
+        indicate which channel information items to include in the results. The
+        column order in the results will match the order of the parameters.
+        <var class="Ar">channelinfoitem</var> can take any value from the list
+        that follows:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#pid"><code class="Cm" title="Cm" id="pid">pid</code></a></dt>
+      <dt id="pid"><a class="permalink" href="#pid"><code class="Cm">pid</code></a></dt>
       <dd>Id of the Erlang process associated with the connection.</dd>
-      <dt><a class="permalink" href="#connection"><code class="Cm" title="Cm" id="connection">connection</code></a></dt>
+      <dt id="connection"><a class="permalink" href="#connection"><code class="Cm">connection</code></a></dt>
       <dd>Id of the Erlang process associated with the connection to which the
           channel belongs.</dd>
-      <dt><a class="permalink" href="#name_2"><code class="Cm" title="Cm" id="name_2">name</code></a></dt>
+      <dt id="name~2"><a class="permalink" href="#name~2"><code class="Cm">name</code></a></dt>
       <dd>Readable name for the channel.</dd>
-      <dt><a class="permalink" href="#number"><code class="Cm" title="Cm" id="number">number</code></a></dt>
+      <dt id="number"><a class="permalink" href="#number"><code class="Cm">number</code></a></dt>
       <dd>The number of the channel, which uniquely identifies it within a
           connection.</dd>
-      <dt><a class="permalink" href="#user"><code class="Cm" title="Cm" id="user">user</code></a></dt>
+      <dt id="user"><a class="permalink" href="#user"><code class="Cm">user</code></a></dt>
       <dd>Username associated with the channel.</dd>
-      <dt><a class="permalink" href="#vhost"><code class="Cm" title="Cm" id="vhost">vhost</code></a></dt>
+      <dt id="vhost"><a class="permalink" href="#vhost"><code class="Cm">vhost</code></a></dt>
       <dd>Virtual host in which the channel operates.</dd>
-      <dt><a class="permalink" href="#transactional"><code class="Cm" title="Cm" id="transactional">transactional</code></a></dt>
+      <dt id="transactional"><a class="permalink" href="#transactional"><code class="Cm">transactional</code></a></dt>
       <dd>True if the channel is in transactional mode, false otherwise.</dd>
-      <dt><a class="permalink" href="#confirm"><code class="Cm" title="Cm" id="confirm">confirm</code></a></dt>
+      <dt id="confirm"><a class="permalink" href="#confirm"><code class="Cm">confirm</code></a></dt>
       <dd>True if the channel is in confirm mode, false otherwise.</dd>
-      <dt><a class="permalink" href="#consumer_count"><code class="Cm" title="Cm" id="consumer_count">consumer_count</code></a></dt>
+      <dt id="consumer_count"><a class="permalink" href="#consumer_count"><code class="Cm">consumer_count</code></a></dt>
       <dd>Number of logical AMQP consumers retrieving messages via the
         channel.</dd>
-      <dt><a class="permalink" href="#messages_unacknowledged"><code class="Cm" title="Cm" id="messages_unacknowledged">messages_unacknowledged</code></a></dt>
+      <dt id="messages_unacknowledged"><a class="permalink" href="#messages_unacknowledged"><code class="Cm">messages_unacknowledged</code></a></dt>
       <dd>Number of messages delivered via this channel but not yet
           acknowledged.</dd>
-      <dt><a class="permalink" href="#messages_uncommitted"><code class="Cm" title="Cm" id="messages_uncommitted">messages_uncommitted</code></a></dt>
+      <dt id="messages_uncommitted"><a class="permalink" href="#messages_uncommitted"><code class="Cm">messages_uncommitted</code></a></dt>
       <dd>Number of messages received in an as yet uncommitted transaction.</dd>
-      <dt><a class="permalink" href="#acks_uncommitted"><code class="Cm" title="Cm" id="acks_uncommitted">acks_uncommitted</code></a></dt>
+      <dt id="acks_uncommitted"><a class="permalink" href="#acks_uncommitted"><code class="Cm">acks_uncommitted</code></a></dt>
       <dd>Number of acknowledgements received in an as yet uncommitted
           transaction.</dd>
-      <dt><a class="permalink" href="#messages_unconfirmed"><code class="Cm" title="Cm" id="messages_unconfirmed">messages_unconfirmed</code></a></dt>
+      <dt id="messages_unconfirmed"><a class="permalink" href="#messages_unconfirmed"><code class="Cm">messages_unconfirmed</code></a></dt>
       <dd>Number of published messages not yet confirmed. On channels not in
           confirm mode, this remains 0.</dd>
-      <dt><a class="permalink" href="#prefetch_count"><code class="Cm" title="Cm" id="prefetch_count">prefetch_count</code></a></dt>
+      <dt id="prefetch_count"><a class="permalink" href="#prefetch_count"><code class="Cm">prefetch_count</code></a></dt>
       <dd>QoS prefetch limit for new consumers, 0 if unlimited.</dd>
-      <dt><a class="permalink" href="#global_prefetch_count"><code class="Cm" title="Cm" id="global_prefetch_count">global_prefetch_count</code></a></dt>
+      <dt id="global_prefetch_count"><a class="permalink" href="#global_prefetch_count"><code class="Cm">global_prefetch_count</code></a></dt>
       <dd>QoS prefetch limit for the entire channel, 0 if unlimited.</dd>
     </dl>
-    <div class="Pp"></div>
-    If no <var class="Ar" title="Ar">channelinfoitem</var> are specified then
-      pid, user, consumer_count, and messages_unacknowledged are assumed.
-    <div class="Pp"></div>
-    For example, this command displays the connection process and count of
-      unacknowledged messages for each channel:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_channels
+    <p class="Pp">If no <var class="Ar">channelinfoitem</var> are specified then
+        pid, user, consumer_count, and messages_unacknowledged are assumed.</p>
+    <p class="Pp">For example, this command displays the connection process and
+        count of unacknowledged messages for each channel:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_channels
       connection messages_unacknowledged</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_ciphers"><code class="Cm" title="Cm" id="list_ciphers">list_ciphers</code></a></dt>
+  <dt id="list_ciphers"><a class="permalink" href="#list_ciphers"><code class="Cm">list_ciphers</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Lists cipher suites supported by encoding commands.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all cipher
-      suites supported by encoding commands:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists cipher suites supported by encoding commands.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all cipher suites supported by encoding commands:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_ciphers</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_connections"><code class="Cm" title="Cm" id="list_connections">list_connections</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">connectioninfoitem
-    ...</var></div>]</dt>
+  <dt id="list_connections"><a class="permalink" href="#list_connections"><code class="Cm">list_connections</code></a>
+    [<var class="Ar">connectioninfoitem ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Returns TCP/IP connection statistics.
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">connectioninfoitem</var> parameter is used to
-      indicate which connection information items to include in the results. The
-      column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">connectioninfoitem</var> can take any value
-      from the list that follows:
+    <p class="Pp">Returns TCP/IP connection statistics.</p>
+    <p class="Pp">The <var class="Ar">connectioninfoitem</var> parameter is used
+        to indicate which connection information items to include in the
+        results. The column order in the results will match the order of the
+        parameters. <var class="Ar">connectioninfoitem</var> can take any value
+        from the list that follows:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#pid_2"><code class="Cm" title="Cm" id="pid_2">pid</code></a></dt>
+      <dt id="pid~2"><a class="permalink" href="#pid~2"><code class="Cm">pid</code></a></dt>
       <dd>Id of the Erlang process associated with the connection.</dd>
-      <dt><a class="permalink" href="#name_3"><code class="Cm" title="Cm" id="name_3">name</code></a></dt>
+      <dt id="name~3"><a class="permalink" href="#name~3"><code class="Cm">name</code></a></dt>
       <dd>Readable name for the connection.</dd>
-      <dt><a class="permalink" href="#port"><code class="Cm" title="Cm" id="port">port</code></a></dt>
+      <dt id="port"><a class="permalink" href="#port"><code class="Cm">port</code></a></dt>
       <dd>Server port.</dd>
-      <dt><a class="permalink" href="#host"><code class="Cm" title="Cm" id="host">host</code></a></dt>
+      <dt id="host"><a class="permalink" href="#host"><code class="Cm">host</code></a></dt>
       <dd>Server hostname obtained via reverse DNS, or its IP address if reverse
-          DNS failed or was disabled.</dd>
-      <dt><a class="permalink" href="#peer_port"><code class="Cm" title="Cm" id="peer_port">peer_port</code></a></dt>
+          DNS failed or was turned off.</dd>
+      <dt id="peer_port"><a class="permalink" href="#peer_port"><code class="Cm">peer_port</code></a></dt>
       <dd>Peer port.</dd>
-      <dt><a class="permalink" href="#peer_host"><code class="Cm" title="Cm" id="peer_host">peer_host</code></a></dt>
+      <dt id="peer_host"><a class="permalink" href="#peer_host"><code class="Cm">peer_host</code></a></dt>
       <dd>Peer hostname obtained via reverse DNS, or its IP address if reverse
           DNS failed or was not enabled.</dd>
-      <dt><a class="permalink" href="#ssl"><code class="Cm" title="Cm" id="ssl">ssl</code></a></dt>
+      <dt id="ssl"><a class="permalink" href="#ssl"><code class="Cm">ssl</code></a></dt>
       <dd>Boolean indicating whether the connection is secured with SSL.</dd>
-      <dt><a class="permalink" href="#ssl_protocol"><code class="Cm" title="Cm" id="ssl_protocol">ssl_protocol</code></a></dt>
+      <dt id="ssl_protocol"><a class="permalink" href="#ssl_protocol"><code class="Cm">ssl_protocol</code></a></dt>
       <dd>SSL protocol (e.g. &quot;tlsv1&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_key_exchange"><code class="Cm" title="Cm" id="ssl_key_exchange">ssl_key_exchange</code></a></dt>
+      <dt id="ssl_key_exchange"><a class="permalink" href="#ssl_key_exchange"><code class="Cm">ssl_key_exchange</code></a></dt>
       <dd>SSL key exchange algorithm (e.g. &quot;rsa&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_cipher"><code class="Cm" title="Cm" id="ssl_cipher">ssl_cipher</code></a></dt>
+      <dt id="ssl_cipher"><a class="permalink" href="#ssl_cipher"><code class="Cm">ssl_cipher</code></a></dt>
       <dd>SSL cipher algorithm (e.g. &quot;aes_256_cbc&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_hash"><code class="Cm" title="Cm" id="ssl_hash">ssl_hash</code></a></dt>
+      <dt id="ssl_hash"><a class="permalink" href="#ssl_hash"><code class="Cm">ssl_hash</code></a></dt>
       <dd>SSL hash function (e.g. &quot;sha&quot;).</dd>
-      <dt><a class="permalink" href="#peer_cert_subject"><code class="Cm" title="Cm" id="peer_cert_subject">peer_cert_subject</code></a></dt>
+      <dt id="peer_cert_subject"><a class="permalink" href="#peer_cert_subject"><code class="Cm">peer_cert_subject</code></a></dt>
       <dd>The subject of the peer's SSL certificate, in RFC4514 form.</dd>
-      <dt><a class="permalink" href="#peer_cert_issuer"><code class="Cm" title="Cm" id="peer_cert_issuer">peer_cert_issuer</code></a></dt>
+      <dt id="peer_cert_issuer"><a class="permalink" href="#peer_cert_issuer"><code class="Cm">peer_cert_issuer</code></a></dt>
       <dd>The issuer of the peer's SSL certificate, in RFC4514 form.</dd>
-      <dt><a class="permalink" href="#peer_cert_validity"><code class="Cm" title="Cm" id="peer_cert_validity">peer_cert_validity</code></a></dt>
+      <dt id="peer_cert_validity"><a class="permalink" href="#peer_cert_validity"><code class="Cm">peer_cert_validity</code></a></dt>
       <dd>The period for which the peer's SSL certificate is valid.</dd>
-      <dt><a class="permalink" href="#state"><code class="Cm" title="Cm" id="state">state</code></a></dt>
+      <dt id="state"><a class="permalink" href="#state"><code class="Cm">state</code></a></dt>
       <dd>Connection state; one of:
         <ul class="Bl-bullet Bl-compact">
           <li>starting</li>
@@ -1147,92 +1033,85 @@ Note that all user management commands
           <li>closed</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#channels"><code class="Cm" title="Cm" id="channels">channels</code></a></dt>
+      <dt id="channels"><a class="permalink" href="#channels"><code class="Cm">channels</code></a></dt>
       <dd>Number of channels using the connection.</dd>
-      <dt><a class="permalink" href="#protocol"><code class="Cm" title="Cm" id="protocol">protocol</code></a></dt>
+      <dt id="protocol"><a class="permalink" href="#protocol"><code class="Cm">protocol</code></a></dt>
       <dd>Version of the AMQP protocol in use; currently one of:
         <ul class="Bl-bullet Bl-compact">
           <li>{0,9,1}</li>
           <li>{0,8,0}</li>
         </ul>
-        <div class="Pp"></div>
-        Note that if a client requests an AMQP 0-9 connection, we treat it as
-          AMQP 0-9-1.</dd>
-      <dt><a class="permalink" href="#auth_mechanism"><code class="Cm" title="Cm" id="auth_mechanism">auth_mechanism</code></a></dt>
-      <dd>SASL authentication mechanism used, such as
-        &quot;PLAIN&quot;.</dd>
-      <dt><a class="permalink" href="#user_2"><code class="Cm" title="Cm" id="user_2">user</code></a></dt>
+        <p class="Pp">Note that if a client requests an AMQP 0-9 connection, we
+            treat it as AMQP 0-9-1.</p>
+      </dd>
+      <dt id="auth_mechanism"><a class="permalink" href="#auth_mechanism"><code class="Cm">auth_mechanism</code></a></dt>
+      <dd>SASL authentication mechanism used, such as &quot;PLAIN&quot;.</dd>
+      <dt id="user~2"><a class="permalink" href="#user~2"><code class="Cm">user</code></a></dt>
       <dd>Username associated with the connection.</dd>
-      <dt><a class="permalink" href="#vhost_2"><code class="Cm" title="Cm" id="vhost_2">vhost</code></a></dt>
+      <dt id="vhost~2"><a class="permalink" href="#vhost~2"><code class="Cm">vhost</code></a></dt>
       <dd>Virtual host name with non-ASCII characters escaped as in C.</dd>
-      <dt><a class="permalink" href="#timeout"><code class="Cm" title="Cm" id="timeout">timeout</code></a></dt>
+      <dt id="timeout"><a class="permalink" href="#timeout"><code class="Cm">timeout</code></a></dt>
       <dd>Connection timeout / negotiated heartbeat interval, in seconds.</dd>
-      <dt><a class="permalink" href="#frame_max"><code class="Cm" title="Cm" id="frame_max">frame_max</code></a></dt>
+      <dt id="frame_max"><a class="permalink" href="#frame_max"><code class="Cm">frame_max</code></a></dt>
       <dd>Maximum frame size (bytes).</dd>
-      <dt><a class="permalink" href="#channel_max"><code class="Cm" title="Cm" id="channel_max">channel_max</code></a></dt>
+      <dt id="channel_max"><a class="permalink" href="#channel_max"><code class="Cm">channel_max</code></a></dt>
       <dd>Maximum number of channels on this connection.</dd>
-      <dt><a class="permalink" href="#client_properties"><code class="Cm" title="Cm" id="client_properties">client_properties</code></a></dt>
+      <dt id="client_properties"><a class="permalink" href="#client_properties"><code class="Cm">client_properties</code></a></dt>
       <dd>Informational properties transmitted by the client during connection
           establishment.</dd>
-      <dt><a class="permalink" href="#recv_oct"><code class="Cm" title="Cm" id="recv_oct">recv_oct</code></a></dt>
+      <dt id="recv_oct"><a class="permalink" href="#recv_oct"><code class="Cm">recv_oct</code></a></dt>
       <dd>Octets received.</dd>
-      <dt><a class="permalink" href="#recv_cnt"><code class="Cm" title="Cm" id="recv_cnt">recv_cnt</code></a></dt>
+      <dt id="recv_cnt"><a class="permalink" href="#recv_cnt"><code class="Cm">recv_cnt</code></a></dt>
       <dd>Packets received.</dd>
-      <dt><a class="permalink" href="#send_oct"><code class="Cm" title="Cm" id="send_oct">send_oct</code></a></dt>
+      <dt id="send_oct"><a class="permalink" href="#send_oct"><code class="Cm">send_oct</code></a></dt>
       <dd>Octets send.</dd>
-      <dt><a class="permalink" href="#send_cnt"><code class="Cm" title="Cm" id="send_cnt">send_cnt</code></a></dt>
+      <dt id="send_cnt"><a class="permalink" href="#send_cnt"><code class="Cm">send_cnt</code></a></dt>
       <dd>Packets sent.</dd>
-      <dt><a class="permalink" href="#send_pend"><code class="Cm" title="Cm" id="send_pend">send_pend</code></a></dt>
+      <dt id="send_pend"><a class="permalink" href="#send_pend"><code class="Cm">send_pend</code></a></dt>
       <dd>Send queue size.</dd>
-      <dt><a class="permalink" href="#connected_at"><code class="Cm" title="Cm" id="connected_at">connected_at</code></a></dt>
+      <dt id="connected_at"><a class="permalink" href="#connected_at"><code class="Cm">connected_at</code></a></dt>
       <dd>Date and time this connection was established, as timestamp.</dd>
     </dl>
-    <div class="Pp"></div>
-    If no <var class="Ar" title="Ar">connectioninfoitem</var> are specified then
-      user, peer host, peer port, time since flow control and memory block state
-      are displayed.
-    <div class="Pp"></div>
-    For example, this command displays the send queue size and server port for
-      each connection:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_connections
+    <p class="Pp">If no <var class="Ar">connectioninfoitem</var> are specified
+        then user, peer host, peer port, time since flow control and memory
+        block state are displayed.</p>
+    <p class="Pp">For example, this command displays the send queue size and
+        server port for each connection:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_connections
       send_pend port</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_consumers"><code class="Cm" title="Cm" id="list_consumers">list_consumers</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="list_consumers"><a class="permalink" href="#list_consumers"><code class="Cm">list_consumers</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists consumers, i.e. subscriptions to a queue&#x00B4;s message stream. Each
-      line printed shows, separated by tab characters, the name of the queue
-      subscribed to, the id of the channel process via which the subscription
-      was created and is managed, the consumer tag which uniquely identifies the
-      subscription within a channel, a boolean indicating whether
-      acknowledgements are expected for messages delivered to this consumer, an
-      integer indicating the prefetch limit (with 0 meaning
-      &quot;none&quot;), and any arguments for this consumer.</dd>
-  <dt><a class="permalink" href="#list_exchanges"><code class="Cm" title="Cm" id="list_exchanges">list_exchanges</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><var class="Ar" title="Ar">exchangeinfoitem
-    ...</var></div>]</dt>
+    <p class="Pp">Lists consumers, i.e. subscriptions to a queue&#x00B4;s
+        message stream. Each line printed shows, separated by tab characters,
+        the name of the queue subscribed to, the id of the channel process via
+        which the subscription was created and is managed, the consumer tag
+        which uniquely identifies the subscription within a channel, a boolean
+        indicating whether acknowledgements are expected for messages delivered
+        to this consumer, an integer indicating the prefetch limit (with 0
+        meaning &quot;none&quot;), and any arguments for this consumer.</p>
+  </dd>
+  <dt id="list_exchanges"><a class="permalink" href="#list_exchanges"><code class="Cm">list_exchanges</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<var class="Ar">exchangeinfoitem ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Returns exchange details. Exchange details of the &quot;/&quot; virtual
-      host are returned if the <code class="Fl" title="Fl">-p</code> flag is
-      absent. The <code class="Fl" title="Fl">-p</code> flag can be used to
-      override this default.
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">exchangeinfoitem</var> parameter is used to
-      indicate which exchange information items to include in the results. The
-      column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">exchangeinfoitem</var> can take any value from
-      the list that follows:
+    <p class="Pp">Returns exchange details. Exchange details of the
+        &quot;/&quot; virtual host are returned if the
+        <code class="Fl">-p</code> flag is absent. The
+        <code class="Fl">-p</code> flag can be used to override this
+      default.</p>
+    <p class="Pp">The <var class="Ar">exchangeinfoitem</var> parameter is used
+        to indicate which exchange information items to include in the results.
+        The column order in the results will match the order of the parameters.
+        <var class="Ar">exchangeinfoitem</var> can take any value from the list
+        that follows:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#name_4"><code class="Cm" title="Cm" id="name_4">name</code></a></dt>
+      <dt id="name~4"><a class="permalink" href="#name~4"><code class="Cm">name</code></a></dt>
       <dd>The name of the exchange with non-ASCII characters escaped as in
         C.</dd>
-      <dt><a class="permalink" href="#type"><code class="Cm" title="Cm" id="type">type</code></a></dt>
+      <dt id="type"><a class="permalink" href="#type"><code class="Cm">type</code></a></dt>
       <dd>The exchange type, such as:
         <ul class="Bl-bullet Bl-compact">
           <li>direct</li>
@@ -1241,409 +1120,401 @@ Note that all user management commands
           <li>fanout</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#durable"><code class="Cm" title="Cm" id="durable">durable</code></a></dt>
+      <dt id="durable"><a class="permalink" href="#durable"><code class="Cm">durable</code></a></dt>
       <dd>Whether or not the exchange survives server restarts.</dd>
-      <dt><a class="permalink" href="#auto_delete"><code class="Cm" title="Cm" id="auto_delete">auto_delete</code></a></dt>
+      <dt id="auto_delete"><a class="permalink" href="#auto_delete"><code class="Cm">auto_delete</code></a></dt>
       <dd>Whether the exchange will be deleted automatically when no longer
           used.</dd>
-      <dt><a class="permalink" href="#internal"><code class="Cm" title="Cm" id="internal">internal</code></a></dt>
+      <dt id="internal"><a class="permalink" href="#internal"><code class="Cm">internal</code></a></dt>
       <dd>Whether the exchange is internal, i.e. cannot be directly published to
           by a client.</dd>
-      <dt><a class="permalink" href="#arguments_2"><code class="Cm" title="Cm" id="arguments_2">arguments</code></a></dt>
+      <dt id="arguments~2"><a class="permalink" href="#arguments~2"><code class="Cm">arguments</code></a></dt>
       <dd>Exchange arguments.</dd>
-      <dt><a class="permalink" href="#policy"><code class="Cm" title="Cm" id="policy">policy</code></a></dt>
+      <dt id="policy"><a class="permalink" href="#policy"><code class="Cm">policy</code></a></dt>
       <dd>Policy name for applying to the exchange.</dd>
     </dl>
-    <div class="Pp"></div>
-    If no <var class="Ar" title="Ar">exchangeinfoitem</var> are specified then
-      exchange name and type are displayed.
-    <div class="Pp"></div>
-    For example, this command displays the name and type for each exchange of
-      the virtual host named &quot;my-vhost&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_exchanges -p
+    <p class="Pp">If no <var class="Ar">exchangeinfoitem</var> are specified
+        then exchange name and type are displayed.</p>
+    <p class="Pp">For example, this command displays the name and type for each
+        exchange of the virtual host named &quot;my-vhost&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_exchanges -p
       my-vhost name type</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_hashes"><code class="Cm" title="Cm" id="list_hashes">list_hashes</code></a></dt>
+  <dt id="list_hashes"><a class="permalink" href="#list_hashes"><code class="Cm">list_hashes</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Lists hash functions supported by encoding commands.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to list all hash
-      functions supported by encoding commands:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists hash functions supported by encoding commands.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        list all hash functions supported by encoding commands:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_hashes</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_queues"><code class="Cm" title="Cm" id="list_queues">list_queues</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--offline</code> |
-    <code class="Fl" title="Fl">--online</code> |
-    <code class="Fl" title="Fl">--local</code></div>]
-    [<div class="Op"><var class="Ar" title="Ar">queueinfoitem
-    ...</var></div>]</dt>
+  <dt id="list_queues"><a class="permalink" href="#list_queues"><code class="Cm">list_queues</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<code class="Fl">--offline</code> | <code class="Fl">--online</code> |
+    <code class="Fl">--local</code>] [<var class="Ar">queueinfoitem
+    ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Returns queue details. Queue details of the &quot;/&quot; virtual host
-      are returned if the <code class="Fl" title="Fl">-p</code> flag is absent.
-      The <code class="Fl" title="Fl">-p</code> flag can be used to override
-      this default.
-    <div class="Pp"></div>
-    Displayed queues can be filtered by their status or location using one of
-      the following mutually exclusive options:
+    <p class="Pp">Returns queue details. Queue details of the &quot;/&quot;
+        virtual host are returned if the <code class="Fl">-p</code> flag is
+        absent. The <code class="Fl">-p</code> flag can be used to override this
+        default.</p>
+    <p class="Pp">Displayed queues can be filtered by their status or location
+        using one of the following mutually exclusive options:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#-offline_2"><code class="Fl" title="Fl" id="-offline_2">--offline</code></a></dt>
+      <dt id="offline~2"><a class="permalink" href="#offline~2"><code class="Fl">--offline</code></a></dt>
       <dd>List only those durable queues that are not currently available (more
           specifically, their leader node isn't).</dd>
-      <dt><a class="permalink" href="#-online"><code class="Fl" title="Fl" id="-online">--online</code></a></dt>
+      <dt id="online"><a class="permalink" href="#online"><code class="Fl">--online</code></a></dt>
       <dd>List queues that are currently available (their leader node is).</dd>
-      <dt><a class="permalink" href="#-local"><code class="Fl" title="Fl" id="-local">--local</code></a></dt>
+      <dt id="local"><a class="permalink" href="#local"><code class="Fl">--local</code></a></dt>
       <dd>List only those queues whose leader replica is located on the current
           node.</dd>
     </dl>
-    <div class="Pp"></div>
-    The <var class="Ar" title="Ar">queueinfoitem</var> parameter is used to
-      indicate which queue information items to include in the results. The
-      column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">queueinfoitem</var> can take any value from the
-      list that follows:
+    <p class="Pp">The <var class="Ar">queueinfoitem</var> parameter is used to
+        indicate which queue information items to include in the results. The
+        column order in the results will match the order of the parameters.
+        <var class="Ar">queueinfoitem</var> can take any value from the list
+        that follows:</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#name_5"><code class="Cm" title="Cm" id="name_5">name</code></a></dt>
+      <dt id="name~5"><a class="permalink" href="#name~5"><code class="Cm">name</code></a></dt>
       <dd>The name of the queue with non-ASCII characters escaped as in C.</dd>
-      <dt><a class="permalink" href="#durable_2"><code class="Cm" title="Cm" id="durable_2">durable</code></a></dt>
+      <dt id="durable~2"><a class="permalink" href="#durable~2"><code class="Cm">durable</code></a></dt>
       <dd>Whether or not the queue survives server restarts.</dd>
-      <dt><a class="permalink" href="#auto_delete_2"><code class="Cm" title="Cm" id="auto_delete_2">auto_delete</code></a></dt>
+      <dt id="auto_delete~2"><a class="permalink" href="#auto_delete~2"><code class="Cm">auto_delete</code></a></dt>
       <dd>Whether the queue will be deleted automatically when no longer
         used.</dd>
-      <dt><a class="permalink" href="#arguments_3"><code class="Cm" title="Cm" id="arguments_3">arguments</code></a></dt>
+      <dt id="arguments~3"><a class="permalink" href="#arguments~3"><code class="Cm">arguments</code></a></dt>
       <dd>Queue arguments.</dd>
-      <dt><a class="permalink" href="#policy_2"><code class="Cm" title="Cm" id="policy_2">policy</code></a></dt>
+      <dt id="policy~2"><a class="permalink" href="#policy~2"><code class="Cm">policy</code></a></dt>
       <dd>Effective policy name for the queue.</dd>
-      <dt><a class="permalink" href="#pid_3"><code class="Cm" title="Cm" id="pid_3">pid</code></a></dt>
+      <dt id="pid~3"><a class="permalink" href="#pid~3"><code class="Cm">pid</code></a></dt>
       <dd>Erlang process identifier of the queue.</dd>
-      <dt><a class="permalink" href="#owner_pid"><code class="Cm" title="Cm" id="owner_pid">owner_pid</code></a></dt>
+      <dt id="owner_pid"><a class="permalink" href="#owner_pid"><code class="Cm">owner_pid</code></a></dt>
       <dd>Id of the Erlang process of the connection which is the exclusive
           owner of the queue. Empty if the queue is non-exclusive.</dd>
-      <dt><a class="permalink" href="#exclusive"><code class="Cm" title="Cm" id="exclusive">exclusive</code></a></dt>
+      <dt id="exclusive"><a class="permalink" href="#exclusive"><code class="Cm">exclusive</code></a></dt>
       <dd>True if queue is exclusive (i.e. has owner_pid), false otherwise.</dd>
-      <dt><a class="permalink" href="#exclusive_consumer_pid"><code class="Cm" title="Cm" id="exclusive_consumer_pid">exclusive_consumer_pid</code></a></dt>
+      <dt id="exclusive_consumer_pid"><a class="permalink" href="#exclusive_consumer_pid"><code class="Cm">exclusive_consumer_pid</code></a></dt>
       <dd>Id of the Erlang process representing the channel of the exclusive
           consumer subscribed to this queue. Empty if there is no exclusive
           consumer.</dd>
-      <dt><a class="permalink" href="#exclusive_consumer_tag"><code class="Cm" title="Cm" id="exclusive_consumer_tag">exclusive_consumer_tag</code></a></dt>
+      <dt id="exclusive_consumer_tag"><a class="permalink" href="#exclusive_consumer_tag"><code class="Cm">exclusive_consumer_tag</code></a></dt>
       <dd>Consumer tag of the exclusive consumer subscribed to this queue. Empty
           if there is no exclusive consumer.</dd>
-      <dt><a class="permalink" href="#messages_ready"><code class="Cm" title="Cm" id="messages_ready">messages_ready</code></a></dt>
+      <dt id="messages_ready"><a class="permalink" href="#messages_ready"><code class="Cm">messages_ready</code></a></dt>
       <dd>Number of messages ready to be delivered to clients.</dd>
-      <dt><a class="permalink" href="#messages_unacknowledged_2"><code class="Cm" title="Cm" id="messages_unacknowledged_2">messages_unacknowledged</code></a></dt>
+      <dt id="messages_unacknowledged~2"><a class="permalink" href="#messages_unacknowledged~2"><code class="Cm">messages_unacknowledged</code></a></dt>
       <dd>Number of messages delivered to clients but not yet acknowledged.</dd>
-      <dt><a class="permalink" href="#messages"><code class="Cm" title="Cm" id="messages">messages</code></a></dt>
+      <dt id="messages"><a class="permalink" href="#messages"><code class="Cm">messages</code></a></dt>
       <dd>Sum of ready and unacknowledged messages (queue depth).</dd>
-      <dt><a class="permalink" href="#messages_ready_ram"><code class="Cm" title="Cm" id="messages_ready_ram">messages_ready_ram</code></a></dt>
+      <dt id="messages_ready_ram"><a class="permalink" href="#messages_ready_ram"><code class="Cm">messages_ready_ram</code></a></dt>
       <dd>Number of messages from messages_ready which are resident in ram.</dd>
-      <dt><a class="permalink" href="#messages_unacknowledged_ram"><code class="Cm" title="Cm" id="messages_unacknowledged_ram">messages_unacknowledged_ram</code></a></dt>
+      <dt id="messages_unacknowledged_ram"><a class="permalink" href="#messages_unacknowledged_ram"><code class="Cm">messages_unacknowledged_ram</code></a></dt>
       <dd>Number of messages from messages_unacknowledged which are resident in
           ram.</dd>
-      <dt><a class="permalink" href="#messages_ram"><code class="Cm" title="Cm" id="messages_ram">messages_ram</code></a></dt>
+      <dt id="messages_ram"><a class="permalink" href="#messages_ram"><code class="Cm">messages_ram</code></a></dt>
       <dd>Total number of messages which are resident in ram.</dd>
-      <dt><a class="permalink" href="#messages_persistent"><code class="Cm" title="Cm" id="messages_persistent">messages_persistent</code></a></dt>
+      <dt id="messages_persistent"><a class="permalink" href="#messages_persistent"><code class="Cm">messages_persistent</code></a></dt>
       <dd>Total number of persistent messages in the queue (will always be 0 for
           transient queues).</dd>
-      <dt><a class="permalink" href="#message_bytes"><code class="Cm" title="Cm" id="message_bytes">message_bytes</code></a></dt>
+      <dt id="message_bytes"><a class="permalink" href="#message_bytes"><code class="Cm">message_bytes</code></a></dt>
       <dd>Sum of the size of all message bodies in the queue. This does not
           include the message properties (including headers) or any
         overhead.</dd>
-      <dt><a class="permalink" href="#message_bytes_ready"><code class="Cm" title="Cm" id="message_bytes_ready">message_bytes_ready</code></a></dt>
-      <dd>Like <code class="Cm" title="Cm">message_bytes</code> but counting
-          only those messages ready to be delivered to clients.</dd>
-      <dt><a class="permalink" href="#message_bytes_unacknowledged"><code class="Cm" title="Cm" id="message_bytes_unacknowledged">message_bytes_unacknowledged</code></a></dt>
-      <dd>Like <code class="Cm" title="Cm">message_bytes</code> but counting
-          only those messages delivered to clients but not yet
-        acknowledged.</dd>
-      <dt><a class="permalink" href="#message_bytes_ram"><code class="Cm" title="Cm" id="message_bytes_ram">message_bytes_ram</code></a></dt>
-      <dd>Like <code class="Cm" title="Cm">message_bytes</code> but counting
-          only those messages which are currently held in RAM.</dd>
-      <dt><a class="permalink" href="#message_bytes_persistent"><code class="Cm" title="Cm" id="message_bytes_persistent">message_bytes_persistent</code></a></dt>
-      <dd>Like <code class="Cm" title="Cm">message_bytes</code> but counting
-          only those messages which are persistent.</dd>
-      <dt><a class="permalink" href="#head_message_timestamp"><code class="Cm" title="Cm" id="head_message_timestamp">head_message_timestamp</code></a></dt>
+      <dt id="message_bytes_ready"><a class="permalink" href="#message_bytes_ready"><code class="Cm">message_bytes_ready</code></a></dt>
+      <dd>Like <code class="Cm">message_bytes</code> but counting only those
+          messages ready to be delivered to clients.</dd>
+      <dt id="message_bytes_unacknowledged"><a class="permalink" href="#message_bytes_unacknowledged"><code class="Cm">message_bytes_unacknowledged</code></a></dt>
+      <dd>Like <code class="Cm">message_bytes</code> but counting only those
+          messages delivered to clients but not yet acknowledged.</dd>
+      <dt id="message_bytes_ram"><a class="permalink" href="#message_bytes_ram"><code class="Cm">message_bytes_ram</code></a></dt>
+      <dd>Like <code class="Cm">message_bytes</code> but counting only those
+          messages which are currently held in RAM.</dd>
+      <dt id="message_bytes_persistent"><a class="permalink" href="#message_bytes_persistent"><code class="Cm">message_bytes_persistent</code></a></dt>
+      <dd>Like <code class="Cm">message_bytes</code> but counting only those
+          messages which are persistent.</dd>
+      <dt id="head_message_timestamp"><a class="permalink" href="#head_message_timestamp"><code class="Cm">head_message_timestamp</code></a></dt>
       <dd>The timestamp property of the first message in the queue, if present.
           Timestamps of messages only appear when they are in the paged-in
           state.</dd>
-      <dt><a class="permalink" href="#disk_reads"><code class="Cm" title="Cm" id="disk_reads">disk_reads</code></a></dt>
+      <dt id="disk_reads"><a class="permalink" href="#disk_reads"><code class="Cm">disk_reads</code></a></dt>
       <dd>Total number of times messages have been read from disk by this queue
           since it started.</dd>
-      <dt><a class="permalink" href="#disk_writes"><code class="Cm" title="Cm" id="disk_writes">disk_writes</code></a></dt>
+      <dt id="disk_writes"><a class="permalink" href="#disk_writes"><code class="Cm">disk_writes</code></a></dt>
       <dd>Total number of times messages have been written to disk by this queue
           since it started.</dd>
-      <dt><a class="permalink" href="#consumers"><code class="Cm" title="Cm" id="consumers">consumers</code></a></dt>
+      <dt id="consumers"><a class="permalink" href="#consumers"><code class="Cm">consumers</code></a></dt>
       <dd>Number of consumers.</dd>
-      <dt><a class="permalink" href="#consumer_utilisation"><code class="Cm" title="Cm" id="consumer_utilisation">consumer_utilisation</code></a></dt>
+      <dt id="consumer_utilisation"><a class="permalink" href="#consumer_utilisation"><code class="Cm">consumer_utilisation</code></a></dt>
       <dd>Fraction of the time (between 0.0 and 1.0) that the queue is able to
           immediately deliver messages to consumers. This can be less than 1.0
           if consumers are limited by network congestion or prefetch count.</dd>
-      <dt><a class="permalink" href="#memory"><code class="Cm" title="Cm" id="memory">memory</code></a></dt>
+      <dt id="memory"><a class="permalink" href="#memory"><code class="Cm">memory</code></a></dt>
       <dd>Bytes of memory allocated by the runtime for the queue, including
           stack, heap and internal structures.</dd>
-      <dt><a class="permalink" href="#slave_pids"><code class="Cm" title="Cm" id="slave_pids">slave_pids</code></a></dt>
+      <dt id="mirror_pids"><a class="permalink" href="#mirror_pids"><code class="Cm">mirror_pids</code></a></dt>
       <dd>If the queue is mirrored, this lists the IDs of the mirrors (follower
           replicas). To learn more, see the
-          <a class="Lk" title="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ
+          <a class="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ
           Mirroring guide</a></dd>
-      <dt><a class="permalink" href="#synchronised_slave_pids"><code class="Cm" title="Cm" id="synchronised_slave_pids">synchronised_slave_pids</code></a></dt>
+      <dt id="synchronised_mirror_pids"><a class="permalink" href="#synchronised_mirror_pids"><code class="Cm">synchronised_mirror_pids</code></a></dt>
       <dd>If the queue is mirrored, this gives the IDs of the mirrors (follower
           replicas) which are in sync with the leader replica. To learn more,
-          see the
-          <a class="Lk" title="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ
+          see the <a class="Lk" href="https://www.rabbitmq.com/ha.html">RabbitMQ
           Mirroring guide</a></dd>
-      <dt><a class="permalink" href="#state_2"><code class="Cm" title="Cm" id="state_2">state</code></a></dt>
+      <dt id="state~2"><a class="permalink" href="#state~2"><code class="Cm">state</code></a></dt>
       <dd>The state of the queue. Normally &quot;running&quot;, but may be
-          &quot;{syncing,
-          <var class="Ar" title="Ar">message_count</var>}&quot; if the queue
-          is synchronising.
-        <div class="Pp"></div>
-        Queues which are located on cluster nodes that are currently down will
-          be shown with a status of &quot;down&quot; (and most other
-          <var class="Ar" title="Ar">queueinfoitem</var> will be
-        unavailable).</dd>
+          &quot;{syncing, <var class="Ar">message_count</var>}&quot; if the
+          queue is synchronising.
+        <p class="Pp">Queues which are located on cluster nodes that are
+            currently down will be shown with a status of &quot;down&quot; (and
+            most other <var class="Ar">queueinfoitem</var> will be
+          unavailable).</p>
+      </dd>
+      <dt id="type~2"><a class="permalink" href="#type~2"><code class="Cm">type</code></a></dt>
+      <dd>Queue type, one of: quorum, stream, classic.</dd>
     </dl>
-    <div class="Pp"></div>
-    If no <var class="Ar" title="Ar">queueinfoitem</var> are specified then
-      queue name and depth are displayed.
-    <div class="Pp"></div>
-    For example, this command displays the depth and number of consumers for
-      each queue of the virtual host named &quot;my-vhost&quot;
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_queues -p
+    <p class="Pp">If no <var class="Ar">queueinfoitem</var> are specified then
+        queue name and depth are displayed.</p>
+    <p class="Pp">For example, this command displays the depth and number of
+        consumers for each queue of the virtual host named
+      &quot;my-vhost&quot;</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl list_queues -p
       my-vhost messages consumers</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_unresponsive_queues"><code class="Cm" title="Cm" id="list_unresponsive_queues">list_unresponsive_queues</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">--local</code></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--queue-timeout</code>
-    <var class="Ar" title="Ar">milliseconds</var></div>]
-    [<div class="Op"><var class="Ar" title="Ar">column ...</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--no-table-headers</code></div>]</dt>
+  <dt id="list_unresponsive_queues"><a class="permalink" href="#list_unresponsive_queues"><code class="Cm">list_unresponsive_queues</code></a>
+    [<code class="Fl">--local</code>] [<code class="Fl">--queue-timeout</code>
+    <var class="Ar">milliseconds</var>] [<var class="Ar">queueinfoitem
+    ...</var>] [<code class="Fl">--no-table-headers</code>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Tests queues to respond within timeout. Lists those which did not respond
-    <div class="Pp"></div>
-    For example, this command lists only those unresponsive queues whose leader
-      replica is hosted on the target node.
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Tests queue leader replicas to respond within the given
+        timeout. Lists those which did not respond in time.</p>
+    <p class="Pp">Displayed queues can be filtered by their status or location
+        using one of the following mutually exclusive options:</p>
+    <dl class="Bl-tag">
+      <dt id="all"><a class="permalink" href="#all"><code class="Fl">--all</code></a></dt>
+      <dd>List all queues.</dd>
+      <dt id="local~2"><a class="permalink" href="#local~2"><code class="Fl">--local</code></a></dt>
+      <dd>List only those queues whose leader replica is located on the current
+          node.</dd>
+    </dl>
+    <p class="Pp">The <var class="Ar">queueinfoitem</var> parameter is used to
+        indicate which queue information items to include in the results. The
+        column order in the results will match the order of the parameters.
+        <var class="Ar">queueinfoitem</var> can take any value from the list
+        that follows:</p>
+    <dl class="Bl-tag">
+      <dt id="name~6"><a class="permalink" href="#name~6"><code class="Cm">name</code></a></dt>
+      <dd>The name of the queue with non-ASCII characters escaped as in C.</dd>
+      <dt id="durable~3"><a class="permalink" href="#durable~3"><code class="Cm">durable</code></a></dt>
+      <dd>Whether or not the queue should survive server restarts.</dd>
+      <dt id="auto_delete~3"><a class="permalink" href="#auto_delete~3"><code class="Cm">auto_delete</code></a></dt>
+      <dd>Whether the queue will be deleted automatically when all of its
+          explicit bindings are deleted.</dd>
+      <dt id="arguments~4"><a class="permalink" href="#arguments~4"><code class="Cm">arguments</code></a></dt>
+      <dd>Queue arguments.</dd>
+      <dt id="policy~3"><a class="permalink" href="#policy~3"><code class="Cm">policy</code></a></dt>
+      <dd>Effective policy name for the queue.</dd>
+      <dt id="pid~4"><a class="permalink" href="#pid~4"><code class="Cm">pid</code></a></dt>
+      <dd>Erlang process identifier of the leader replica.</dd>
+      <dt id="recoverable_mirrors"><a class="permalink" href="#recoverable_mirrors"><code class="Cm">recoverable_mirrors</code></a></dt>
+      <dd>Erlang process identifiers of the mirror replicas that are considered
+          reachable (available).</dd>
+      <dt id="type~3"><a class="permalink" href="#type~3"><code class="Cm">type</code></a></dt>
+      <dd>Queue type, one of: quorum, stream, classic.</dd>
+    </dl>
+    <p class="Pp">For example, this command lists only those unresponsive queues
+        whose leader replica is hosted on the target node.</p>
+    <div class=00><code class="Li">rabbitmqctl
       list_unresponsive_queues --local name</code></div>
   </dd>
-  <dt><a class="permalink" href="#ping"><code class="Cm" title="Cm" id="ping">ping</code></a></dt>
+  <dt id="ping"><a class="permalink" href="#ping"><code class="Cm">ping</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Checks that the node OS process is up, registered with EPMD and CLI tools
-      can authenticate with it
-    <div class="Pp"></div>
-    Example:
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl ping -n
+    <p class="Pp">Checks that the node OS process is up, registered with EPMD
+        and CLI tools can authenticate with it</p>
+    <p class="Pp">Example:</p>
+    <div class=00><code class="Li">rabbitmqctl ping -n
       rabbit@hostname</code></div>
   </dd>
-  <dt><a class="permalink" href="#report"><code class="Cm" title="Cm" id="report">report</code></a></dt>
+  <dt id="report"><a class="permalink" href="#report"><code class="Cm">report</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Generate a server status report containing a concatenation of all server
-      status information for support purposes. The output should be redirected
-      to a file when accompanying a support request.
-    <div class="Pp"></div>
-    For example, this command creates a server report which may be attached to a
-      support request email:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl report &gt;
+    <p class="Pp">Generate a server status report containing a concatenation of
+        all server status information for support purposes. The output should be
+        redirected to a file when accompanying a support request.</p>
+    <p class="Pp">For example, this command creates a server report which may be
+        attached to a support request email:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl report &gt;
       server_report.txt</code></div>
   </dd>
-  <dt><a class="permalink" href="#schema_info"><code class="Cm" title="Cm" id="schema_info">schema_info</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">--no-table-headers</code></div>]
-    [<div class="Op"><var class="Ar" title="Ar">column ...</var></div>]</dt>
+  <dt id="schema_info"><a class="permalink" href="#schema_info"><code class="Cm">schema_info</code></a>
+    [<code class="Fl">--no-table-headers</code>] [<var class="Ar">column
+    ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists schema database tables and their properties
-    <div class="Pp"></div>
-    For example, this command lists the table names and their active replicas:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl schema_info name
+    <p class="Pp">Lists schema database tables and their properties</p>
+    <p class="Pp">For example, this command lists the table names and their
+        active replicas:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl schema_info name
       active_replicas</code></div>
   </dd>
-  <dt><a class="permalink" href="#status"><code class="Cm" title="Cm" id="status">status</code></a></dt>
+  <dt id="status"><a class="permalink" href="#status"><code class="Cm">status</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Displays broker status information such as the running applications on the
-      current Erlang node, RabbitMQ and Erlang versions, OS name, memory and
-      file descriptor statistics. (See the
-      <code class="Cm" title="Cm">cluster_status</code> command to find out
-      which nodes are clustered and running.)
-    <div class="Pp"></div>
-    For example, this command displays information about the RabbitMQ broker:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl status</code></div>
+    <p class="Pp">Displays broker status information such as the running
+        applications on the current Erlang node, RabbitMQ and Erlang versions,
+        OS name, memory and file descriptor statistics. (See the
+        <code class="Cm">cluster_status</code> command to find out which nodes
+        are clustered and running.)</p>
+    <p class="Pp">For example, this command displays information about the
+        RabbitMQ broker:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl status</code></div>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Runtime_Parameters_and_Policies"><a class="permalink" href="#Runtime_Parameters_and_Policies">Runtime
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Runtime_Parameters_and_Policies"><a class="permalink" href="#Runtime_Parameters_and_Policies">Runtime
   Parameters and Policies</a></h3>
-Certain features of RabbitMQ (such as the Federation plugin) are controlled by
-  dynamic, cluster-wide <i class="Em" title="Em">parameters.</i> There are 2
-  kinds of parameters: parameters scoped to a virtual host and global
-  parameters. Each vhost-scoped parameter consists of a component name, a name
-  and a value. The component name and name are strings, and the value is a valid
-  JSON document. A global parameter consists of a name and value. The name is a
-  string and the value is an arbitrary Erlang data structure. Parameters can be
-  set, cleared and listed. In general you should refer to the documentation for
-  the feature in question to see how to set parameters.
-<div class="Pp"></div>
-Policies is a feature built on top of runtime parameters. Policies are used to
-  control and modify the behaviour of queues and exchanges on a cluster-wide
-  basis. Policies apply within a given vhost, and consist of a name, pattern,
-  definition and an optional priority. Policies can be set, cleared and listed.
+<p class="Pp">Certain features of RabbitMQ (such as the Federation plugin) are
+    controlled by dynamic, cluster-wide
+    <a class="permalink" href="#parameters."><i class="Em" id="parameters.">parameters.</i></a>
+    There are 2 kinds of parameters: parameters scoped to a virtual host and
+    global parameters. Each vhost-scoped parameter consists of a component name,
+    a name and a value. The component name and name are strings, and the value
+    is a valid JSON document. A global parameter consists of a name and value.
+    The name is a string and the value is an arbitrary Erlang data structure.
+    Parameters can be set, cleared and listed. In general you should refer to
+    the documentation for the feature in question to see how to set
+  parameters.</p>
+<p class="Pp">Policies is a feature built on top of runtime parameters. Policies
+    are used to control and modify the behaviour of queues and exchanges on a
+    cluster-wide basis. Policies apply within a given vhost, and consist of a
+    name, pattern, definition and an optional priority. Policies can be set,
+    cleared and listed.</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#clear_global_parameter"><code class="Cm" title="Cm" id="clear_global_parameter">clear_global_parameter</code></a>
-    <var class="Ar" title="Ar">name</var></dt>
+  <dt id="clear_global_parameter"><a class="permalink" href="#clear_global_parameter"><code class="Cm">clear_global_parameter</code></a>
+    <var class="Ar">name</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Clears a global runtime parameter. This is similar to
-      <code class="Cm" title="Cm">clear_parameter</code> but the key-value pair
-      isn't tied to a virtual host.
+    <p class="Pp">Clears a global runtime parameter. This is similar to
+        <code class="Cm">clear_parameter</code> but the key-value pair isn't
+        tied to a virtual host.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">name</var></dt>
+      <dt><var class="Ar">name</var></dt>
       <dd>The name of the global runtime parameter being cleared.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command clears the global runtime parameter
-      &quot;mqtt_default_vhosts&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">For example, this command clears the global runtime parameter
+        &quot;mqtt_default_vhosts&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       clear_global_parameter mqtt_default_vhosts</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_parameter"><code class="Cm" title="Cm" id="clear_parameter">clear_parameter</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">component_name</var>
-    <var class="Ar" title="Ar">key</var></dt>
+  <dt id="clear_parameter"><a class="permalink" href="#clear_parameter"><code class="Cm">clear_parameter</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">component_name</var> <var class="Ar">key</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Clears a parameter.
+    <p class="Pp">Clears a parameter.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">component_name</var></dt>
+      <dt><var class="Ar">component_name</var></dt>
       <dd>The name of the component for which the parameter is being
         cleared.</dd>
-      <dt><var class="Ar" title="Ar">name</var></dt>
+      <dt><var class="Ar">name</var></dt>
       <dd>The name of the parameter being cleared.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command clears the parameter &quot;node01&quot; for
-      the &quot;federation-upstream&quot; component in the default virtual
-      host:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_parameter
+    <p class="Pp">For example, this command clears the parameter
+        &quot;node01&quot; for the &quot;federation-upstream&quot; component in
+        the default virtual host:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_parameter
       federation-upstream node01</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_global_parameters"><code class="Cm" title="Cm" id="list_global_parameters">list_global_parameters</code></a></dt>
+  <dt id="list_global_parameters"><a class="permalink" href="#list_global_parameters"><code class="Cm">list_global_parameters</code></a></dt>
   <dd>
-    <div class="Pp"></div>
-    Lists all global runtime parameters. This is similar to
-      <code class="Cm" title="Cm">list_parameters</code> but the global runtime
-      parameters are not tied to any virtual host.
-    <div class="Pp"></div>
-    For example, this command lists all global parameters:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists all global runtime parameters. This is similar to
+        <code class="Cm">list_parameters</code> but the global runtime
+        parameters are not tied to any virtual host.</p>
+    <p class="Pp">For example, this command lists all global parameters:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_global_parameters</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_parameters"><code class="Cm" title="Cm" id="list_parameters">list_parameters</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="list_parameters"><a class="permalink" href="#list_parameters"><code class="Cm">list_parameters</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists all parameters for a virtual host.
-    <div class="Pp"></div>
-    For example, this command lists all parameters in the default virtual host:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists all parameters for a virtual host.</p>
+    <p class="Pp">For example, this command lists all parameters in the default
+        virtual host:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_parameters</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_global_parameter"><code class="Cm" title="Cm" id="set_global_parameter">set_global_parameter</code></a>
-    <var class="Ar" title="Ar">name</var>
-    <var class="Ar" title="Ar">value</var></dt>
+  <dt id="set_global_parameter"><a class="permalink" href="#set_global_parameter"><code class="Cm">set_global_parameter</code></a>
+    <var class="Ar">name</var> <var class="Ar">value</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets a global runtime parameter. This is similar to
-      <code class="Cm" title="Cm">set_parameter</code> but the key-value pair
-      isn't tied to a virtual host.
+    <p class="Pp">Sets a global runtime parameter. This is similar to
+        <code class="Cm">set_parameter</code> but the key-value pair isn't tied
+        to a virtual host.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">name</var></dt>
+      <dt><var class="Ar">name</var></dt>
       <dd>The name of the global runtime parameter being set.</dd>
-      <dt><var class="Ar" title="Ar">value</var></dt>
+      <dt><var class="Ar">value</var></dt>
       <dd>The value for the global runtime parameter, as a JSON document. In
           most shells you are very likely to need to quote this.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command sets the global runtime parameter
-      &quot;mqtt_default_vhosts&quot; to the JSON document
-      {&quot;O=client,CN=guest&quot;:&quot;/&quot;}:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_global_parameter
+    <p class="Pp">For example, this command sets the global runtime parameter
+        &quot;mqtt_default_vhosts&quot; to the JSON document
+        {&quot;O=client,CN=guest&quot;:&quot;/&quot;}:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_global_parameter
       mqtt_default_vhosts
       '{&quot;O=client,CN=guest&quot;:&quot;/&quot;}'</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_parameter"><code class="Cm" title="Cm" id="set_parameter">set_parameter</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">component_name</var>
-    <var class="Ar" title="Ar">name</var>
-    <var class="Ar" title="Ar">value</var></dt>
+  <dt id="set_parameter"><a class="permalink" href="#set_parameter"><code class="Cm">set_parameter</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">component_name</var> <var class="Ar">name</var>
+    <var class="Ar">value</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets a parameter.
+    <p class="Pp">Sets a parameter.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">component_name</var></dt>
+      <dt><var class="Ar">component_name</var></dt>
       <dd>The name of the component for which the parameter is being set.</dd>
-      <dt><var class="Ar" title="Ar">name</var></dt>
+      <dt><var class="Ar">name</var></dt>
       <dd>The name of the parameter being set.</dd>
-      <dt><var class="Ar" title="Ar">value</var></dt>
+      <dt><var class="Ar">value</var></dt>
       <dd>The value for the parameter, as a JSON document. In most shells you
           are very likely to need to quote this.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command sets the parameter &quot;node01&quot; for the
-      &quot;federation-upstream&quot; component in the default virtual host
-      to the following JSON &quot;guest&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_parameter
+    <p class="Pp">For example, this command sets the parameter
+        &quot;node01&quot; for the &quot;federation-upstream&quot; component in
+        the default virtual host to the following JSON &quot;guest&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_parameter
       federation-upstream node01
       '{&quot;uri&quot;:&quot;amqp://user:password@server/%2F&quot;,&quot;ack-mode&quot;:&quot;on-publish&quot;}'</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_policies"><code class="Cm" title="Cm" id="list_policies">list_policies</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="list_policies"><a class="permalink" href="#list_policies"><code class="Cm">list_policies</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists all policies for a virtual host.
-    <div class="Pp"></div>
-    For example, this command lists all policies in the default virtual host:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl
+    <p class="Pp">Lists all policies for a virtual host.</p>
+    <p class="Pp">For example, this command lists all policies in the default
+        virtual host:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl
       list_policies</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_operator_policy"><code class="Cm" title="Cm" id="set_operator_policy">set_operator_policy</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--priority</code>
-    <var class="Ar" title="Ar">priority</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--apply-to</code>
-    <var class="Ar" title="Ar">apply-to</var></div>]
-    <var class="Ar" title="Ar">name</var>
-    <var class="Ar" title="Ar">pattern</var>
-    <var class="Ar" title="Ar">definition</var></dt>
+  <dt id="set_operator_policy"><a class="permalink" href="#set_operator_policy"><code class="Cm">set_operator_policy</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<code class="Fl">--priority</code> <var class="Ar">priority</var>]
+    [<code class="Fl">--apply-to</code> <var class="Ar">apply-to</var>]
+    <var class="Ar">name</var> <var class="Ar">pattern</var>
+    <var class="Ar">definition</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets an operator policy that overrides a subset of arguments in user
-      policies. Arguments are identical to those of
-      <code class="Cm" title="Cm">set_policy</code>.
-    <div class="Pp"></div>
-    Supported arguments are:
+    <p class="Pp">Sets an operator policy that overrides a subset of arguments
+        in user policies. Arguments are identical to those of
+        <code class="Cm">set_policy</code>.</p>
+    <p class="Pp">Supported arguments are:</p>
     <ul class="Bl-bullet Bl-compact">
       <li>expires</li>
       <li>message-ttl</li>
@@ -1651,32 +1522,27 @@ Policies is a feature built on top of runtime parameters. Policies are used to
       <li>max-length-bytes</li>
     </ul>
   </dd>
-  <dt><a class="permalink" href="#set_policy"><code class="Cm" title="Cm" id="set_policy">set_policy</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--priority</code>
-    <var class="Ar" title="Ar">priority</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--apply-to</code>
-    <var class="Ar" title="Ar">apply-to</var></div>]
-    <var class="Ar" title="Ar">name</var>
-    <var class="Ar" title="Ar">pattern</var>
-    <var class="Ar" title="Ar">definition</var></dt>
+  <dt id="set_policy"><a class="permalink" href="#set_policy"><code class="Cm">set_policy</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<code class="Fl">--priority</code> <var class="Ar">priority</var>]
+    [<code class="Fl">--apply-to</code> <var class="Ar">apply-to</var>]
+    <var class="Ar">name</var> <var class="Ar">pattern</var>
+    <var class="Ar">definition</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets a policy.
+    <p class="Pp">Sets a policy.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">name</var></dt>
+      <dt><var class="Ar">name</var></dt>
       <dd>The name of the policy.</dd>
-      <dt><var class="Ar" title="Ar">pattern</var></dt>
+      <dt><var class="Ar">pattern</var></dt>
       <dd>The regular expression, which when matches on a given resources causes
           the policy to apply.</dd>
-      <dt><var class="Ar" title="Ar">definition</var></dt>
+      <dt><var class="Ar">definition</var></dt>
       <dd>The definition of the policy, as a JSON document. In most shells you
           are very likely to need to quote this.</dd>
-      <dt><var class="Ar" title="Ar">priority</var></dt>
+      <dt><var class="Ar">priority</var></dt>
       <dd>The priority of the policy as an integer. Higher numbers indicate
           greater precedence. The default is 0.</dd>
-      <dt><var class="Ar" title="Ar">apply-to</var></dt>
+      <dt><var class="Ar">apply-to</var></dt>
       <dd>Which types of object this policy should apply to. Possible values
           are:
         <ul class="Bl-bullet Bl-compact">
@@ -1684,413 +1550,359 @@ Policies is a feature built on top of runtime parameters. Policies are used to
           <li>exchanges</li>
           <li>all</li>
         </ul>
-        The default is <code class="Cm" title="Cm">all ..</code></dd>
+        The default is <code class="Cm">all ..</code></dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command sets the policy &quot;federate-me&quot; in the
-      default virtual host so that built-in exchanges are federated:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_policy
+    <p class="Pp">For example, this command sets the policy
+        &quot;federate-me&quot; in the default virtual host so that built-in
+        exchanges are federated:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_policy
       federate-me ^amq.
       '{&quot;federation-upstream-set&quot;:&quot;all&quot;}'</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_policy"><code class="Cm" title="Cm" id="clear_policy">clear_policy</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">name</var></dt>
+  <dt id="clear_policy"><a class="permalink" href="#clear_policy"><code class="Cm">clear_policy</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">name</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Clears a policy.
+    <p class="Pp">Clears a policy.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">name</var></dt>
+      <dt><var class="Ar">name</var></dt>
       <dd>The name of the policy being cleared.</dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command clears the &quot;federate-me&quot; policy in
-      the default virtual host:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_policy
+    <p class="Pp">For example, this command clears the &quot;federate-me&quot;
+        policy in the default virtual host:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_policy
       federate-me</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_operator_policy"><code class="Cm" title="Cm" id="clear_operator_policy">clear_operator_policy</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">name</var></dt>
+  <dt id="clear_operator_policy"><a class="permalink" href="#clear_operator_policy"><code class="Cm">clear_operator_policy</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">name</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Clears an operator policy. Arguments are identical to those of
-      <code class="Cm" title="Cm">clear_policy</code>.</dd>
-  <dt><a class="permalink" href="#list_operator_policies"><code class="Cm" title="Cm" id="list_operator_policies">list_operator_policies</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+    <p class="Pp">Clears an operator policy. Arguments are identical to those of
+        <code class="Cm">clear_policy</code>.</p>
+  </dd>
+  <dt id="list_operator_policies"><a class="permalink" href="#list_operator_policies"><code class="Cm">list_operator_policies</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists operator policy overrides for a virtual host. Arguments are identical
-      to those of <code class="Cm" title="Cm">list_policies</code>.</dd>
+    <p class="Pp">Lists operator policy overrides for a virtual host. Arguments
+        are identical to those of <code class="Cm">list_policies</code>.</p>
+  </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Virtual_hosts"><a class="permalink" href="#Virtual_hosts">Virtual
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Virtual_hosts"><a class="permalink" href="#Virtual_hosts">Virtual
   hosts</a></h3>
-Note that <code class="Nm" title="Nm">rabbitmqctl</code> manages the RabbitMQ
-  internal user database. Permissions for users from any alternative
-  authorisation backend will not be visible to
-  <code class="Nm" title="Nm">rabbitmqctl</code>.
+<p class="Pp">Note that <code class="Nm">rabbitmqctl</code> manages the RabbitMQ
+    internal user database. Permissions for users from any alternative
+    authorisation backend will not be visible to
+    <code class="Nm">rabbitmqctl</code>.</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#add_vhost"><code class="Cm" title="Cm" id="add_vhost">add_vhost</code></a>
-    <var class="Ar" title="Ar">vhost</var>
-    [<div class="Op"><code class="Fl" title="Fl">--description</code>
-    <var class="Ar" title="Ar">desc</var>
-    <code class="Fl" title="Fl">--tags</code>
-    <var class="Ar" title="Ar">tags</var>
-    <code class="Fl" title="Fl">--default-queue-type</code>
-    <var class="Ar" title="Ar">default-q-type</var></div>]</dt>
+  <dt id="add_vhost"><a class="permalink" href="#add_vhost"><code class="Cm">add_vhost</code></a>
+    <var class="Ar">vhost</var> [<code class="Fl">--description</code>
+    <var class="Ar">desc</var> <code class="Fl">--tags</code>
+    <var class="Ar">tags</var> <code class="Fl">--default-queue-type</code>
+    <var class="Ar">default-q-type</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host entry to create.</dd>
-      <dt><var class="Ar" title="Ar">desc</var></dt>
+      <dt><var class="Ar">desc</var></dt>
       <dd>Arbitrary virtual host description, e.g. its purpose, for operator's
           convenience.</dd>
-      <dt><var class="Ar" title="Ar">tags</var></dt>
+      <dt><var class="Ar">tags</var></dt>
       <dd>A comma-separated list of virtual host tags for operator's
         convenient</dd>
-      <dt><var class="Ar" title="Ar">default-q-type</var></dt>
+      <dt><var class="Ar">default-q-type</var></dt>
       <dd>If clients do not specify queue type explicitly, this type will be
           used. One of: quorum, stream.</dd>
     </dl>
-    <div class="Pp"></div>
-    Creates a virtual host.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to create a new
-      virtual host called &quot;project9_dev_18&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl add_vhost
+    <p class="Pp">Creates a virtual host.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        create a new virtual host called &quot;project9_dev_18&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl add_vhost
       project9_dev_18 --description 'Dev environment no. 18' --tags
       dev,project9</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_vhost_limits"><code class="Cm" title="Cm" id="clear_vhost_limits">clear_vhost_limits</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="clear_vhost_limits"><a class="permalink" href="#clear_vhost_limits"><code class="Cm">clear_vhost_limits</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Clears virtual host limits.
-    <div class="Pp"></div>
-    For example, this command clears vhost limits in vhost
-      &quot;qa_env&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_vhost_limits -p
+    <p class="Pp">Clears virtual host limits.</p>
+    <p class="Pp">For example, this command clears vhost limits in vhost
+        &quot;qa_env&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_vhost_limits -p
       qa_env</code></div>
   </dd>
-  <dt><a class="permalink" href="#delete_vhost"><code class="Cm" title="Cm" id="delete_vhost">delete_vhost</code></a>
-    <var class="Ar" title="Ar">vhost</var></dt>
+  <dt id="delete_vhost"><a class="permalink" href="#delete_vhost"><code class="Cm">delete_vhost</code></a>
+    <var class="Ar">vhost</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host entry to delete.</dd>
     </dl>
-    <div class="Pp"></div>
-    Deletes a virtual host.
-    <div class="Pp"></div>
-    Deleting a virtual host deletes all its exchanges, queues, bindings, user
-      permissions, parameters and policies.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to delete the
-      virtual host called &quot;test&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl delete_vhost
+    <p class="Pp">Deletes a virtual host.</p>
+    <p class="Pp">Deleting a virtual host deletes all its exchanges, queues,
+        bindings, user permissions, parameters and policies.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        delete the virtual host called &quot;test&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl delete_vhost
       a-vhost</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_vhost_limits"><code class="Cm" title="Cm" id="list_vhost_limits">list_vhost_limits</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--global</code></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--no-table-headers</code></div>]</dt>
+  <dt id="list_vhost_limits"><a class="permalink" href="#list_vhost_limits"><code class="Cm">list_vhost_limits</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<code class="Fl">--global</code>]
+    [<code class="Fl">--no-table-headers</code>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Displays configured virtual host limits.
+    <p class="Pp">Displays configured virtual host limits.</p>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#-global"><code class="Fl" title="Fl" id="-global">--global</code></a></dt>
-      <dd>Show limits for all vhosts. Suppresses the
-          <code class="Fl" title="Fl">-p</code> parameter.</dd>
+      <dt id="global"><a class="permalink" href="#global"><code class="Fl">--global</code></a></dt>
+      <dd>Show limits for all vhosts. Suppresses the <code class="Fl">-p</code>
+          parameter.</dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#restart_vhost"><code class="Cm" title="Cm" id="restart_vhost">restart_vhost</code></a>
-    <var class="Ar" title="Ar">vhost</var></dt>
+  <dt id="restart_vhost"><a class="permalink" href="#restart_vhost"><code class="Cm">restart_vhost</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
-      <dd>The name of the virtual host entry to restart.</dd>
+      <dt><var class="Ar">vhost</var></dt>
+      <dd>The name of the virtual host entry to restart, defaulting to
+          &quot;/&quot;.</dd>
     </dl>
-    <div class="Pp"></div>
-    Restarts a failed vhost data stores and queues.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to restart a virtual
-      host called &quot;test&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl restart_vhost
+    <p class="Pp">Restarts a failed vhost data stores and queues.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        restart a virtual host called &quot;test&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl restart_vhost
       test</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_vhost_limits"><code class="Cm" title="Cm" id="set_vhost_limits">set_vhost_limits</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">definition</var></dt>
+  <dt id="set_vhost_limits"><a class="permalink" href="#set_vhost_limits"><code class="Cm">set_vhost_limits</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">definition</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets virtual host limits.
+    <p class="Pp">Sets virtual host limits.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">definition</var></dt>
+      <dt><var class="Ar">definition</var></dt>
       <dd>The definition of the limits, as a JSON document. In most shells you
           are very likely to need to quote this.
-        <div class="Pp"></div>
-        Recognised limits are:
+        <p class="Pp">Recognised limits are:</p>
         <ul class="Bl-bullet Bl-compact">
           <li>max-connections</li>
           <li>max-queues</li>
         </ul>
-        <div class="Pp"></div>
-        Use a negative value to specify &quot;no limit&quot;.</dd>
+        <p class="Pp">Use a negative value to specify &quot;no limit&quot;.</p>
+      </dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command limits the max number of concurrent connections in
-      vhost &quot;qa_env&quot; to 64:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_vhost_limits -p
+    <p class="Pp">For example, this command limits the max number of concurrent
+        connections in vhost &quot;qa_env&quot; to 64:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_vhost_limits -p
       qa_env '{&quot;max-connections&quot;: 64}'</code></div>
-    <div class="Pp"></div>
-    This command limits the max number of queues in vhost &quot;qa_env&quot;
-      to 256:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_vhost_limits -p
+    <p class="Pp">This command limits the max number of queues in vhost
+        &quot;qa_env&quot; to 256:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_vhost_limits -p
       qa_env '{&quot;max-queues&quot;: 256}'</code></div>
-    <div class="Pp"></div>
-    This command clears the max number of connections limit in vhost
-      &quot;qa_env&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_vhost_limits -p
+    <p class="Pp">This command clears the max number of connections limit in
+        vhost &quot;qa_env&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_vhost_limits -p
       qa_env '{&quot;max-connections&quot;: -1}'</code></div>
-    <div class="Pp"></div>
-    This command disables client connections in vhost &quot;qa_env&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_vhost_limits -p
+    <p class="Pp">This command disables client connections in vhost
+        &quot;qa_env&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_vhost_limits -p
       qa_env '{&quot;max-connections&quot;: 0}'</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_user_limits"><code class="Cm" title="Cm" id="set_user_limits">set_user_limits</code></a>
-    <var class="Ar" title="Ar">username</var>
-    <var class="Ar" title="Ar">definition</var></dt>
+  <dt id="set_user_limits"><a class="permalink" href="#set_user_limits"><code class="Cm">set_user_limits</code></a>
+    <var class="Ar">username</var> <var class="Ar">definition</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets user limits.
+    <p class="Pp">Sets user limits.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user to apply limits to</dd>
-      <dt><var class="Ar" title="Ar">definition</var></dt>
+      <dt><var class="Ar">definition</var></dt>
       <dd>The definition of the limits, as a JSON document. In most shells you
           are very likely to need to quote this.
-        <div class="Pp"></div>
-        Recognised limits are:
+        <p class="Pp">Recognised limits are:</p>
         <ul class="Bl-bullet Bl-compact">
           <li>max-connections</li>
           <li>max-channels</li>
         </ul>
-        <div class="Pp"></div>
-        Use a negative value to specify &quot;no limit&quot;.</dd>
+        <p class="Pp">Use a negative value to specify &quot;no limit&quot;.</p>
+      </dd>
     </dl>
-    <div class="Pp"></div>
-    For example, this command limits the max number of concurrent connections a
-      user is allowed to open &quot;limited_user&quot; to 64:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_user_limits
+    <p class="Pp">For example, this command limits the max number of concurrent
+        connections a user is allowed to open &quot;limited_user&quot; to
+      64:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_user_limits
       limited_user '{&quot;max-connections&quot;: 64}'</code></div>
-    <div class="Pp"></div>
-    This command limits the max number of channels a user is allowed to open on
-      a connection &quot;limited_user&quot; to 16:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_user_limits
+    <p class="Pp">This command limits the max number of channels a user is
+        allowed to open on a connection &quot;limited_user&quot; to 16:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_user_limits
       limited_user '{&quot;max-channels&quot;: 16}'</code></div>
-    <div class="Pp"></div>
-    This command clears the max number of connections limit for user
-      &quot;limited_user&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_user_limits
+    <p class="Pp">This command clears the max number of connections limit for
+        user &quot;limited_user&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_user_limits
       limited_user 'max-connections'</code></div>
-    <div class="Pp"></div>
-    This command disables client connections for user
-      &quot;limited_user&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_user_limits
+    <p class="Pp">This command disables client connections for user
+        &quot;limited_user&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_user_limits
       limited_user '{&quot;max-connections&quot;: 0}'</code></div>
   </dd>
-  <dt><a class="permalink" href="#clear_user_limits"><code class="Cm" title="Cm" id="clear_user_limits">clear_user_limits</code></a>
-    <var class="Ar" title="Ar">username</var>
-    <var class="Ar" title="Ar">limit</var></dt>
+  <dt id="clear_user_limits"><a class="permalink" href="#clear_user_limits"><code class="Cm">clear_user_limits</code></a>
+    <var class="Ar">username</var> <var class="Ar">limit</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Clears user limits.
+    <p class="Pp">Clears user limits.</p>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">username</var></dt>
+      <dt><var class="Ar">username</var></dt>
       <dd>The name of the user to clear limits of</dd>
-      <dt><var class="Ar" title="Ar">limit</var></dt>
+      <dt><var class="Ar">limit</var></dt>
       <dd>The name of the limit or &quot;all&quot; to clear all limits at
         once.</dd>
     </dl>
-    <div class="Pp"></div>
-    Recognised limits are:
+    <p class="Pp">Recognised limits are:</p>
     <ul class="Bl-bullet Bl-compact">
       <li>max-connections</li>
       <li>max-channels</li>
     </ul>
-    <div class="Pp"></div>
-    For example, this command clears max connection limits of user
-      &quot;limited_user&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_user_limits
+    <p class="Pp">For example, this command clears max connection limits of user
+        &quot;limited_user&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_user_limits
       limited_user 'max-connections'</code></div>
-    <div class="Pp"></div>
-    This command clears all limits of user &quot;limited_user&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl clear_user_limits
+    <p class="Pp">This command clears all limits of user
+        &quot;limited_user&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl clear_user_limits
       limited_user all</code></div>
   </dd>
-  <dt><a class="permalink" href="#trace_off"><code class="Cm" title="Cm" id="trace_off">trace_off</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+  <dt id="trace_off"><a class="permalink" href="#trace_off"><code class="Cm">trace_off</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host for which to stop tracing.</dd>
     </dl>
-    <div class="Pp"></div>
-    Stops tracing.</dd>
-  <dt><a class="permalink" href="#trace_on"><code class="Cm" title="Cm" id="trace_on">trace_on</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]</dt>
+    <p class="Pp">Stops tracing.</p>
+  </dd>
+  <dt id="trace_on"><a class="permalink" href="#trace_on"><code class="Cm">trace_on</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">vhost</var></dt>
+      <dt><var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host for which to start tracing.</dd>
     </dl>
-    <div class="Pp"></div>
-    Starts tracing. Note that the trace state is not persistent; it will revert
-      to being off if the node is restarted.</dd>
+    <p class="Pp">Starts tracing. Note that the trace state is not persistent;
+        it will revert to being off if the node is restarted.</p>
+  </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Configuration"><a class="permalink" href="#Configuration">Configuration</a></h3>
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Configuration"><a class="permalink" href="#Configuration">Configuration</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#decode"><code class="Cm" title="Cm" id="decode">decode</code></a>
-    <var class="Ar" title="Ar">value</var>
-    <var class="Ar" title="Ar">passphrase</var>
-    [<div class="Op"><code class="Fl" title="Fl">--cipher</code>
-    <var class="Ar" title="Ar">cipher</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--hash</code>
-    <var class="Ar" title="Ar">hash</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--iterations</code>
-    <var class="Ar" title="Ar">iterations</var></div>]</dt>
+  <dt id="decode"><a class="permalink" href="#decode"><code class="Cm">decode</code></a>
+    <var class="Ar">value</var> <var class="Ar">passphrase</var>
+    [<code class="Fl">--cipher</code> <var class="Ar">cipher</var>]
+    [<code class="Fl">--hash</code> <var class="Ar">hash</var>]
+    [<code class="Fl">--iterations</code> <var class="Ar">iterations</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">value</var>
-        <var class="Ar" title="Ar">passphrase</var></dt>
+      <dt><var class="Ar">value</var> <var class="Ar">passphrase</var></dt>
       <dd>Value to decrypt (as produced by the encode command) and passphrase.
-        <div class="Pp"></div>
-        For example:
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl decode
+        <p class="Pp">For example:</p>
+        <p class="Pp"></p>
+        <div class=00><code class="Li">rabbitmqctl decode
           '{encrypted, &lt;&lt;&quot;...&quot;&gt;&gt;}'
           mypassphrase</code></div>
       </dd>
-      <dt><a class="permalink" href="#-cipher"><code class="Fl" title="Fl" id="-cipher">--cipher</code></a>
-        <var class="Ar" title="Ar">cipher</var>
-        <code class="Fl" title="Fl">--hash</code>
-        <var class="Ar" title="Ar">hash</var>
-        <code class="Fl" title="Fl">--iterations</code>
-        <var class="Ar" title="Ar">iterations</var></dt>
+      <dt id="cipher"><a class="permalink" href="#cipher"><code class="Fl">--cipher</code></a>
+        <var class="Ar">cipher</var> <code class="Fl">--hash</code>
+        <var class="Ar">hash</var> <code class="Fl">--iterations</code>
+        <var class="Ar">iterations</var></dt>
       <dd>Options to specify the decryption settings. They can be used
           independently.
-        <div class="Pp"></div>
-        For example:
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl decode --cipher
+        <p class="Pp">For example:</p>
+        <p class="Pp"></p>
+        <div class=00><code class="Li">rabbitmqctl decode --cipher
           blowfish_cfb64 --hash sha256 --iterations 10000
           '{encrypted,&lt;&lt;&quot;...&quot;&gt;&gt;} mypassphrase</code></div>
       </dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#encode"><code class="Cm" title="Cm" id="encode">encode</code></a>
-    <var class="Ar" title="Ar">value</var>
-    <var class="Ar" title="Ar">passphrase</var>
-    [<div class="Op"><code class="Fl" title="Fl">--cipher</code>
-    <var class="Ar" title="Ar">cipher</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--hash</code>
-    <var class="Ar" title="Ar">hash</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--iterations</code>
-    <var class="Ar" title="Ar">iterations</var></div>]</dt>
+  <dt id="encode"><a class="permalink" href="#encode"><code class="Cm">encode</code></a>
+    <var class="Ar">value</var> <var class="Ar">passphrase</var>
+    [<code class="Fl">--cipher</code> <var class="Ar">cipher</var>]
+    [<code class="Fl">--hash</code> <var class="Ar">hash</var>]
+    [<code class="Fl">--iterations</code> <var class="Ar">iterations</var>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">value</var>
-        <var class="Ar" title="Ar">passphrase</var></dt>
+      <dt><var class="Ar">value</var> <var class="Ar">passphrase</var></dt>
       <dd>Value to encrypt and passphrase.
-        <div class="Pp"></div>
-        For example:
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl encode
+        <p class="Pp">For example:</p>
+        <p class="Pp"></p>
+        <div class=00><code class="Li">rabbitmqctl encode
           '&lt;&lt;&quot;guest&quot;&gt;&gt;' mypassphrase</code></div>
       </dd>
-      <dt><a class="permalink" href="#-cipher_2"><code class="Fl" title="Fl" id="-cipher_2">--cipher</code></a>
-        <var class="Ar" title="Ar">cipher</var>
-        <code class="Fl" title="Fl">--hash</code>
-        <var class="Ar" title="Ar">hash</var>
-        <code class="Fl" title="Fl">--iterations</code>
-        <var class="Ar" title="Ar">iterations</var></dt>
+      <dt id="cipher~2"><a class="permalink" href="#cipher~2"><code class="Fl">--cipher</code></a>
+        <var class="Ar">cipher</var> <code class="Fl">--hash</code>
+        <var class="Ar">hash</var> <code class="Fl">--iterations</code>
+        <var class="Ar">iterations</var></dt>
       <dd>Options to specify the encryption settings. They can be used
           independently.
-        <div class="Pp"></div>
-        For example:
-        <div class="Pp"></div>
-        <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl encode --cipher
+        <p class="Pp">For example:</p>
+        <p class="Pp"></p>
+        <div class=00><code class="Li">rabbitmqctl encode --cipher
           blowfish_cfb64 --hash sha256 --iterations 10000
           '&lt;&lt;&quot;guest&quot;&gt;&gt;' mypassphrase</code></div>
       </dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#set_cluster_name"><code class="Cm" title="Cm" id="set_cluster_name">set_cluster_name</code></a>
-    <var class="Ar" title="Ar">name</var></dt>
+  <dt id="set_cluster_name"><a class="permalink" href="#set_cluster_name"><code class="Cm">set_cluster_name</code></a>
+    <var class="Ar">name</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Sets the cluster name to <var class="Ar" title="Ar">name</var>. The cluster
-      name is announced to clients on connection, and used by the federation and
-      shovel plugins to record where a message has been. The cluster name is by
-      default derived from the hostname of the first node in the cluster, but
-      can be changed.
-    <div class="Pp"></div>
-    For example, this sets the cluster name to &quot;london&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_cluster_name
+    <p class="Pp">Sets the cluster name to <var class="Ar">name</var>. The
+        cluster name is announced to clients on connection, and used by the
+        federation and shovel plugins to record where a message has been. The
+        cluster name is by default derived from the hostname of the first node
+        in the cluster, but can be changed.</p>
+    <p class="Pp">For example, this sets the cluster name to
+      &quot;london&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl set_cluster_name
       london</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_disk_free_limit"><code class="Cm" title="Cm" id="set_disk_free_limit">set_disk_free_limit</code></a>
-    <var class="Ar" title="Ar">disk_limit</var></dt>
+  <dt id="set_disk_free_limit"><a class="permalink" href="#set_disk_free_limit"><code class="Cm">set_disk_free_limit</code></a>
+    <var class="Ar">disk_limit</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">disk_limit</var></dt>
+      <dt><var class="Ar">disk_limit</var></dt>
       <dd>Lower bound limit as an integer in bytes or a string with memory unit
           symbols (see vm_memory_high_watermark), e.g. 512M or 1G. Once free
           disk space reaches the limit, a disk alarm will be set.</dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#set_disk_free_limit_mem_relative"><code class="Cm" title="Cm" id="set_disk_free_limit_mem_relative">set_disk_free_limit
-    mem_relative</code></a> <var class="Ar" title="Ar">fraction</var></dt>
+  <dt id="set_disk_free_limit~2"><a class="permalink" href="#set_disk_free_limit~2"><code class="Cm">set_disk_free_limit
+    mem_relative</code></a> <var class="Ar">fraction</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">fraction</var></dt>
+      <dt><var class="Ar">fraction</var></dt>
       <dd>Limit relative to the total amount available RAM as a non-negative
           floating point number. Values lower than 1.0 can be dangerous and
           should be used carefully.</dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#set_log_level"><code class="Cm" title="Cm" id="set_log_level">set_log_level</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">log_level</var></div>]</dt>
+  <dt id="set_log_level"><a class="permalink" href="#set_log_level"><code class="Cm">set_log_level</code></a>
+    [<var class="Ar">log_level</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Sets log level in the running node
-    <div class="Pp"></div>
-    Supported <var class="Ar" title="Ar">log_level</var> values are:
+    <p class="Pp">Sets log level in the running node</p>
+    <p class="Pp">Supported <var class="Ar">log_level</var> values are:</p>
     <ul class="Bl-bullet Bl-compact">
       <li>debug</li>
       <li>info</li>
@@ -2099,74 +1911,70 @@ Note that <code class="Nm" title="Nm">rabbitmqctl</code> manages the RabbitMQ
       <li>critical</li>
       <li>none</li>
     </ul>
-    <div class="Pp"></div>
-    Example:
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl set_log_level
+    <p class="Pp">Example:</p>
+    <div class=00><code class="Li">rabbitmqctl set_log_level
       debug</code></div>
   </dd>
-  <dt><a class="permalink" href="#set_vm_memory_high_watermark"><code class="Cm" title="Cm" id="set_vm_memory_high_watermark">set_vm_memory_high_watermark</code></a>
-    <var class="Ar" title="Ar">fraction</var></dt>
+  <dt id="set_vm_memory_high_watermark"><a class="permalink" href="#set_vm_memory_high_watermark"><code class="Cm">set_vm_memory_high_watermark</code></a>
+    <var class="Ar">fraction</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">fraction</var></dt>
+      <dt><var class="Ar">fraction</var></dt>
       <dd>The new memory threshold fraction at which flow control is triggered,
           as a floating point number greater than or equal to 0.</dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#set_vm_memory_high_watermark_2"><code class="Cm" title="Cm" id="set_vm_memory_high_watermark_2">set_vm_memory_high_watermark</code></a>
-    [<div class="Op">absolute</div>]
-    <var class="Ar" title="Ar">memory_limit</var></dt>
+  <dt id="set_vm_memory_high_watermark~2"><a class="permalink" href="#set_vm_memory_high_watermark~2"><code class="Cm">set_vm_memory_high_watermark</code></a>
+    [absolute] <var class="Ar">memory_limit</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">memory_limit</var></dt>
+      <dt><var class="Ar">memory_limit</var></dt>
       <dd>The new memory limit at which flow control is triggered, expressed in
           bytes as an integer number greater than or equal to 0 or as a string
           with memory unit symbol(e.g. 512M or 1G). Available unit symbols are:
         <dl class="Bl-tag">
-          <dt><a class="permalink" href="#k"><code class="Cm" title="Cm" id="k">k</code></a>,
-            <code class="Cm" title="Cm">kiB</code></dt>
+          <dt id="k"><a class="permalink" href="#k"><code class="Cm">k</code></a>,
+            <code class="Cm">kiB</code></dt>
           <dd>kibibytes (2^10 bytes)</dd>
-          <dt><a class="permalink" href="#M"><code class="Cm" title="Cm" id="M">M</code></a>,
-            <code class="Cm" title="Cm">MiB</code></dt>
+          <dt id="M"><a class="permalink" href="#M"><code class="Cm">M</code></a>,
+            <code class="Cm">MiB</code></dt>
           <dd>mebibytes (2^20 bytes)</dd>
-          <dt><a class="permalink" href="#G"><code class="Cm" title="Cm" id="G">G</code></a>,
-            <code class="Cm" title="Cm">GiB</code></dt>
+          <dt id="G"><a class="permalink" href="#G"><code class="Cm">G</code></a>,
+            <code class="Cm">GiB</code></dt>
           <dd>gibibytes (2^30 bytes)</dd>
-          <dt><a class="permalink" href="#kB"><code class="Cm" title="Cm" id="kB">kB</code></a></dt>
+          <dt id="kB"><a class="permalink" href="#kB"><code class="Cm">kB</code></a></dt>
           <dd>kilobytes (10^3 bytes)</dd>
-          <dt><a class="permalink" href="#MB"><code class="Cm" title="Cm" id="MB">MB</code></a></dt>
+          <dt id="MB"><a class="permalink" href="#MB"><code class="Cm">MB</code></a></dt>
           <dd>megabytes (10^6 bytes)</dd>
-          <dt><a class="permalink" href="#GB"><code class="Cm" title="Cm" id="GB">GB</code></a></dt>
+          <dt id="GB"><a class="permalink" href="#GB"><code class="Cm">GB</code></a></dt>
           <dd>gigabytes (10^9 bytes)</dd>
         </dl>
       </dd>
     </dl>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Feature_flags"><a class="permalink" href="#Feature_flags">Feature
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Feature_flags"><a class="permalink" href="#Feature_flags">Feature
   flags</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#enable_feature_flag"><code class="Cm" title="Cm" id="enable_feature_flag">enable_feature_flag</code></a>
-    <var class="Ar" title="Ar">feature_flag</var></dt>
+  <dt id="enable_feature_flag"><a class="permalink" href="#enable_feature_flag"><code class="Cm">enable_feature_flag</code></a>
+    <var class="Ar">feature_flag</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Enables a feature flag on the target node.
-    <div class="Pp"></div>
-    Example:
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl enable_feature_flag
+    <p class="Pp">Enables a feature flag on the target node.</p>
+    <p class="Pp">Example:</p>
+    <div class=00><code class="Li">rabbitmqctl enable_feature_flag
       stream_queue</code></div>
-    <div class="Pp"></div>
-    You can also enable all feature flags by specifying &quot;all&quot;:
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl enable_feature_flag
+    <p class="Pp">You can also enable all feature flags by specifying
+        &quot;all&quot;:</p>
+    <div class=00><code class="Li">rabbitmqctl enable_feature_flag
       all</code></div>
   </dd>
-  <dt><a class="permalink" href="#list_feature_flags"><code class="Cm" title="Cm" id="list_feature_flags">list_feature_flags</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">column ...</var></div>]</dt>
+  <dt id="list_feature_flags"><a class="permalink" href="#list_feature_flags"><code class="Cm">list_feature_flags</code></a>
+    [<var class="Ar">column ...</var>]</dt>
   <dd>
-    <div class="Pp"></div>
-    Lists feature flags
-    <div class="Pp"></div>
-    Supported <var class="Ar" title="Ar">column</var> values are:
+    <p class="Pp">Lists feature flags</p>
+    <p class="Pp">Supported <var class="Ar">column</var> values are:</p>
     <ul class="Bl-bullet Bl-compact">
       <li>name</li>
       <li>state</li>
@@ -2175,192 +1983,189 @@ Note that <code class="Nm" title="Nm">rabbitmqctl</code> manages the RabbitMQ
       <li>desc</li>
       <li>doc_url</li>
     </ul>
-    <div class="Pp"></div>
-    Example:
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl list_feature_flags
+    <p class="Pp">Example:</p>
+    <div class=00><code class="Li">rabbitmqctl list_feature_flags
       name state</code></div>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Connection_Operations"><a class="permalink" href="#Connection_Operations">Connection
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Connection_Operations"><a class="permalink" href="#Connection_Operations">Connection
   Operations</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#close_all_connections"><code class="Cm" title="Cm" id="close_all_connections">close_all_connections</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--global</code></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--per-connection-delay</code>
-    <var class="Ar" title="Ar">delay</var></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--limit</code>
-    <var class="Ar" title="Ar">limit</var></div>]
-    <var class="Ar" title="Ar">explanation</var></dt>
+  <dt id="close_all_connections"><a class="permalink" href="#close_all_connections"><code class="Cm">close_all_connections</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    [<code class="Fl">--global</code>]
+    [<code class="Fl">--per-connection-delay</code> <var class="Ar">delay</var>]
+    [<code class="Fl">--limit</code> <var class="Ar">limit</var>]
+    <var class="Ar">explanation</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#p"><code class="Fl" title="Fl" id="p">-p</code></a>
-        <var class="Ar" title="Ar">vhost</var></dt>
+      <dt id="p"><a class="permalink" href="#p"><code class="Fl">-p</code></a>
+        <var class="Ar">vhost</var></dt>
       <dd>The name of the virtual host for which connections should be closed.
-          Ignored when <code class="Fl" title="Fl">--global</code> is
-        specified.</dd>
-      <dt><a class="permalink" href="#-global_2"><code class="Fl" title="Fl" id="-global_2">--global</code></a></dt>
+          Ignored when <code class="Fl">--global</code> is specified.</dd>
+      <dt id="global~2"><a class="permalink" href="#global~2"><code class="Fl">--global</code></a></dt>
       <dd>If connections should be close for all vhosts. Overrides
-          <code class="Fl" title="Fl">-p</code></dd>
-      <dt><a class="permalink" href="#-per-connection-delay"><code class="Fl" title="Fl" id="-per-connection-delay">--per-connection-delay</code></a>
-        <var class="Ar" title="Ar">delay</var></dt>
+          <code class="Fl">-p</code></dd>
+      <dt id="per-connection-delay"><a class="permalink" href="#per-connection-delay"><code class="Fl">--per-connection-delay</code></a>
+        <var class="Ar">delay</var></dt>
       <dd>Time in milliseconds to wait after each connection closing.</dd>
-      <dt><a class="permalink" href="#-limit"><code class="Fl" title="Fl" id="-limit">--limit</code></a>
-        <var class="Ar" title="Ar">limit</var></dt>
+      <dt id="limit"><a class="permalink" href="#limit"><code class="Fl">--limit</code></a>
+        <var class="Ar">limit</var></dt>
       <dd>Number of connection to close. Only works per vhost. Ignored when
-          <code class="Fl" title="Fl">--global</code> is specified.</dd>
-      <dt><var class="Ar" title="Ar">explanation</var></dt>
+          <code class="Fl">--global</code> is specified.</dd>
+      <dt><var class="Ar">explanation</var></dt>
       <dd>Explanation string.</dd>
     </dl>
-    <div class="Pp"></div>
-    Instructs the broker to close all connections for the specified vhost or
-      entire RabbitMQ node.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to close 10
-      connections on &quot;qa_env&quot; vhost, passing the explanation
-      &quot;Please close&quot;:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl close_all_connections
+    <p class="Pp">Instructs the broker to close all connections for the
+        specified vhost or entire RabbitMQ node.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        close 10 connections on &quot;qa_env&quot; vhost, passing the
+        explanation &quot;Please close&quot;:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl close_all_connections
       -p qa_env --limit 10 'Please close'</code></div>
-    <div class="Pp"></div>
-    This command instructs broker to close all connections to the node:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl close_all_connections
+    <p class="Pp">This command instructs broker to close all connections to the
+        node:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl close_all_connections
       --global</code></div>
-    <div class="Pp"></div>
+    <p class="Pp"></p>
   </dd>
-  <dt><a class="permalink" href="#close_connection"><code class="Cm" title="Cm" id="close_connection">close_connection</code></a>
-    <var class="Ar" title="Ar">connectionpid</var>
-    <var class="Ar" title="Ar">explanation</var></dt>
+  <dt id="close_connection"><a class="permalink" href="#close_connection"><code class="Cm">close_connection</code></a>
+    <var class="Ar">connectionpid</var> <var class="Ar">explanation</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">connectionpid</var></dt>
+      <dt><var class="Ar">connectionpid</var></dt>
       <dd>Id of the Erlang process associated with the connection to close.</dd>
-      <dt><var class="Ar" title="Ar">explanation</var></dt>
+      <dt><var class="Ar">explanation</var></dt>
       <dd>Explanation string.</dd>
     </dl>
-    <div class="Pp"></div>
-    Instructs the broker to close the connection associated with the Erlang
-      process id <var class="Ar" title="Ar">connectionpid</var> (see also the
-      <code class="Cm" title="Cm">list_connections</code> command), passing the
-      <var class="Ar" title="Ar">explanation</var> string to the connected
-      client as part of the AMQP connection shutdown protocol.
-    <div class="Pp"></div>
-    For example, this command instructs the RabbitMQ broker to close the
-      connection associated with the Erlang process id
-      &quot;&lt;rabbit@tanto.4262.0&gt;&quot;, passing the explanation
-      &quot;go away&quot; to the connected client:
-    <div class="Pp"></div>
-    <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmqctl close_connection
-      &quot;&lt;rabbit@tanto.4262.0&gt;&quot; &quot;go
-      away&quot;</code></div>
+    <p class="Pp">Instructs the broker to close the connection associated with
+        the Erlang process id <var class="Ar">connectionpid</var> (see also the
+        <code class="Cm">list_connections</code> command), passing the
+        <var class="Ar">explanation</var> string to the connected client as part
+        of the AMQP connection shutdown protocol.</p>
+    <p class="Pp">For example, this command instructs the RabbitMQ broker to
+        close the connection associated with the Erlang process id
+        &quot;&lt;rabbit@tanto.4262.0&gt;&quot;, passing the explanation
+        &quot;go away&quot; to the connected client:</p>
+    <p class="Pp"></p>
+    <div class=00><code class="Li">rabbitmqctl close_connection
+      &quot;&lt;rabbit@tanto.4262.0&gt;&quot; &quot;go away&quot;</code></div>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Misc"><a class="permalink" href="#Misc">Misc</a></h3>
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Misc"><a class="permalink" href="#Misc">Misc</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#eval"><code class="Cm" title="Cm" id="eval">eval</code></a>
-    <var class="Ar" title="Ar">expression</var></dt>
+  <dt id="eval"><a class="permalink" href="#eval"><code class="Cm">eval</code></a>
+    <var class="Ar">expression</var></dt>
   <dd>
-    <div class="Pp"></div>
-    Evaluates an Erlang expression on the target node</dd>
+    <p class="Pp">Evaluates an Erlang expression on the target node</p>
+  </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Queue_Operations"><a class="permalink" href="#Queue_Operations">Queue
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Queue_Operations"><a class="permalink" href="#Queue_Operations">Queue
   Operations</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#delete_queue"><code class="Cm" title="Cm" id="delete_queue">delete_queue</code></a>
-    <var class="Ar" title="Ar">queue_name</var>
-    [<div class="Op"><code class="Fl" title="Fl">--if-empty</code> |
-    <code class="Fl" title="Fl">-e</code></div>]
-    [<div class="Op"><code class="Fl" title="Fl">--if-unused</code> |
-    <code class="Fl" title="Fl">-u</code></div>]</dt>
+  <dt id="delete_queue"><a class="permalink" href="#delete_queue"><code class="Cm">delete_queue</code></a>
+    <var class="Ar">queue_name</var> [<code class="Fl">--if-empty</code> |
+    <code class="Fl">-e</code>] [<code class="Fl">--if-unused</code> |
+    <code class="Fl">-u</code>]</dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">queue_name</var></dt>
+      <dt><var class="Ar">queue_name</var></dt>
       <dd>The name of the queue to delete.</dd>
-      <dt><var class="Ar" title="Ar">--if-empty</var></dt>
+      <dt><var class="Ar">--if-empty</var></dt>
       <dd>Delete the queue if it is empty (has no messages ready for
         delivery)</dd>
-      <dt><var class="Ar" title="Ar">--if-unused</var></dt>
+      <dt><var class="Ar">--if-unused</var></dt>
       <dd>Delete the queue only if it has no consumers</dd>
     </dl>
-    <div class="Pp"></div>
-    Deletes a queue.</dd>
-  <dt><a class="permalink" href="#purge_queue"><code class="Cm" title="Cm" id="purge_queue">purge_queue</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">queue</var></dt>
+    <p class="Pp">Deletes a queue.</p>
+  </dd>
+  <dt id="purge_queue"><a class="permalink" href="#purge_queue"><code class="Cm">purge_queue</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">queue</var></dt>
   <dd>
     <dl class="Bl-tag">
-      <dt><var class="Ar" title="Ar">queue</var></dt>
+      <dt><var class="Ar">queue</var></dt>
       <dd>The name of the queue to purge.</dd>
     </dl>
-    <div class="Pp"></div>
-    Purges a queue (removes all messages in it).</dd>
+    <p class="Pp">Purges a queue (removes all messages in it).</p>
+  </dd>
 </dl>
-<h2 class="Sh" title="Sh" id="PLUGIN_COMMANDS"><a class="permalink" href="#PLUGIN_COMMANDS">PLUGIN
+</section>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="PLUGIN_COMMANDS"><a class="permalink" href="#PLUGIN_COMMANDS">PLUGIN
   COMMANDS</a></h2>
-RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
-  Currently available commands can be found in
-  <code class="Cm" title="Cm">rabbitmqctl help</code> output. Following commands
-  are added by RabbitMQ plugins, available in default distribution:
-<h3 class="Ss" title="Ss" id="Shovel_plugin"><a class="permalink" href="#Shovel_plugin">Shovel
+<p class="Pp">RabbitMQ plugins can extend rabbitmqctl tool to add new commands
+    when enabled. Currently available commands can be found in
+    <code class="Cm">rabbitmqctl help</code> output. Following commands are
+    added by RabbitMQ plugins, available in default distribution:</p>
+<section class="Ss">
+<h3 class="Ss" id="Shovel_plugin"><a class="permalink" href="#Shovel_plugin">Shovel
   plugin</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#shovel_status"><code class="Cm" title="Cm" id="shovel_status">shovel_status</code></a></dt>
+  <dt id="shovel_status"><a class="permalink" href="#shovel_status"><code class="Cm">shovel_status</code></a></dt>
   <dd>Prints a list of configured Shovels</dd>
-  <dt><a class="permalink" href="#delete_shovel"><code class="Cm" title="Cm" id="delete_shovel">delete_shovel</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">-p</code>
-    <var class="Ar" title="Ar">vhost</var></div>]
-    <var class="Ar" title="Ar">name</var></dt>
+  <dt id="delete_shovel"><a class="permalink" href="#delete_shovel"><code class="Cm">delete_shovel</code></a>
+    [<code class="Fl">-p</code> <var class="Ar">vhost</var>]
+    <var class="Ar">name</var></dt>
   <dd>Instructs the RabbitMQ node to delete the configured shovel by
-      <var class="Ar" title="Ar">name</var>.</dd>
+      <var class="Ar">name</var>.</dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Federation_plugin"><a class="permalink" href="#Federation_plugin">Federation
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Federation_plugin"><a class="permalink" href="#Federation_plugin">Federation
   plugin</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#federation_status"><code class="Cm" title="Cm" id="federation_status">federation_status</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">--only-down</code></div>]</dt>
+  <dt id="federation_status"><a class="permalink" href="#federation_status"><code class="Cm">federation_status</code></a>
+    [<code class="Fl">--only-down</code>]</dt>
   <dd>Prints a list of federation links.
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#-only-down"><code class="Fl" title="Fl" id="-only-down">--only-down</code></a></dt>
+      <dt id="only-down"><a class="permalink" href="#only-down"><code class="Fl">--only-down</code></a></dt>
       <dd>Only list federation links which are not running.</dd>
     </dl>
   </dd>
-  <dt><a class="permalink" href="#restart_federation_link"><code class="Cm" title="Cm" id="restart_federation_link">restart_federation_link</code></a>
-    <var class="Ar" title="Ar">link_id</var></dt>
+  <dt id="restart_federation_link"><a class="permalink" href="#restart_federation_link"><code class="Cm">restart_federation_link</code></a>
+    <var class="Ar">link_id</var></dt>
   <dd>Instructs the RabbitMQ node to restart the federation link with specified
-      <var class="Ar" title="Ar">link_id</var>.</dd>
+      <var class="Ar">link_id</var>.</dd>
 </dl>
-<h3 class="Ss" title="Ss" id="AMQP_1.0_plugin"><a class="permalink" href="#AMQP_1.0_plugin">AMQP
+</section>
+<section class="Ss">
+<h3 class="Ss" id="AMQP_1.0_plugin"><a class="permalink" href="#AMQP_1.0_plugin">AMQP
   1.0 plugin</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#list_amqp10_connections"><code class="Cm" title="Cm" id="list_amqp10_connections">list_amqp10_connections</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">amqp10_connectioninfoitem
-    ...</var></div>]</dt>
-  <dd>Similar to the <code class="Cm" title="Cm">list_connections</code>
-      command, but returns fields which make sense for AMQP-1.0 connections.
-      <var class="Ar" title="Ar">amqp10_connectioninfoitem</var> parameter is
-      used to indicate which connection information items to include in the
-      results. The column order in the results will match the order of the
-      parameters. <var class="Ar" title="Ar">amqp10_connectioninfoitem</var> can
-      take any value from the list that follows:
+  <dt id="list_amqp10_connections"><a class="permalink" href="#list_amqp10_connections"><code class="Cm">list_amqp10_connections</code></a>
+    [<var class="Ar">amqp10_connectioninfoitem ...</var>]</dt>
+  <dd>Similar to the <code class="Cm">list_connections</code> command, but
+      returns fields which make sense for AMQP-1.0 connections.
+      <var class="Ar">amqp10_connectioninfoitem</var> parameter is used to
+      indicate which connection information items to include in the results. The
+      column order in the results will match the order of the parameters.
+      <var class="Ar">amqp10_connectioninfoitem</var> can take any value from
+      the list that follows:
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#pid_4"><code class="Cm" title="Cm" id="pid_4">pid</code></a></dt>
+      <dt id="pid~5"><a class="permalink" href="#pid~5"><code class="Cm">pid</code></a></dt>
       <dd>Id of the Erlang process associated with the connection.</dd>
-      <dt><a class="permalink" href="#auth_mechanism_2"><code class="Cm" title="Cm" id="auth_mechanism_2">auth_mechanism</code></a></dt>
-      <dd>SASL authentication mechanism used, such as
-        &quot;PLAIN&quot;.</dd>
-      <dt><a class="permalink" href="#host_2"><code class="Cm" title="Cm" id="host_2">host</code></a></dt>
+      <dt id="auth_mechanism~2"><a class="permalink" href="#auth_mechanism~2"><code class="Cm">auth_mechanism</code></a></dt>
+      <dd>SASL authentication mechanism used, such as &quot;PLAIN&quot;.</dd>
+      <dt id="host~2"><a class="permalink" href="#host~2"><code class="Cm">host</code></a></dt>
       <dd>Server hostname obtained via reverse DNS, or its IP address if reverse
-          DNS failed or was disabled.</dd>
-      <dt><a class="permalink" href="#frame_max_2"><code class="Cm" title="Cm" id="frame_max_2">frame_max</code></a></dt>
+          DNS failed or was turned off.</dd>
+      <dt id="frame_max~2"><a class="permalink" href="#frame_max~2"><code class="Cm">frame_max</code></a></dt>
       <dd>Maximum frame size (bytes).</dd>
-      <dt><a class="permalink" href="#timeout_2"><code class="Cm" title="Cm" id="timeout_2">timeout</code></a></dt>
+      <dt id="timeout~2"><a class="permalink" href="#timeout~2"><code class="Cm">timeout</code></a></dt>
       <dd>Connection timeout / negotiated heartbeat interval, in seconds.</dd>
-      <dt><a class="permalink" href="#user_3"><code class="Cm" title="Cm" id="user_3">user</code></a></dt>
+      <dt id="user~3"><a class="permalink" href="#user~3"><code class="Cm">user</code></a></dt>
       <dd>Username associated with the connection.</dd>
-      <dt><a class="permalink" href="#state_3"><code class="Cm" title="Cm" id="state_3">state</code></a></dt>
+      <dt id="state~3"><a class="permalink" href="#state~3"><code class="Cm">state</code></a></dt>
       <dd>Connection state; one of:
         <ul class="Bl-bullet Bl-compact">
           <li>starting</li>
@@ -2373,60 +2178,62 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
           <li>closed</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#recv_oct_2"><code class="Cm" title="Cm" id="recv_oct_2">recv_oct</code></a></dt>
+      <dt id="recv_oct~2"><a class="permalink" href="#recv_oct~2"><code class="Cm">recv_oct</code></a></dt>
       <dd>Octets received.</dd>
-      <dt><a class="permalink" href="#recv_cnt_2"><code class="Cm" title="Cm" id="recv_cnt_2">recv_cnt</code></a></dt>
+      <dt id="recv_cnt~2"><a class="permalink" href="#recv_cnt~2"><code class="Cm">recv_cnt</code></a></dt>
       <dd>Packets received.</dd>
-      <dt><a class="permalink" href="#send_oct_2"><code class="Cm" title="Cm" id="send_oct_2">send_oct</code></a></dt>
+      <dt id="send_oct~2"><a class="permalink" href="#send_oct~2"><code class="Cm">send_oct</code></a></dt>
       <dd>Octets send.</dd>
-      <dt><a class="permalink" href="#send_cnt_2"><code class="Cm" title="Cm" id="send_cnt_2">send_cnt</code></a></dt>
+      <dt id="send_cnt~2"><a class="permalink" href="#send_cnt~2"><code class="Cm">send_cnt</code></a></dt>
       <dd>Packets sent.</dd>
-      <dt><a class="permalink" href="#ssl_2"><code class="Cm" title="Cm" id="ssl_2">ssl</code></a></dt>
+      <dt id="ssl~2"><a class="permalink" href="#ssl~2"><code class="Cm">ssl</code></a></dt>
       <dd>Boolean indicating whether the connection is secured with SSL.</dd>
-      <dt><a class="permalink" href="#ssl_protocol_2"><code class="Cm" title="Cm" id="ssl_protocol_2">ssl_protocol</code></a></dt>
+      <dt id="ssl_protocol~2"><a class="permalink" href="#ssl_protocol~2"><code class="Cm">ssl_protocol</code></a></dt>
       <dd>SSL protocol (e.g. &quot;tlsv1&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_key_exchange_2"><code class="Cm" title="Cm" id="ssl_key_exchange_2">ssl_key_exchange</code></a></dt>
+      <dt id="ssl_key_exchange~2"><a class="permalink" href="#ssl_key_exchange~2"><code class="Cm">ssl_key_exchange</code></a></dt>
       <dd>SSL key exchange algorithm (e.g. &quot;rsa&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_cipher_2"><code class="Cm" title="Cm" id="ssl_cipher_2">ssl_cipher</code></a></dt>
+      <dt id="ssl_cipher~2"><a class="permalink" href="#ssl_cipher~2"><code class="Cm">ssl_cipher</code></a></dt>
       <dd>SSL cipher algorithm (e.g. &quot;aes_256_cbc&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_hash_2"><code class="Cm" title="Cm" id="ssl_hash_2">ssl_hash</code></a></dt>
+      <dt id="ssl_hash~2"><a class="permalink" href="#ssl_hash~2"><code class="Cm">ssl_hash</code></a></dt>
       <dd>SSL hash function (e.g. &quot;sha&quot;).</dd>
-      <dt><a class="permalink" href="#peer_cert_subject_2"><code class="Cm" title="Cm" id="peer_cert_subject_2">peer_cert_subject</code></a></dt>
+      <dt id="peer_cert_subject~2"><a class="permalink" href="#peer_cert_subject~2"><code class="Cm">peer_cert_subject</code></a></dt>
       <dd>The subject of the peer's SSL certificate, in RFC4514 form.</dd>
-      <dt><a class="permalink" href="#peer_cert_issuer_2"><code class="Cm" title="Cm" id="peer_cert_issuer_2">peer_cert_issuer</code></a></dt>
+      <dt id="peer_cert_issuer~2"><a class="permalink" href="#peer_cert_issuer~2"><code class="Cm">peer_cert_issuer</code></a></dt>
       <dd>The issuer of the peer's SSL certificate, in RFC4514 form.</dd>
-      <dt><a class="permalink" href="#peer_cert_validity_2"><code class="Cm" title="Cm" id="peer_cert_validity_2">peer_cert_validity</code></a></dt>
+      <dt id="peer_cert_validity~2"><a class="permalink" href="#peer_cert_validity~2"><code class="Cm">peer_cert_validity</code></a></dt>
       <dd>The period for which the peer's SSL certificate is valid.</dd>
-      <dt><a class="permalink" href="#node"><code class="Cm" title="Cm" id="node">node</code></a></dt>
+      <dt id="node"><a class="permalink" href="#node"><code class="Cm">node</code></a></dt>
       <dd>The node name of the RabbitMQ node to which connection is
         established.</dd>
     </dl>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="MQTT_plugin"><a class="permalink" href="#MQTT_plugin">MQTT
+</section>
+<section class="Ss">
+<h3 class="Ss" id="MQTT_plugin"><a class="permalink" href="#MQTT_plugin">MQTT
   plugin</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#list_mqtt_connections"><code class="Cm" title="Cm" id="list_mqtt_connections">list_mqtt_connections</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">mqtt_connectioninfoitem</var></div>]</dt>
-  <dd>Similar to the <code class="Cm" title="Cm">list_connections</code>
-      command, but returns fields which make sense for MQTT connections.
-      <var class="Ar" title="Ar">mqtt_connectioninfoitem</var> parameter is used
-      to indicate which connection information items to include in the results.
-      The column order in the results will match the order of the parameters.
-      <var class="Ar" title="Ar">mqtt_connectioninfoitem</var> can take any
-      value from the list that follows:
+  <dt id="list_mqtt_connections"><a class="permalink" href="#list_mqtt_connections"><code class="Cm">list_mqtt_connections</code></a>
+    [<var class="Ar">mqtt_connectioninfoitem</var>]</dt>
+  <dd>Similar to the <code class="Cm">list_connections</code> command, but
+      returns fields which make sense for MQTT connections.
+      <var class="Ar">mqtt_connectioninfoitem</var> parameter is used to
+      indicate which connection information items to include in the results. The
+      column order in the results will match the order of the parameters.
+      <var class="Ar">mqtt_connectioninfoitem</var> can take any value from the
+      list that follows:
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#host_3"><code class="Cm" title="Cm" id="host_3">host</code></a></dt>
+      <dt id="host~3"><a class="permalink" href="#host~3"><code class="Cm">host</code></a></dt>
       <dd>Server hostname obtained via reverse DNS, or its IP address if reverse
-          DNS failed or was disabled.</dd>
-      <dt><a class="permalink" href="#port_2"><code class="Cm" title="Cm" id="port_2">port</code></a></dt>
+          DNS failed or was turned off.</dd>
+      <dt id="port~2"><a class="permalink" href="#port~2"><code class="Cm">port</code></a></dt>
       <dd>Server port.</dd>
-      <dt><a class="permalink" href="#peer_host_2"><code class="Cm" title="Cm" id="peer_host_2">peer_host</code></a></dt>
+      <dt id="peer_host~2"><a class="permalink" href="#peer_host~2"><code class="Cm">peer_host</code></a></dt>
       <dd>Peer hostname obtained via reverse DNS, or its IP address if reverse
           DNS failed or was not enabled.</dd>
-      <dt><a class="permalink" href="#peer_port_2"><code class="Cm" title="Cm" id="peer_port_2">peer_port</code></a></dt>
+      <dt id="peer_port~2"><a class="permalink" href="#peer_port~2"><code class="Cm">peer_port</code></a></dt>
       <dd>Peer port.</dd>
-      <dt><a class="permalink" href="#protocol_2"><code class="Cm" title="Cm" id="protocol_2">protocol</code></a></dt>
+      <dt id="protocol~2"><a class="permalink" href="#protocol~2"><code class="Cm">protocol</code></a></dt>
       <dd>MQTT protocol version, which can be on of the following:
         <ul class="Bl-bullet Bl-compact">
           <li>{'MQTT', N/A}</li>
@@ -2434,28 +2241,28 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
           <li>{'MQTT', 3.1.1}</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#channels_2"><code class="Cm" title="Cm" id="channels_2">channels</code></a></dt>
+      <dt id="channels~2"><a class="permalink" href="#channels~2"><code class="Cm">channels</code></a></dt>
       <dd>Number of channels using the connection.</dd>
-      <dt><a class="permalink" href="#channel_max_2"><code class="Cm" title="Cm" id="channel_max_2">channel_max</code></a></dt>
+      <dt id="channel_max~2"><a class="permalink" href="#channel_max~2"><code class="Cm">channel_max</code></a></dt>
       <dd>Maximum number of channels on this connection.</dd>
-      <dt><a class="permalink" href="#frame_max_3"><code class="Cm" title="Cm" id="frame_max_3">frame_max</code></a></dt>
+      <dt id="frame_max~3"><a class="permalink" href="#frame_max~3"><code class="Cm">frame_max</code></a></dt>
       <dd>Maximum frame size (bytes).</dd>
-      <dt><a class="permalink" href="#client_properties_2"><code class="Cm" title="Cm" id="client_properties_2">client_properties</code></a></dt>
+      <dt id="client_properties~2"><a class="permalink" href="#client_properties~2"><code class="Cm">client_properties</code></a></dt>
       <dd>Informational properties transmitted by the client during connection
           establishment.</dd>
-      <dt><a class="permalink" href="#ssl_3"><code class="Cm" title="Cm" id="ssl_3">ssl</code></a></dt>
+      <dt id="ssl~3"><a class="permalink" href="#ssl~3"><code class="Cm">ssl</code></a></dt>
       <dd>Boolean indicating whether the connection is secured with SSL.</dd>
-      <dt><a class="permalink" href="#ssl_protocol_3"><code class="Cm" title="Cm" id="ssl_protocol_3">ssl_protocol</code></a></dt>
+      <dt id="ssl_protocol~3"><a class="permalink" href="#ssl_protocol~3"><code class="Cm">ssl_protocol</code></a></dt>
       <dd>SSL protocol (e.g. &quot;tlsv1&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_key_exchange_3"><code class="Cm" title="Cm" id="ssl_key_exchange_3">ssl_key_exchange</code></a></dt>
+      <dt id="ssl_key_exchange~3"><a class="permalink" href="#ssl_key_exchange~3"><code class="Cm">ssl_key_exchange</code></a></dt>
       <dd>SSL key exchange algorithm (e.g. &quot;rsa&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_cipher_3"><code class="Cm" title="Cm" id="ssl_cipher_3">ssl_cipher</code></a></dt>
+      <dt id="ssl_cipher~3"><a class="permalink" href="#ssl_cipher~3"><code class="Cm">ssl_cipher</code></a></dt>
       <dd>SSL cipher algorithm (e.g. &quot;aes_256_cbc&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_hash_3"><code class="Cm" title="Cm" id="ssl_hash_3">ssl_hash</code></a></dt>
+      <dt id="ssl_hash~3"><a class="permalink" href="#ssl_hash~3"><code class="Cm">ssl_hash</code></a></dt>
       <dd>SSL hash function (e.g. &quot;sha&quot;).</dd>
-      <dt><a class="permalink" href="#conn_name"><code class="Cm" title="Cm" id="conn_name">conn_name</code></a></dt>
+      <dt id="conn_name"><a class="permalink" href="#conn_name"><code class="Cm">conn_name</code></a></dt>
       <dd>Readable name for the connection.</dd>
-      <dt><a class="permalink" href="#connection_state"><code class="Cm" title="Cm" id="connection_state">connection_state</code></a></dt>
+      <dt id="connection_state"><a class="permalink" href="#connection_state"><code class="Cm">connection_state</code></a></dt>
       <dd>Connection state; one of:
         <ul class="Bl-bullet Bl-compact">
           <li>starting</li>
@@ -2463,53 +2270,55 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
           <li>blocked</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#connection_2"><code class="Cm" title="Cm" id="connection_2">connection</code></a></dt>
+      <dt id="connection~2"><a class="permalink" href="#connection~2"><code class="Cm">connection</code></a></dt>
       <dd>Id of the Erlang process associated with the internal amqp direct
           connection.</dd>
-      <dt><a class="permalink" href="#consumer_tags"><code class="Cm" title="Cm" id="consumer_tags">consumer_tags</code></a></dt>
+      <dt id="consumer_tags"><a class="permalink" href="#consumer_tags"><code class="Cm">consumer_tags</code></a></dt>
       <dd>A tuple of consumer tags for QOS0 and QOS1.</dd>
-      <dt><a class="permalink" href="#message_id"><code class="Cm" title="Cm" id="message_id">message_id</code></a></dt>
+      <dt id="message_id"><a class="permalink" href="#message_id"><code class="Cm">message_id</code></a></dt>
       <dd>The last Packet ID sent in a control message.</dd>
-      <dt><a class="permalink" href="#client_id"><code class="Cm" title="Cm" id="client_id">client_id</code></a></dt>
+      <dt id="client_id"><a class="permalink" href="#client_id"><code class="Cm">client_id</code></a></dt>
       <dd>MQTT client identifier for the connection.</dd>
-      <dt><a class="permalink" href="#clean_sess"><code class="Cm" title="Cm" id="clean_sess">clean_sess</code></a></dt>
+      <dt id="clean_sess"><a class="permalink" href="#clean_sess"><code class="Cm">clean_sess</code></a></dt>
       <dd>MQTT clean session flag.</dd>
-      <dt><a class="permalink" href="#will_msg"><code class="Cm" title="Cm" id="will_msg">will_msg</code></a></dt>
+      <dt id="will_msg"><a class="permalink" href="#will_msg"><code class="Cm">will_msg</code></a></dt>
       <dd>MQTT Will message sent in CONNECT frame.</dd>
-      <dt><a class="permalink" href="#exchange"><code class="Cm" title="Cm" id="exchange">exchange</code></a></dt>
+      <dt id="exchange"><a class="permalink" href="#exchange"><code class="Cm">exchange</code></a></dt>
       <dd>Exchange to route MQTT messages configured in rabbitmq_mqtt
           application environment.</dd>
-      <dt><a class="permalink" href="#ssl_login_name"><code class="Cm" title="Cm" id="ssl_login_name">ssl_login_name</code></a></dt>
+      <dt id="ssl_login_name"><a class="permalink" href="#ssl_login_name"><code class="Cm">ssl_login_name</code></a></dt>
       <dd>SSL peer cert auth name</dd>
-      <dt><a class="permalink" href="#retainer_pid"><code class="Cm" title="Cm" id="retainer_pid">retainer_pid</code></a></dt>
+      <dt id="retainer_pid"><a class="permalink" href="#retainer_pid"><code class="Cm">retainer_pid</code></a></dt>
       <dd>Id of the Erlang process associated with retain storage for the
           connection.</dd>
-      <dt><a class="permalink" href="#user_4"><code class="Cm" title="Cm" id="user_4">user</code></a></dt>
+      <dt id="user~4"><a class="permalink" href="#user~4"><code class="Cm">user</code></a></dt>
       <dd>Username associated with the connection.</dd>
-      <dt><a class="permalink" href="#vhost_3"><code class="Cm" title="Cm" id="vhost_3">vhost</code></a></dt>
+      <dt id="vhost~3"><a class="permalink" href="#vhost~3"><code class="Cm">vhost</code></a></dt>
       <dd>Virtual host name with non-ASCII characters escaped as in C.</dd>
     </dl>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="STOMP_plugin"><a class="permalink" href="#STOMP_plugin">STOMP
+</section>
+<section class="Ss">
+<h3 class="Ss" id="STOMP_plugin"><a class="permalink" href="#STOMP_plugin">STOMP
   plugin</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#list_stomp_connections"><code class="Cm" title="Cm" id="list_stomp_connections">list_stomp_connections</code></a>
-    [<div class="Op"><var class="Ar" title="Ar">stomp_connectioninfoitem</var></div>]</dt>
-  <dd>Similar to the <code class="Cm" title="Cm">list_connections</code>
-      command, but returns fields which make sense for STOMP connections.
-      <var class="Ar" title="Ar">stomp_connectioninfoitem</var> parameter is
-      used to indicate which connection information items to include in the
-      results. The column order in the results will match the order of the
-      parameters. <var class="Ar" title="Ar">stomp_connectioninfoitem</var> can
-      take any value from the list that follows:
+  <dt id="list_stomp_connections"><a class="permalink" href="#list_stomp_connections"><code class="Cm">list_stomp_connections</code></a>
+    [<var class="Ar">stomp_connectioninfoitem</var>]</dt>
+  <dd>Similar to the <code class="Cm">list_connections</code> command, but
+      returns fields which make sense for STOMP connections.
+      <var class="Ar">stomp_connectioninfoitem</var> parameter is used to
+      indicate which connection information items to include in the results. The
+      column order in the results will match the order of the parameters.
+      <var class="Ar">stomp_connectioninfoitem</var> can take any value from the
+      list that follows:
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#conn_name_2"><code class="Cm" title="Cm" id="conn_name_2">conn_name</code></a></dt>
+      <dt id="conn_name~2"><a class="permalink" href="#conn_name~2"><code class="Cm">conn_name</code></a></dt>
       <dd>Readable name for the connection.</dd>
-      <dt><a class="permalink" href="#connection_3"><code class="Cm" title="Cm" id="connection_3">connection</code></a></dt>
+      <dt id="connection~3"><a class="permalink" href="#connection~3"><code class="Cm">connection</code></a></dt>
       <dd>Id of the Erlang process associated with the internal amqp direct
           connection.</dd>
-      <dt><a class="permalink" href="#connection_state_2"><code class="Cm" title="Cm" id="connection_state_2">connection_state</code></a></dt>
+      <dt id="connection_state~2"><a class="permalink" href="#connection_state~2"><code class="Cm">connection_state</code></a></dt>
       <dd>Connection state; one of:
         <ul class="Bl-bullet Bl-compact">
           <li>running</li>
@@ -2517,18 +2326,18 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
           <li>blocked</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#session_id"><code class="Cm" title="Cm" id="session_id">session_id</code></a></dt>
+      <dt id="session_id"><a class="permalink" href="#session_id"><code class="Cm">session_id</code></a></dt>
       <dd>STOMP protocol session identifier</dd>
-      <dt><a class="permalink" href="#channel"><code class="Cm" title="Cm" id="channel">channel</code></a></dt>
+      <dt id="channel"><a class="permalink" href="#channel"><code class="Cm">channel</code></a></dt>
       <dd>AMQP channel associated with the connection</dd>
-      <dt><a class="permalink" href="#version_2"><code class="Cm" title="Cm" id="version_2">version</code></a></dt>
+      <dt id="version~2"><a class="permalink" href="#version~2"><code class="Cm">version</code></a></dt>
       <dd>Negotiated STOMP protocol version for the connection.</dd>
-      <dt><a class="permalink" href="#implicit_connect"><code class="Cm" title="Cm" id="implicit_connect">implicit_connect</code></a></dt>
+      <dt id="implicit_connect"><a class="permalink" href="#implicit_connect"><code class="Cm">implicit_connect</code></a></dt>
       <dd>Indicates if the connection was established using implicit connect
           (without CONNECT frame)</dd>
-      <dt><a class="permalink" href="#auth_login"><code class="Cm" title="Cm" id="auth_login">auth_login</code></a></dt>
+      <dt id="auth_login"><a class="permalink" href="#auth_login"><code class="Cm">auth_login</code></a></dt>
       <dd>Effective username for the connection.</dd>
-      <dt><a class="permalink" href="#auth_mechanism_3"><code class="Cm" title="Cm" id="auth_mechanism_3">auth_mechanism</code></a></dt>
+      <dt id="auth_mechanism~3"><a class="permalink" href="#auth_mechanism~3"><code class="Cm">auth_mechanism</code></a></dt>
       <dd>STOMP authorization mechanism. Can be one of:
         <ul class="Bl-bullet Bl-compact">
           <li>config</li>
@@ -2536,17 +2345,17 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
           <li>stomp_headers</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#port_3"><code class="Cm" title="Cm" id="port_3">port</code></a></dt>
+      <dt id="port~3"><a class="permalink" href="#port~3"><code class="Cm">port</code></a></dt>
       <dd>Server port.</dd>
-      <dt><a class="permalink" href="#host_4"><code class="Cm" title="Cm" id="host_4">host</code></a></dt>
+      <dt id="host~4"><a class="permalink" href="#host~4"><code class="Cm">host</code></a></dt>
       <dd>Server hostname obtained via reverse DNS, or its IP address if reverse
           DNS failed or was not enabled.</dd>
-      <dt><a class="permalink" href="#peer_port_3"><code class="Cm" title="Cm" id="peer_port_3">peer_port</code></a></dt>
+      <dt id="peer_port~3"><a class="permalink" href="#peer_port~3"><code class="Cm">peer_port</code></a></dt>
       <dd>Peer port.</dd>
-      <dt><a class="permalink" href="#peer_host_3"><code class="Cm" title="Cm" id="peer_host_3">peer_host</code></a></dt>
+      <dt id="peer_host~3"><a class="permalink" href="#peer_host~3"><code class="Cm">peer_host</code></a></dt>
       <dd>Peer hostname obtained via reverse DNS, or its IP address if reverse
           DNS failed or was not enabled.</dd>
-      <dt><a class="permalink" href="#protocol_3"><code class="Cm" title="Cm" id="protocol_3">protocol</code></a></dt>
+      <dt id="protocol~3"><a class="permalink" href="#protocol~3"><code class="Cm">protocol</code></a></dt>
       <dd>STOMP protocol version, which can be on of the following:
         <ul class="Bl-bullet Bl-compact">
           <li>{'STOMP', 0}</li>
@@ -2554,51 +2363,60 @@ RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
           <li>{'STOMP', 2}</li>
         </ul>
       </dd>
-      <dt><a class="permalink" href="#channels_3"><code class="Cm" title="Cm" id="channels_3">channels</code></a></dt>
+      <dt id="channels~3"><a class="permalink" href="#channels~3"><code class="Cm">channels</code></a></dt>
       <dd>Number of channels using the connection.</dd>
-      <dt><a class="permalink" href="#channel_max_3"><code class="Cm" title="Cm" id="channel_max_3">channel_max</code></a></dt>
+      <dt id="channel_max~3"><a class="permalink" href="#channel_max~3"><code class="Cm">channel_max</code></a></dt>
       <dd>Maximum number of channels on this connection.</dd>
-      <dt><a class="permalink" href="#frame_max_4"><code class="Cm" title="Cm" id="frame_max_4">frame_max</code></a></dt>
+      <dt id="frame_max~4"><a class="permalink" href="#frame_max~4"><code class="Cm">frame_max</code></a></dt>
       <dd>Maximum frame size (bytes).</dd>
-      <dt><a class="permalink" href="#client_properties_3"><code class="Cm" title="Cm" id="client_properties_3">client_properties</code></a></dt>
+      <dt id="client_properties~3"><a class="permalink" href="#client_properties~3"><code class="Cm">client_properties</code></a></dt>
       <dd>Informational properties transmitted by the client during
         connection</dd>
-      <dt><a class="permalink" href="#ssl_4"><code class="Cm" title="Cm" id="ssl_4">ssl</code></a></dt>
+      <dt id="ssl~4"><a class="permalink" href="#ssl~4"><code class="Cm">ssl</code></a></dt>
       <dd>Boolean indicating whether the connection is secured with SSL.</dd>
-      <dt><a class="permalink" href="#ssl_protocol_4"><code class="Cm" title="Cm" id="ssl_protocol_4">ssl_protocol</code></a></dt>
+      <dt id="ssl_protocol~4"><a class="permalink" href="#ssl_protocol~4"><code class="Cm">ssl_protocol</code></a></dt>
       <dd>TLS protocol (e.g. &quot;tlsv1&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_key_exchange_4"><code class="Cm" title="Cm" id="ssl_key_exchange_4">ssl_key_exchange</code></a></dt>
+      <dt id="ssl_key_exchange~4"><a class="permalink" href="#ssl_key_exchange~4"><code class="Cm">ssl_key_exchange</code></a></dt>
       <dd>TLS key exchange algorithm (e.g. &quot;rsa&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_cipher_4"><code class="Cm" title="Cm" id="ssl_cipher_4">ssl_cipher</code></a></dt>
+      <dt id="ssl_cipher~4"><a class="permalink" href="#ssl_cipher~4"><code class="Cm">ssl_cipher</code></a></dt>
       <dd>TLS cipher algorithm (e.g. &quot;aes_256_cbc&quot;).</dd>
-      <dt><a class="permalink" href="#ssl_hash_4"><code class="Cm" title="Cm" id="ssl_hash_4">ssl_hash</code></a></dt>
+      <dt id="ssl_hash~4"><a class="permalink" href="#ssl_hash~4"><code class="Cm">ssl_hash</code></a></dt>
       <dd>SSL hash function (e.g. &quot;sha&quot;).</dd>
     </dl>
   </dd>
 </dl>
-<h3 class="Ss" title="Ss" id="Management_agent_plugin"><a class="permalink" href="#Management_agent_plugin">Management
+</section>
+<section class="Ss">
+<h3 class="Ss" id="Management_agent_plugin"><a class="permalink" href="#Management_agent_plugin">Management
   agent plugin</a></h3>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#reset_stats_db"><code class="Cm" title="Cm" id="reset_stats_db">reset_stats_db</code></a>
-    [<div class="Op"><code class="Fl" title="Fl">--all</code></div>]</dt>
+  <dt id="reset_stats_db"><a class="permalink" href="#reset_stats_db"><code class="Cm">reset_stats_db</code></a>
+    [<code class="Fl">--all</code>]</dt>
   <dd>Reset management stats database for the RabbitMQ node.
     <dl class="Bl-tag">
-      <dt><a class="permalink" href="#-all"><code class="Fl" title="Fl" id="-all">--all</code></a></dt>
+      <dt id="all~2"><a class="permalink" href="#all~2"><code class="Fl">--all</code></a></dt>
       <dd>Reset stats database for all nodes in the cluster.</dd>
     </dl>
   </dd>
 </dl>
-<h2 class="Sh" title="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+</section>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h2>
-<a class="Xr" title="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>,
-  <a class="Xr" title="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>
-<h2 class="Sh" title="Sh" id="AUTHOR"><a class="permalink" href="#AUTHOR">AUTHOR</a></h2>
-<span class="An" title="An">The RabbitMQ Team</span>
-  &lt;<a class="Mt" title="Mt" href="mailto:info@rabbitmq.com">info@rabbitmq.com</a>&gt;</div>
+<p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>,
+    <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>,
+    <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>,
+    <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>,
+    <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>,
+    <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>,
+    <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>,
+    <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>,
+    <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+</section>
+<section class="Sh">
+<h2 class="Sh" id="AUTHOR"><a class="permalink" href="#AUTHOR">AUTHOR</a></h2>
+<p class="Pp"><span class="An">The RabbitMQ Team</span>
+    &lt;<a class="Mt" href="mailto:info@rabbitmq.com">info@rabbitmq.com</a>&gt;</p>
+</section>
+</div>

--- a/site/upgrade.md
+++ b/site/upgrade.md
@@ -512,9 +512,9 @@ there would be at least one replica suitable for promotion.
 Classic mirrored queue replica state can be verified by listing queues in the management UI or using `rabbitmqctl`:
 
 <pre class="lang-bash">
-# For queues with non-empty `slave_pids`, you must have at least one
-# `synchronised_slave_pids`.
-rabbitmqctl -n rabbit@to-be-stopped list_queues --local name slave_pids synchronised_slave_pids
+# For queues with non-empty `mirror_pids`, you must have at least one
+# `synchronised_mirror_pids`.
+rabbitmqctl -n rabbit@to-be-stopped list_queues --local name mirror_pids synchronised_mirror_pids
 </pre>
 
 If there are unsynchronised queues, either enable


### PR DESCRIPTION
Amended several mentions of `slave_pids`, updated build instructions to refer to bazel


Regenerated rabbitmqctl man-page. Opted to do it only for one page since my `mandoc` apparently produces a significantly different result. Subject to discussion.