### PR TITLE
3.12: add a classic-queues page to the documentation

### DIFF
--- a/site/admin-guide.md
+++ b/site/admin-guide.md
@@ -149,7 +149,7 @@ see <a href="./documentation.html">All Documentation Guides</a>.
  * [Reliable Message Delivery](reliability.html)
 
 
-## Message Store and Resource Management
+## Resource Management
 
  * [Memory Usage Analysis](memory-use.html)
  * [Memory Management](memory.html)
@@ -157,15 +157,14 @@ see <a href="./documentation.html">All Documentation Guides</a>.
  * [Free Disk Space Alarms](disk-alarms.html)
  * [Runtime Tuning](runtime.html)
  * [Flow Control](flow-control.html)
- * [Message Store Configuration](persistence-conf.html)
  * [Queue and Message TTL](ttl.html)
  * [Queue Length Limits](maxlength.html)
- * [Lazy Queues](lazy-queues.html)
 
 
 ## Queue and Consumer Features
 
  * [Queues guide](queues.html)
+ * [Classic Queues](classic-queues.html)
  * [Consumers guide](consumers.html)
  * [Queue and Message TTL](ttl.html)
  * [Queue Length Limits](maxlength.html)

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -83,9 +83,9 @@ Both [persistent and transient messages](./publishers.html#message-properties)
 are always persisted to disk except when:
 
  * the queue is declared as transient or messages are transient
- * messages are smaller than the embed limit (defaults to 4096 bytes)
- * for **RabbitMQ 3.12** and above: the queue is short (queues may
-   keep up to 2048 messages in memory at most, depending on the consume rate)
+ * messages are smaller than the embedding threshold (defaults to 4096 bytes)
+ * for **RabbitMQ 3.12** and later versions: the queue is short (queues may
+   keep up to 2048 messages in memory at most, depending on the consumer delivery rate)
 
 In general messages are not kept in memory unless the rate of
 consumption of messages is high enough that the messages that

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -143,8 +143,11 @@ disk when necessary. It will load more messages based on the
 current consumption rate. Version 2 does not embed messages
 in its index, instead a per-queue message store is used.
 
-Version 2 was added in **RabbitMQ 3.10.0**. It is possible to
-switch back and forth between version 1 and version 2.
+Version 2 was added in **RabbitMQ 3.10.0** and was significantly
+improved in **RabbitMQ 3.12.0**. It is currently possible to
+switch back and forth between version 1 and version 2. In the future,
+version 1 will be removed and the migration to version 2 will be performed
+automatically on node startup after the upgrade.
 
 The version can be changed using the `queue-version` policy.
 When setting a new version via policy the queue will immediately
@@ -160,7 +163,7 @@ The default version can be set through configuration by setting
 
 Classic queues aim to provide reasonably good throughput in the majority
 of situations without configuration. However, some configuration is
-soemtimes useful. This section covers a few configurable values that
+sometimes useful. This section covers a few configurable values that
 affect stability, throughput, latency and I/O characteristics of a node.
 Consider getting accustomed to [benchmarking with PerfTest](https://rabbitmq.github.io/rabbitmq-perf-test/stable/htmlsingle/)
 in addition to get the most out of your queues.
@@ -210,7 +213,7 @@ descriptors available to properly function, in theory. In
 practice only busy queues will need that many; other queues
 will function just fine with 3 or 4 file handles.
 
-As a result from not using the file handle management subsystem,
+As a result of not using the file handle management subsystem,
 version 2 does not track as many I/O statistics; only the numbers
 of reads and writes. Other metrics can be obtained at the OS level.
 
@@ -219,7 +222,7 @@ of reads and writes. Other metrics can be obtained at the OS level.
 Classic queues may keep up to 2048 messages in memory, depending
 on the consume rate. Classic queues will however avoid reading
 larger messages from disk too early. In **RabbitMQ 3.12** this
-means messages larger than the embed size.
+means messages larger than the embed size (by default, 4096 bytes).
 
 The index in version 1 has to read entire segment files in order
 to access the messages inside. This can lead to memory usage spikes,

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -154,10 +154,22 @@ When setting a new version via policy the queue will immediately
 convert its data on disk. It is possible to upgrade to version 2
 or downgrade to version 1. Note that for large queues the conversion
 may take some time and results in the queue being unavailable while
-the conversion is running.
+the conversion is running. As a point of reference, on our test machine,
+the migration takes:
+
+* 2 seconds to migrate 1000 queues with 1000 100-byte messages each
+* 9 seconds to migrate a queue with 1 million 100-byte messages
+* 3 seconds to migrate a queue with 1 million 5000-byte messages
+  (with the default embedding size of 4096 bytes, 5000-byte
+  messages are in the message store so there is less data to migrate)
+
+Given the numbers above, unless there is a lot of queues with a lot of messages,
+the migration should complete in a matter of seconds.
 
 The default version can be set through configuration by setting
-`classic_queue.default_version` in rabbitmq.conf.
+`classic_queue.default_version` in rabbitmq.conf. Changing the default version
+only affects newly declared queues. Pre-existing queues will remain on version 1,
+until explicitly migrated or deleted and redeclared.
 
 ## <a id="resource-use" class="anchor" href="#resource-use">Resource Use</a>
 

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -61,7 +61,7 @@ support at-least-once dead-lettering, suported by quorum queues.
 
 [Per-consumer QoS prefetch](./consumer-prefetch.html) should be
 preferred over global QoS prefetch, even though classic queues support
-both optiojs. Global QoS prefetch is a deprecated feature that will be
+both options. Global QoS prefetch is a deprecated feature that will be
 removed in **RabbitMQ 4.0**.
 
 While classic queues can be declared as transient, this makes queue
@@ -117,7 +117,7 @@ index.
 
 Embedded messages are written in its queue index when
 using classic queues version 1; and in its
-**_**per-queue message store** when using classic
+**per-queue message store** when using classic
 queues version 2.
 
 Larger messages are written to a shared message store.

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -171,6 +171,7 @@ Some related guides include:
  * [File and Directory Locations](./relocate.html)
  * [Runtime Tuning](./runtime.html)
  * [Queues](./queues.html#runtime-characteristics) and their runtime characteristics
+ * [Lazy Queues](./lazy-queues.html) for **RabbitMQ before 3.12**
 
 ### <a id="file-handles" class="anchor" href="#file-handles">File Handles</a>
 

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -27,6 +27,14 @@ where data safety is not a top priority, because the data stored in
 classic queues is not replicated. If data safety is important,
 we recommend using quorum queues or streams.
 
+Classic queues are the original as well as the default queue type
+for RabbitMQ.
+
+Classic queues are currently being modernised to improve their
+stability and performance. As a result of this effort there
+exists [two versions](#versions) of classic queues. The version
+only impacts how the data is stored on and read from disk.
+
 ## <a id="features" class="anchor" href="#features">Features</a>
 
 Classic queues fully support [queue exclusivity](queues.html),
@@ -121,7 +129,7 @@ use a different index for messages depending on the version, as well
 as operate differently regarding the embedding of small messages in
 the index.
 
-Version 1 is the default and the historical implementation of classic
+Version 1 is the default and the original implementation of classic
 queues. The index in version 1 uses a combination of a journal and
 segment files. When reading messages from segment files it loads
 an entire segment file in memory, which can lead to memory issues

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -48,9 +48,12 @@ Classic queues support [dead letter exchanges](./dlx.html) with
 the exception of [at-least-once dead-lettering](./quorum-queues.html#dead-lettering).
 
 Messages stored in classic queues are always persisted to disk
-except when **all** of the following conditions are true: the queue is declared as transient,
-messages are published as transient by clients, and publisher confirms are not used.
-However, classic queues v1 tend to accumulate messages in memory.
+except when:
+
+ * the queue is declared as transient or messages are transient
+ * messages are smaller than the embed limit (defaults to 4096 bytes)
+ * for **RabbitMQ 3.12** and above: the queue is short (queues may
+   keep up to 2048 messages in memory at most, depending on the consume rate)
 
 Classic queues do not support [poison message handling](https://en.wikipedia.org/wiki/Poison_message),
 unlike [quorum queues](./quorum-queues.html). Classic queues also do not

--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -47,14 +47,6 @@ and adhere to settings [controlled using policies](./parameters.html#policies).
 Classic queues support [dead letter exchanges](./dlx.html) with
 the exception of [at-least-once dead-lettering](./quorum-queues.html#dead-lettering).
 
-Messages stored in classic queues are always persisted to disk
-except when:
-
- * the queue is declared as transient or messages are transient
- * messages are smaller than the embed limit (defaults to 4096 bytes)
- * for **RabbitMQ 3.12** and above: the queue is short (queues may
-   keep up to 2048 messages in memory at most, depending on the consume rate)
-
 Classic queues do not support [poison message handling](https://en.wikipedia.org/wiki/Poison_message),
 unlike [quorum queues](./quorum-queues.html). Classic queues also do not
 support at-least-once dead-lettering, suported by quorum queues.
@@ -87,12 +79,13 @@ all other messages are written to disk directly.
 Classic queues use an on-disk index for storing message locations on disk
 as well as a message store for persisting messages.
 
-Both [persistent and transient messages](./publishers.html#message-properties) can be written to disk.
-Persistent messages and transient messages sent with publisher
-confirms enabled will be written to disk as soon as they reach
-the queue. Other transient messages will likely be written to
-disk as well unless there is a chance that they will be
-consumed fairly quickly.
+Both [persistent and transient messages](./publishers.html#message-properties)
+are always persisted to disk except when:
+
+ * the queue is declared as transient or messages are transient
+ * messages are smaller than the embed limit (defaults to 4096 bytes)
+ * for **RabbitMQ 3.12** and above: the queue is short (queues may
+   keep up to 2048 messages in memory at most, depending on the consume rate)
 
 In general messages are not kept in memory unless the rate of
 consumption of messages is high enough that the messages that

--- a/site/lazy-queues.md
+++ b/site/lazy-queues.md
@@ -25,6 +25,10 @@ behave in a similar manner to lazy queues. They may however
 keep a small number of messages in memory (up to 2048 at the
 time of writing) based on the consumption rate.
 
+We recommend users of **RabbitMQ 3.11** and below to either
+upgrade to **RabbitMQ 3.12** or enable **lazy mode** to avoid
+running into memory issues.
+
 Classic queues operating in **lazy mode**
 move their contents to disk as early as practically possible,
 and only load them in RAM when requested by consumers,

--- a/site/lazy-queues.md
+++ b/site/lazy-queues.md
@@ -19,7 +19,13 @@ classic queues will remain a supported non-replicated queue type.
 
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
-Classic queues can operate in **lazy mode**: that is,
+Until **RabbitMQ 3.12**, classic queues could operate in **lazy mode**.
+As of RabbitMQ 3.12 the queue mode is ignored and classic queues
+behave in a similar manner to lazy queues. They may however
+keep a small number of messages in memory (up to 2048 at the
+time of writing) based on the consumption rate.
+
+Classic queues operating in **lazy mode**
 move their contents to disk as early as practically possible,
 and only load them in RAM when requested by consumers,
 therefore the lazy denomination.

--- a/site/persistence-conf.md
+++ b/site/persistence-conf.md
@@ -17,8 +17,6 @@ limitations under the License.
 
 # Persistence Configuration
 
-TODO remove/redirect
-
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 The RabbitMQ persistence layer is intended to provide reasonably good throughput

--- a/site/persistence-conf.md
+++ b/site/persistence-conf.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 # Persistence Configuration
 
+TODO remove/redirect
+
 ## <a id="overview" class="anchor" href="#overview">Overview</a>
 
 The RabbitMQ persistence layer is intended to provide reasonably good throughput

--- a/site/queues.md
+++ b/site/queues.md
@@ -49,7 +49,8 @@ Some key topics covered in this guide are
  * [TTL](#ttl-and-limits) and length limits
  * [Priority queues](#priorities)
 
-For topics related to consumers, see the [Consumers guide](consumers.html). [Quorum queues](quorum-queues.html)
+For topics related to consumers, see the [Consumers guide](consumers.html).
+[Classic queues](classic-queues.html), [quorum queues](quorum-queues.html)
 and [streams](streams.html) also have dedicated guides.
 
 ## <a id="basics" class="anchor" href="#basics">The Basics</a>
@@ -136,7 +137,7 @@ pairs that can be provided by clients when a queue is declared.
 
 The map is used by various features and plugins such as
 
- * Queue type (e.g. [quorum](quorum-queues.html) or classic)
+ * Queue type (e.g. [quorum](quorum-queues.html) or [classic](classic-queues.html))
  * [Message and queue TTL](ttl.html)
  * [Queue length limit](maxlength.html)
  * Max number of [priorities](priority.html)


### PR DESCRIPTION
It has updated information about classic queues and aims
to replace persistence-conf and lazy-queues ultimately.

* [x] It has TODOs
* [x] It probably should be linked to
* [x] It should be reviewed from a technical POV
* [x] It should be reviewed from a grammar POV
* [ ] persistent-conf.html should redirect to classic-queues.html and be removed
