### PR TITLE
Expand documentation for `/metrics/detailed` endpoint

### DIFF
--- a/site/prometheus.md
+++ b/site/prometheus.md
@@ -506,9 +506,18 @@ which is `false`, and still scrape per-object metrics when necessary, by setting
 
 ### <a id="detailed-endpoint" class="anchor" href="#detailed-endpoint">Prometheus endpoints: `/metrics/detailed`</a>
 
-Because [enabling per-object metics can be very expensive](#metric-aggregation) but at times necessary,
-a separate endpoint, `GET /metrics/detailed`, provides access to them even if per-object
-metrics are disabled for the node.
+As mentioned in the previous sections, returning a lot of per-object metrics is quite computationally expensive. One of the reasons is that `/metrics/per-object` returns every possible metric for every possible object - even if having them makes no sense in the day-to-day monitoring activity.
+
+That's why there is an additional endpoint that always returns per-object metrics and allows one to explicitly query only the things that are relevant - `/metrics/detailed`. By default it doesn't return anything at all, but it's possible to specify required metric groups and virtual host filters in the GET-parameters. Scraping `/metrics/detailed?vhost=vhost-1&vhost=vhost-2&family=queue_coarse_metrics&family=queue_consumer_count`. will only return requested metrics (and not, for example, channel metrics that include erlang PID in labels).
+
+This endpoint supports the following parameters:
+
+* Zero or more `family` - only the requested metric families will be returned. The full list is documented in [metrics-detailed](metrics-detailed.md).
+* Zero or more `vhost` - if it's given, queue related metrics (`queue_coarse_metrics`, `queue_consumer_count` and `queue_metrics`) will be returned only for given vhost(s).
+
+The returned metrics use different prefix `rabbitmq_detailed_` (instead of plain `rabbitmq_` used by other  endpoints), so that endpoint can be used simultaneously with `/metrics`, and existing dashboards won't be affected.
+
+Here are the performance gains you can expect from using this endpoint. On a test system with 10k queues/10k consumer/10k producers, `/metrics/per-object` took a bit over 2 minutes. Querying `/metrics/detailed?family=queue_coarse_metrics&family=queue_consumer_count` provides just enough metrics to see how many messages sit in every queue and how much consumers each of these queues have. And it takes only 2 seconds, a significant improvement over indiscriminate `/metrics/per-object`.
 
 #### Generic metrics
 


### PR DESCRIPTION
I noticed there were some details missing on how to construct queries to the detailed endpoint.

These docs are almost verbatim copy/paste from the plugin `README` in the server repo, I will remove those in a follow-up PR.