### PR TITLE
Clarification on AMQP single active consumer

### DIFF
--- a/site/consumers.md
+++ b/site/consumers.md
@@ -501,6 +501,11 @@ Please note the following about single active consumer:
  of single active consumer do not play well with the dynamic nature of policies,
  this feature can be enabled only when declaring a queue, with queue arguments.
 
+Please note: this guide is for AMQP single active consumer. It is not related to
+[RabbitMQ Streams Single Active Consumer](https://rabbitmq.com/streams.html#single-active-consumer).
+Setting a single active consumer, using an AMQP client, on a queue type 'stream' will
+not enable SAC. To use SAC on Streams, you have to use a native Stream Client,
+like the [RabbitMQ Java Stream client](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#single-active-consumer).
 
 ## <a id="active-consumer" class="anchor" href="#active-consumer">Consumer Activity</a>
 


### PR DESCRIPTION
From time to time, we receive a message in RabbitMQ Slack, from people trying to
enable Single Active Consumer on a stream queue type, using an AMQP client. This
does not work, as expected, because SAC in streams requires coordination with
the client; a coordination that is not built-in the AMQP client, and the
AMQP-Stream bridge.

This PR updates the consumers guide, to clarify that SAC, in this section, is
specific to AMQP protocol.
