### PR TITLE
Added alternative paths for Apple Silicon

### DIFF
--- a/site/install-homebrew.md
+++ b/site/install-homebrew.md
@@ -45,12 +45,16 @@ Installing the RabbitMQ formula will install key dependencies such as a [support
 
 ## <a id="operations" class="anchor" href="#operations">Operations</a>
 
-The RabbitMQ server scripts and [CLI tools](./cli.html) are installed into the `sbin` directory under `/usr/local/Cellar/rabbitmq/<version>/`,
-which is accessible from `/usr/local/opt/rabbitmq/sbin`. Links to binaries have been created under `/usr/local/sbin`.
+The RabbitMQ server scripts and [CLI tools](./cli.html) are installed into the `sbin` directory under `/usr/local/Cellar/rabbitmq/<version>/` for macOS Intel or `/opt/homebrew/Cellar/rabbitmq/<version>/` for Apple Silicon,
+which is accessible from `/usr/local/opt/rabbitmq/sbin` for for macOS Intel or `/opt/homebrew/opt/rabbitmq/sbin` for Apple Silicon. Links to binaries have been created under `/usr/local/sbin` for macOS Intel or `/opt/homebrew/sbin` for Apple Silicon.
+
 In case that directory is not in `PATH` it's recommended to append it:
 
 <pre class="lang-bash">
+# for macOS Intel
 export PATH=$PATH:/usr/local/sbin
+# for Apple Silicon
+export PATH=$PATH:/opt/homebrew/sbin
 </pre>
 
 Add the above export to the shell profile (such as `~/.bashrc` for bash or `~/.zshrc` for zsh)


### PR DESCRIPTION
Added alternative paths to homebrew installations for Apple Silicon according to https://www.rabbitmq.com/install-homebrew.html