### PR TITLE
Add node-rabbitmq-client to Node.js client libraries

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -112,6 +112,7 @@ Miscellaneous projects:
  * [amqp-stats](https://github.com/timisbusy/node-amqp-stats): a node.js interface for RabbitMQ management statistics
  * [Rascal](https://github.com/guidesmiths/rascal): a config driven wrapper for [amqp.node](https://github.com/squaremo/amqp.node) supporting multi-host connections,
    automatic error recovery, redelivery flood protection, transparent encryption and channel pooling.
+ * [node-rabbitmq-client](https://github.com/cody-greene/node-rabbitmq-client): RabbitMQ (AMQP 0-9-1) client library with auto-reconnect, zero dependencies, TypeScript support, and Promise-based API.
 
 
 ## <a id="go-dev" class="anchor" href="#go-dev">Go</a>


### PR DESCRIPTION
In my search for a RabbitMQ Node.js library that meets these criteria:

- TypeScript support
- Allows specifying multiple nodes in a cluster
- Await-able components
- Good docs
- Few dependencies

I found https://github.com/cody-greene/node-rabbitmq-client

This PR adds it to the docs list of Node.js client libraries. 