### PR TITLE
add Content-Type header to import definitions using curl

### DIFF
--- a/site/definitions.md
+++ b/site/definitions.md
@@ -113,7 +113,7 @@ It is also possible to use the `POST /api/definitions` API endpoint directly:
 # Requires management plugin to be enabled,
 # placeholders are used for credentials and hostname.
 # Use HTTPS when possible.
-curl -u {username}:{password} -X POST -T /path/to/definitions.file.json http://{hostname}:15672/api/definitions
+curl -u {username}:{password} -H "Content-Type: application/json" -X POST -T /path/to/definitions.file.json http://{hostname}:15672/api/definitions
 </pre>
 
 


### PR DESCRIPTION
Add missing header "Content-Type : application/json" to import definitions using rest api with curl. Without it I receive an error code ...
