### PR TITLE
Add new section in which-erlang.md for version 3.9.28

### DIFF
--- a/site/which-erlang.md
+++ b/site/which-erlang.md
@@ -329,6 +329,38 @@ source, including specific tags from GitHub, a much more pleasant experience.
     <td>
       <ul>
         <li>3.9.28</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>24.3</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>25.2</li>
+      </ul>
+    </td>
+    <td>
+      <ul class="notes">
+        <li>
+          24.3 is the only maintained (updated) series of Erlang 24.
+        </li>
+        <li>
+          As of Erlang 25.1, OpenSSL 3.0 support in Erlang is considered to
+          be mature enough to consider for production.
+        </li>
+        <li>
+          Erlang 25 before 25.0.2 and 24 before 24.3.4.2 are affected by <a href="https://nvd.nist.gov/vuln/detail/CVE-2022-37026">CVE-2022-37026</a>,
+          a CVE with critical severity (CVSS 3.x Base Score: 9.8)
+        </li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <ul>
         <li>3.9.27</li>
         <li>3.9.26</li>
         <li>3.9.25</li>


### PR DESCRIPTION
RabbitMQ version 3.9.28 requires Erlang 24.3 as minimum version

At the moment, the which-erlang.md states 24.2 as minimum version while the deb package and release notes states that it requires 24.3. 
Added a new section for RabbitMQ version 3.9.28 with notes copied from the 3.10 versions with the same Erlang requirements.

I am however, unsure of the maximum version that 3.9.28 supports.