### PR TITLE
Fix default value for policy priority

### DIFF
--- a/site/parameters.md
+++ b/site/parameters.md
@@ -269,7 +269,7 @@ of matching queues (exchanges).
 **At most one policy matches** a queue or exchange. Since multiple policies can match a single
 name, a mechanism is needed to resolve such policy conflicts. This mechanism is called policy priorities.
 Every policy has a a numeric priority associated with it. This priority can be specified when declaring
-a policy. If not explicitly provided, the priority of 1 will be used.
+a policy. If not explicitly provided, the priority of 0 will be used.
 
 Matching policies are then sorted by priority and the one with the highest priority will take
 effect.


### PR DESCRIPTION
When not provided, `rabbitmqctl set_policy` and `rabbit_policy:set/7` use 0 as the default for policy priority.

See:

* https://github.com/rabbitmq/rabbitmq-server/blob/9513bfaa694e826770dfefc5f84a8eb27a6cc67c/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex#L15
* https://github.com/rabbitmq/rabbitmq-server/blob/9513bfaa694e826770dfefc5f84a8eb27a6cc67c/deps/rabbit/src/rabbit_policy.erl#L294-L297

Looks like this was also partially addressed in #1624