### PR TITLE
Update dotnet tutorials to match dotnet 7 examples

### DIFF
--- a/site/tutorials/tutorial-five-dotnet.md
+++ b/site/tutorials/tutorial-five-dotnet.md
@@ -157,94 +157,77 @@ The code is almost the same as in the
 The code for `EmitLogTopic.cs`:
 
 <pre class="lang-csharp">
-using System;
-using System.Linq;
-using RabbitMQ.Client;
 using System.Text;
+using RabbitMQ.Client;
 
-class EmitLogTopic
-{
-    public static void Main(string[] args)
-    {
-        var factory = new ConnectionFactory() { HostName = "localhost" };
-        using(var connection = factory.CreateConnection())
-        using(var channel = connection.CreateModel())
-        {
-            channel.ExchangeDeclare(exchange: "topic_logs",
-                                    type: "topic");
+var factory = new ConnectionFactory { HostName = "localhost" };
 
-            var routingKey = (args.Length > 0) ? args[0] : "anonymous.info";
-            var message = (args.Length > 1)
-                          ? string.Join(" ", args.Skip( 1 ).ToArray())
-                          : "Hello World!";
-            var body = Encoding.UTF8.GetBytes(message);
-            channel.BasicPublish(exchange: "topic_logs",
-                                 routingKey: routingKey,
-                                 basicProperties: null,
-                                 body: body);
-            Console.WriteLine(" [x] Sent '{0}':'{1}'", routingKey, message);
-        }
-    }
-}
+using var connection = factory.CreateConnection();
+using var channel = connection.CreateModel();
+
+channel.ExchangeDeclare(exchange: "topic_logs", type: ExchangeType.Topic);
+
+var routingKey = (args.Length > 0) ? args[0] : "anonymous.info";
+var message = (args.Length > 1)
+              ? string.Join(" ", args.Skip(1).ToArray())
+              : "Hello World!";
+var body = Encoding.UTF8.GetBytes(message);
+channel.BasicPublish(exchange: "topic_logs",
+                     routingKey: routingKey,
+                     basicProperties: null,
+                     body: body);
+Console.WriteLine($" [x] Sent '{routingKey}':'{message}'");
 </pre>
 
 The code for `ReceiveLogsTopic.cs`:
 
 <pre class="lang-csharp">
-using System;
+using System.Text;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
-using System.Text;
 
-class ReceiveLogsTopic
+var factory = new ConnectionFactory { HostName = "localhost" };
+
+using var connection = factory.CreateConnection();
+using var channel = connection.CreateModel();
+
+channel.ExchangeDeclare(exchange: "topic_logs", type: ExchangeType.Topic);
+// declare a server-named queue
+var queueName = channel.QueueDeclare().QueueName;
+
+if (args.Length &lt; 1)
 {
-    public static void Main(string[] args)
-    {
-        var factory = new ConnectionFactory() { HostName = "localhost" };
-        using(var connection = factory.CreateConnection())
-        using(var channel = connection.CreateModel())
-        {
-            channel.ExchangeDeclare(exchange: "topic_logs", type: "topic");
-            var queueName = channel.QueueDeclare().QueueName;
-
-            if(args.Length &lt; 1)
-            {
-                Console.Error.WriteLine("Usage: {0} [binding_key...]",
-                                        Environment.GetCommandLineArgs()[0]);
-                Console.WriteLine(" Press [enter] to exit.");
-                Console.ReadLine();
-                Environment.ExitCode = 1;
-                return;
-            }
-
-            foreach(var bindingKey in args)
-            {
-                channel.QueueBind(queue: queueName,
-                                  exchange: "topic_logs",
-                                  routingKey: bindingKey);
-            }
-
-            Console.WriteLine(" [*] Waiting for messages. To exit press CTRL+C");
-
-            var consumer = new EventingBasicConsumer(channel);
-            consumer.Received += (model, ea) =>
-            {
-                var body = ea.Body.ToArray();
-                var message = Encoding.UTF8.GetString(body);
-                var routingKey = ea.RoutingKey;
-                Console.WriteLine(" [x] Received '{0}':'{1}'",
-                                  routingKey,
-                                  message);
-            };
-            channel.BasicConsume(queue: queueName,
-                                 autoAck: true,
-                                 consumer: consumer);
-
-            Console.WriteLine(" Press [enter] to exit.");
-            Console.ReadLine();
-        }
-    }
+    Console.Error.WriteLine("Usage: {0} [binding_key...]",
+                            Environment.GetCommandLineArgs()[0]);
+    Console.WriteLine(" Press [enter] to exit.");
+    Console.ReadLine();
+    Environment.ExitCode = 1;
+    return;
 }
+
+foreach (var bindingKey in args)
+{
+    channel.QueueBind(queue: queueName,
+                      exchange: "topic_logs",
+                      routingKey: bindingKey);
+}
+
+Console.WriteLine(" [*] Waiting for messages. To exit press CTRL+C");
+
+var consumer = new EventingBasicConsumer(channel);
+consumer.Received += (model, ea) =>
+{
+    var body = ea.Body.ToArray();
+    var message = Encoding.UTF8.GetString(body);
+    var routingKey = ea.RoutingKey;
+    Console.WriteLine($" [x] Received '{routingKey}':'{message}'");
+};
+channel.BasicConsume(queue: queueName,
+                     autoAck: true,
+                     consumer: consumer);
+
+Console.WriteLine(" Press [enter] to exit.");
+Console.ReadLine();
 </pre>
 
 Run the following examples:

--- a/site/tutorials/tutorial-seven-dotnet.md
+++ b/site/tutorials/tutorial-seven-dotnet.md
@@ -64,7 +64,7 @@ while (ThereAreMessagesToPublish())
     IBasicProperties properties = ...;
     channel.BasicPublish(exchange, queue, properties, body);
     // uses a 5 second timeout
-    channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, 5));
+    channel.WaitForConfirmsOrDie(TimeSpan.FromSeconds(5));
 }
 </pre>
 
@@ -112,13 +112,13 @@ while (ThereAreMessagesToPublish())
     outstandingMessageCount++;
     if (outstandingMessageCount == batchSize)
     {
-        channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, 5));
+        channel.WaitForConfirmsOrDie(TimeSpan.FromSeconds(5));
         outstandingMessageCount = 0;
     }
 }
 if (outstandingMessageCount > 0)
 {
-    channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, 5));
+    channel.WaitForConfirmsOrDie(TimeSpan.FromSeconds(5));
 }
 </pre>
 
@@ -185,7 +185,7 @@ when messages are nack-ed:
 <pre class="lang-csharp">
 var outstandingConfirms = new ConcurrentDictionary&lt;ulong, string&gt;();
 
-void cleanOutstandingConfirms(ulong sequenceNumber, bool multiple)
+void CleanOutstandingConfirms(ulong sequenceNumber, bool multiple)
 {
     if (multiple)
     {
@@ -201,12 +201,12 @@ void cleanOutstandingConfirms(ulong sequenceNumber, bool multiple)
     }
 }
 
-channel.BasicAcks += (sender, ea) => cleanOutstandingConfirms(ea.DeliveryTag, ea.Multiple);
+channel.BasicAcks += (sender, ea) => CleanOutstandingConfirms(ea.DeliveryTag, ea.Multiple);
 channel.BasicNacks += (sender, ea) =>
 {
     outstandingConfirms.TryGetValue(ea.DeliveryTag, out string body);
     Console.WriteLine($"Message with body {body} has been nack-ed. Sequence number: {ea.DeliveryTag}, multiple: {ea.Multiple}");
-    cleanOutstandingConfirms(ea.DeliveryTag, ea.Multiple);
+    CleanOutstandingConfirms(ea.DeliveryTag, ea.Multiple);
 };
 
 // ... publishing code

--- a/site/tutorials/tutorial-two-dotnet.md
+++ b/site/tutorials/tutorial-two-dotnet.md
@@ -230,8 +230,7 @@ After the existing _WriteLine_, add a call to _BasicAck_ and update _BasicConsum
 <pre class="lang-csharp">
     Console.WriteLine(" [x] Done");
 
-    // here channel could also be accessed 
-    // as ((EventingBasicConsumer)sender).Model
+    // here channel could also be accessed as ((EventingBasicConsumer)sender).Model
     channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
 };
 channel.BasicConsume(queue: "hello",


### PR DESCRIPTION
Hi 👋 

I'm in the process of updating the RabbitMQ examples for dotnet to dotnet7: https://github.com/rabbitmq/rabbitmq-tutorials/pull/350

The purpose of this PR is to update the website tutorials for dotnet to match the updated examples.