### PR TITLE
Oauth2 login with authorization header

### DIFF
--- a/site/management.md
+++ b/site/management.md
@@ -401,9 +401,7 @@ In addition to the `connect-src` CSP header, RabbitMQ also needs the CSP directi
 ### Identity-Provider initiated logon
 
 By default, the RabbitMQ Management UI uses the OAuth 2.0 **authorization code flow** to authenticate and authorize users.
-However, there are scenarios where users preferred to be automatically redirected to RabbitMQ without getting
-involved in additional logon flows. This is common in Oauth2 proxies and in Web Portals where with a single click, users navigate straight to a RabbitMQ cluster's management UI with a token obtained under the covers. This is known as
-**Identity-Provider initiated logon**.
+However, there are scenarios where users prefer to be automatically redirected to RabbitMQ without getting involved in additional logon flows. By using OAuth2 proxies and web portals, these additional logon flows can be avoided. With a single click, users navigate straight to a RabbitMQ Management UI with a token obtained under the covers. This is known as **Identity-Provider initiated logon**.
 
 RabbitMQ exposes a new setting called `management.oauth_initiated_logon_type` whose default value `sp_initiated`.
 To enable an **Identity-Provider initiated logon** you set it to `idp_initiated`.
@@ -414,7 +412,7 @@ management.oauth_initiated_logon_type = idp_initiated
 management.oauth_provider_url = https://my-web-portal
 </pre>
 
-With the settings above, the management UI exposes the HTTP endpoint `/login` which accepts `content-type: application/x-www-form-urlencoded` and it expects the JWT token in the `access_token` form field. This is the endpoint where the web portal would redirect users to access the RabbitMQ Management ui.
+With the previous settings, the management UI exposes the HTTP endpoint `/login` which accepts `content-type: application/x-www-form-urlencoded` and it expects the JWT token in the `access_token` form field. This is the endpoint where the Web portal will redirect users to the management UI.
 Additionally, RabbitMQ also accepts a JWT token in the HTTP `Authorization` header when the user lands on the management UI.
 
 ## <a id="http-api" class="anchor" href="#http-api">HTTP API</a>

--- a/site/management.md
+++ b/site/management.md
@@ -294,6 +294,7 @@ against the OAuth 2 server, this must be configured separately. Currently,
 * [Keycloak](https://www.keycloak.org/)
 * [Auth0](https://auth0.com/)
 * [Azure](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/auth-oauth2)
+* [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/)
 
 **Important**: from the OAuth 2.0 point of view, the RabbitMQ Management UI is a **public app** which
 means it cannot securely store credentials such as the *client_secret*. This means that RabbitMQ does not need to present a client_secret when authenticating users.
@@ -401,17 +402,11 @@ In addition to the `connect-src` CSP header, RabbitMQ also needs the CSP directi
 
 By default, the RabbitMQ Management UI uses the OAuth 2.0 **authorization code flow** to authenticate and authorize users.
 However, there are scenarios where users preferred to be automatically redirected to RabbitMQ without getting
-involved in additional logon flows. This is common in Web Portals where with a single click, users navigate
-straight to a RabbitMQ cluster's management UI with a token obtained under the covers. This is known as
+involved in additional logon flows. This is common in Oauth2 proxies and in Web Portals where with a single click, users navigate straight to a RabbitMQ cluster's management UI with a token obtained under the covers. This is known as
 **Identity-Provider initiated logon**.
 
 RabbitMQ exposes a new setting called `management.oauth_initiated_logon_type` whose default value `sp_initiated`.
 To enable an **Identity-Provider initiated logon** you set it to `idp_initiated`.
-
-After you set `management.oauth_initiated_logon_type` to `idp_initiated` and
-`oauth_enabled: true` and `oauth_provider_url` are configured, the management UI exposes the HTTP endpoint `/login` which accepts `content-type: application/x-www-form-urlencoded` and it expects the JWT token in the `access_token` form field. This is the endpoint where the web portal would redirect users to access the RabbitMQ Management ui.
-
-This is the minimum required configuration for a RabbitMQ cluster configured with `idp_initiated` logon type:
 
 <pre class="lang-ini">
 management.oauth_enabled = true
@@ -419,6 +414,8 @@ management.oauth_initiated_logon_type = idp_initiated
 management.oauth_provider_url = https://my-web-portal
 </pre>
 
+With the settings above, the management UI exposes the HTTP endpoint `/login` which accepts `content-type: application/x-www-form-urlencoded` and it expects the JWT token in the `access_token` form field. This is the endpoint where the web portal would redirect users to access the RabbitMQ Management ui.
+Additionally, RabbitMQ also accepts a JWT token in the HTTP `Authorization` header when the user lands on the management UI.
 
 ## <a id="http-api" class="anchor" href="#http-api">HTTP API</a>
 

--- a/site/oauth2-examples-azure.md
+++ b/site/oauth2-examples-azure.md
@@ -118,6 +118,13 @@ Now that some roles have been created for your application, you still need to as
 
 9. Repeat the operations for all the roles you want to assign.
 
+## About custom signing keys
+
+You do not need to create a custom signing key for your application. If you create one though, you must append an `appid` query parameter containing the *app ID* to the  `jwks_uri`.
+
+For example `https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration?appid=<my-app-id>` contains a `jwks_uri` of  `https://login.microsoftonline.com/{tenant}/discovery/keys?appid=<my-app-id>`.
+
+
 ## Configure RabbitMQ to use Azure AD as OAuth 2.0 authentication backend
 
 The configuration on Azure side is done. You now have to configure RabbitMQ to use the resources you just created.

--- a/site/oauth2-examples-azure.md
+++ b/site/oauth2-examples-azure.md
@@ -122,8 +122,9 @@ Now that some roles have been created for your application, you still need to as
 
 You do not need to create a custom signing key for your application. If you create one though, you must append an `appid` query parameter containing the *app ID* to the  `jwks_uri`.
 
-For example `https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration?appid=<my-app-id>` contains a `jwks_uri` of  `https://login.microsoftonline.com/{tenant}/discovery/keys?appid=<my-app-id>`.
+For example, if you try `https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration?appid=<my-app-id>` it returns a `jwks_uri` with the value  `https://login.microsoftonline.com/{tenant}/discovery/keys?appid=<my-app-id>`.
 
+If you do not use the above `jwks_uri`, the standard jwks_uri will not return your custom signing key and RabbitMQ will not be able to find the signing key to validate the token's signature.
 
 ## Configure RabbitMQ to use Azure AD as OAuth 2.0 authentication backend
 

--- a/site/oauth2-examples-azure.md
+++ b/site/oauth2-examples-azure.md
@@ -127,11 +127,12 @@ For example, given your application id, `{my-app-id}` and your tenant `{tenant}`
 
 ## Configure RabbitMQ to use Azure AD as OAuth 2.0 authentication backend
 
-The configuration on Azure side is done. You now have to configure RabbitMQ to use the resources you just created.
+The configuration on Azure side is done. Next, configure RabbitMQ to use these resources.
 
 [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/azure/rabbitmq.config) is a sample RabbitMQ advanced configuration to **enable Azure AD as OAuth 2.0 authentication backend** for the RabbitMQ Management UI.
 
-Update it with the following values (you should have noted these in the previous steps):
+Update it with the following values:
+
 * **Tenant ID** associated to the app that you registered in Azure AD
 * **Application ID** associated to the app that you registered in Azure AD
 * Value of the **jwks_uri** key from `https://login.microsoftonline.com/{TENANT_ID}/v2.0/.well-known/openid-configuration`
@@ -157,10 +158,11 @@ $ vi rabbitmq.config
 ].
 </pre>
 
-> **IMPORTANT**: Please update the file available in this tutorial ([here](../conf/azure/rabbitmq.config)), as it will be automatically loaded in the RabbitMQ instance that you are going to deploy later in this tutorial
+> **Important**: Please update the file available in this tutorial ([here](../conf/azure/rabbitmq.config)), as it will be automatically loaded in the RabbitMQ instance that you are going to deploy later in this tutorial
 
-### Generate SSL certificate and key
-> **IMPORTANT**: Remember when you have registered your app on Azure AD that it only allows **https** protocol for OAuth 2.0 **Redirect URI**? You will thus need to enable HTTPS for RabbitMQ Management UI amd its underlying API.
+### Generate a TLS Certificate and Key Pair
+
+> **Important**: Remember when you have registered your app on Azure AD that it only allows **https** protocol for OAuth 2.0 **Redirect URI**? You will thus need to enable HTTPS for RabbitMQ Management UI amd its underlying API.
 
 For the purpose of this tutorial, you can generate a self-signed certificate/key pair.
 

--- a/site/oauth2-examples-azure.md
+++ b/site/oauth2-examples-azure.md
@@ -118,13 +118,12 @@ Now that some roles have been created for your application, you still need to as
 
 9. Repeat the operations for all the roles you want to assign.
 
-## About custom signing keys
+## Configure Custom Signing Keys
 
-You do not need to create a custom signing key for your application. If you create one though, you must append an `appid` query parameter containing the *app ID* to the  `jwks_uri`.
+It is optional to create a signing key for your application. If you create one though, you must append an `appid` query parameter containing the *app ID* to the `jwks_uri`. Otherwise, the standard jwks_uri endpoint will not include the custom signing key and RabbitMQ will not find the signing key to validate the token's signature.
 
-For example, if you try `https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration?appid=<my-app-id>` it returns a `jwks_uri` with the value  `https://login.microsoftonline.com/{tenant}/discovery/keys?appid=<my-app-id>`.
+For example, given your application id, `{my-app-id}` and your tenant `{tenant}`, the OIDC discovery endpoint uri would be `https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration?appid={my-app-id}`. The returned payload contains the `jwks_uri` attribute whose value is something like `https://login.microsoftonline.com/{tenant}/discovery/keys?appid=<my-app-idp>`. RabbitMQ should be configured with that `jwks_uri` value.
 
-If you do not use the above `jwks_uri`, the standard jwks_uri will not return your custom signing key and RabbitMQ will not be able to find the signing key to validate the token's signature.
 
 ## Configure RabbitMQ to use Azure AD as OAuth 2.0 authentication backend
 

--- a/site/oauth2-examples-proxy.md
+++ b/site/oauth2-examples-proxy.md
@@ -15,7 +15,7 @@ Let's test the following flow:
             1. rabbit_admin from a browser
 </pre>
 
-## Prerequisites to follow this guide
+## Prerequisites for Using OAuth 2 Proxy and Keycloak
 
 - Docker
 - make

--- a/site/oauth2-examples-proxy.md
+++ b/site/oauth2-examples-proxy.md
@@ -27,7 +27,7 @@ First, deploy **Key Cloak**. It comes preconfigured with all the required scopes
 make start-keycloak
 </pre>
 
-**Key Cloak** comes configured with its own signing key. And [rabbitmq.conf](../conf/oauth2-proxy/rabbitmq.conf)
+**Key Cloak** comes configured with its own signing key. And [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
 is also configured with the same signing key.
 
 To access KeyCloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
@@ -41,7 +41,7 @@ There is a dedicated **KeyCloak realm** called `Test` configured as follows:
 ## Start RabbitMQ
 
 To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbit.conf found under [conf/oauth2-proxy/rabbitmq.conf](../conf/keycloak/rabbitmq.conf)
+rabbit.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
 
 <pre class="lang-plain">
 export MODE=oauth2-proxy
@@ -50,7 +50,7 @@ make start-rabbitmq
 
 **NOTE**: Oauth2-proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
 `aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
-impossible to configure keycloak with both values, [rabbitmq.conf](../conf/oauth2-proxy/rabbitmq.conf) has
+impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) has
 the setting below which disables validation of the audience claim.
 
 <pre class="lang-ini">
@@ -66,7 +66,7 @@ To start Oauth2-proxy we run the following command:
 make start-oauth2-proxy
 </pre>
 
-Oauth2-proxy is configured using [Alpha configuration](../conf/oauth2-proxy/alpha-config.yaml). This type of configuration permits injecting the access token into the HTTP **Authorization** header.
+Oauth2-proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration permits injecting the access token into the HTTP **Authorization** header.
 
 
 ## Access Management ui

--- a/site/oauth2-examples-proxy.md
+++ b/site/oauth2-examples-proxy.md
@@ -2,7 +2,7 @@
 
 Let's test the following flow:
 
-* Access management ui via a browser thru OAuth2-Proxy
+* Access the RabbitMQ Management UI using a browser through OAuth2 Proxy
 
 <pre class="lang-plain">
                     [ Keycloak ] 3. authenticate
@@ -20,19 +20,18 @@ Let's test the following flow:
 - Docker
 - make
 
-## Deploy Key Cloak
+## Deploy Keycloak
 
-First, deploy **Key Cloak**. It comes preconfigured with all the required scopes, users and clients.
+Deploy Keycloak by running the following command:
 <pre class="bash">
 make start-keycloak
 </pre>
 
-**Key Cloak** comes configured with its own signing key. And [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
-is also configured with the same signing key.
+Note: Keycloak is preconfigured with the required scopes, users, and clients. It is configured with its own signing key and the [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) file is also configured with the same signing key.
 
-To access KeyCloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
-There is a dedicated **KeyCloak realm** called `Test` configured as follows:
+There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
 * [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
 * [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
@@ -41,14 +40,14 @@ There is a dedicated **KeyCloak realm** called `Test` configured as follows:
 ## Start RabbitMQ
 
 To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbit.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
+rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
 
 <pre class="lang-plain">
 export MODE=oauth2-proxy
 make start-rabbitmq
 </pre>
 
-**NOTE**: Oauth2-proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
+**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
 `aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
 impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) has
 the setting below which disables validation of the audience claim.
@@ -60,16 +59,16 @@ auth_oauth2.verify_aud = false
 
 ## Start OAuth2 Proxy
 
-To start Oauth2-proxy we run the following command:
+To start OAuth2 Proxy, run the following command:
 
 <pre class="lang-plain">
 make start-oauth2-proxy
 </pre>
 
-Oauth2-proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration permits injecting the access token into the HTTP **Authorization** header.
+Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
-## Access Management ui
+## Access Management UI
 
-Go to http://0.0.0.0:4180/, click on the link **Sign in with Keycloak OIDC**, and enter the credentials
-`rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management ui.
+Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
+`rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/site/oauth2-examples-proxy.md
+++ b/site/oauth2-examples-proxy.md
@@ -1,0 +1,75 @@
+# Use OAuth2 Proxy and Keycloak as OAuth 2.0 server
+
+Let's test the following flow:
+
+* Access management ui via a browser thru OAuth2-Proxy
+
+<pre class="lang-plain">
+                    [ Keycloak ] 3. authenticate
+                      /|\  |
+                       |   | 4. token
+        2.redirect     |  \|/                                        [ RabbitMQ ]
+                [ Oauth2-Proxy ]       ----5. forward with token-->  [  http    ]
+                      /|\
+                       |
+            1. rabbit_admin from a browser
+</pre>
+
+## Prerequisites to follow this guide
+
+- Docker
+- make
+
+## Deploy Key Cloak
+
+First, deploy **Key Cloak**. It comes preconfigured with all the required scopes, users and clients.
+<pre class="bash">
+make start-keycloak
+</pre>
+
+**Key Cloak** comes configured with its own signing key. And [rabbitmq.conf](../conf/oauth2-proxy/rabbitmq.conf)
+is also configured with the same signing key.
+
+To access KeyCloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+
+There is a dedicated **KeyCloak realm** called `Test` configured as follows:
+
+* [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
+* [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
+* `rabbitmq-proxy-client` client
+
+## Start RabbitMQ
+
+To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
+rabbit.conf found under [conf/oauth2-proxy/rabbitmq.conf](../conf/keycloak/rabbitmq.conf)
+
+<pre class="lang-plain">
+export MODE=oauth2-proxy
+make start-rabbitmq
+</pre>
+
+**NOTE**: Oauth2-proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
+`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
+impossible to configure keycloak with both values, [rabbitmq.conf](../conf/oauth2-proxy/rabbitmq.conf) has
+the setting below which disables validation of the audience claim.
+
+<pre class="lang-ini">
+auth_oauth2.verify_aud = false
+</pre>
+
+
+## Start OAuth2 Proxy
+
+To start Oauth2-proxy we run the following command:
+
+<pre class="lang-plain">
+make start-oauth2-proxy
+</pre>
+
+Oauth2-proxy is configured using [Alpha configuration](../conf/oauth2-proxy/alpha-config.yaml). This type of configuration permits injecting the access token into the HTTP **Authorization** header.
+
+
+## Access Management ui
+
+Go to http://0.0.0.0:4180/, click on the link **Sign in with Keycloak OIDC**, and enter the credentials
+`rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management ui.

--- a/site/oauth2-examples.md
+++ b/site/oauth2-examples.md
@@ -162,7 +162,8 @@ The latter scenario is demonstrated [here](oauth2-examples-proxy.html). The form
 
 #### Idp-initiated Logon using the Login Endpoint
 
-A web portal offers their authenticated users the option to navigate to RabbitMQ by submitting a form with their OAuth token in the `access_token` form field as provided below:
+A Web portal offers their authenticated users the option to navigate to RabbitMQ
+by submitting a form with their OAuth token in the `access_token` form field as provided below:
 
 
 <pre class="lang-plain">

--- a/site/oauth2-examples.md
+++ b/site/oauth2-examples.md
@@ -152,17 +152,17 @@ in `advanced.config`:
 
 ### <a id="identity-provider-initiated-logon" class="anchor" href="#identity-provider-initiated-logon">Identity-Provider initiated logon</a>
 
-Alike Service-Provider initiated logon, with Idp-initiated logon users land to RabbitMQ management ui with a valid token.
-These two scenarios below are examples of Idp-initiated logon:
+Like Service-Provider initiated logon, with Idp-initiated logon users get to the RabbitMQ Management UI with a valid token.
+The following scenarios are examples of Idp-initiated logon:
 
-* RabbitMQ is behind a web portal which conveniently allow users to navigate directly to RabbitMQ fully authenticated
-* There is an OAuth2 proxy in between users and RabbitMQ which intercepts their requests and forwards them to RabbitMQ injecting the token into the HTTP `Authorization` header  
+* RabbitMQ is behind a web portal which conveniently allow users to navigate directly to RabbitMQ fully authenticated.
+* There is an OAuth2 proxy in between users and RabbitMQ which intercepts their requests and forwards them to RabbitMQ inserting the token into the HTTP `Authorization` header.  
 
 The latter scenario is demonstrated [here](oauth2-examples-proxy.html). The former scenario is covered in the following section.
 
-#### Idp-initiated logon via the login endpoint
+#### Idp-initiated Logon using the Login Endpoint
 
-A web portal offers their authenticated users, the option to navigate to RabbitMQ by submitting a form with their OAuth  token in `access_token` form field as it is illustrated below:
+A web portal offers their authenticated users the option to navigate to RabbitMQ by submitting a form with their OAuth token in the `access_token` form field as provided below:
 
 
 <pre class="lang-plain">
@@ -172,7 +172,7 @@ A web portal offers their authenticated users, the option to navigate to RabbitM
       1. rabbit_admin from a browser                                   3. validate token        
 </pre>
 
-If the access token is valid, RabbitMQ redirects the user to the overview page.
+If the access token is valid, RabbitMQ redirects the user to the **Overview** page.
 
 By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**,
 add one entry to `advanced.config`. For example:
@@ -370,7 +370,7 @@ previous use cases, you need to launch rabbitmq first like this `make start-rabb
 make start-mqtt-publish TOKEN=$(bin/jwt_token scopes-for-mqtt.json legacy-token-key private.pem public.pem)
 </pre>
 
-> IMPORTANT: If you try to access the management ui and authenticate with UAA using rabbit_admin you
+> IMPORTANT: If you try to access the Management UI and authenticate with UAA using rabbit_admin you
 wont be able to do bind a queue with routing_key `test` to the `amq.topic` exchange because that user
 in UAA does not have the required permissions. In our handcrafted token, you have granted ourselves the right permissions/scopes.
 
@@ -655,7 +655,7 @@ make stop-perftest-consumer CONSUMER=consumer_with_roles
 
 ### <a id="preferred-username-claims" class="anchor" href="#preferred-username-claims">Preferred username claims</a>
 
-RabbitMQ needs to figure out the username associated to the token so that it can display it in the management ui.
+RabbitMQ needs to figure out the username associated to the token so that it can display it in the Management UI.
 By default, RabbitMQ will first look for the `sub` claim and if it is not found it uses the `client_id`.
 
 Most authorization servers return the user's GUID in the `sub` claim rather than the actual user's username or email address, anything the user can relate to. When the `sub` claim does not carry a *user-friendly username*, you can configure one or several claims to extract the username from the token.
@@ -825,12 +825,12 @@ This user is configured under `{uaa_repo}/uaa/src/main/webapp/WEB-INF/spring/oau
 
 The Make target `make setup-users-and-clients` accomplishes a few things:
 
-* Created `rabbit_client` client -in UAA- which is going to be used by RabbitMQ server to authenticate management users coming to the management ui.
-* Created `rabbit_admin` user -in UAA- which is going to be the full administrator user with full access
-* Created `rabbit_monitor` user -in UAA- which is going to be the monitoring user with just the *monitoring* *user tag*
-* Created `consumer` client -in UAA- which is going to be the RabbitMQ User for the consumer application
-* Created `producer` client -in UAA- which is going to be the RabbitMQ User for the producer application
-* Obtained tokens -from UAA- for the two end users and for the two clients
+* Created `rabbit_client` client -in UAA- which is going to be used by RabbitMQ server to authenticate management users coming to the Management UI.
+* Created `rabbit_admin` user -in UAA- which is going to be the full administrator user with full access.
+* Created `rabbit_monitor` user -in UAA- which is going to be the monitoring user with just the *monitoring* *user tag*.
+* Created `consumer` client -in UAA- which is going to be the RabbitMQ User for the consumer application.
+* Created `producer` client -in UAA- which is going to be the RabbitMQ User for the producer application.
+* Obtained tokens -from UAA- for the two end users and for the two clients.
 
 
 
@@ -937,7 +937,7 @@ First of all, lets quickly go thru how RabbitMQ uses the OAuth Access Tokens; ho
 
 RabbitMQ expects a [JWS](https://tools.ietf.org/html/rfc7515) in the password field.
 
-For end users, the best way to come to the management ui is by the following url, replacing `{token}` with an actual encoded JWT.
+For end users, the best way to come to the Management UI is by the following url, replacing `{token}` with an actual encoded JWT.
 This is how `make open` command is able to open the browser and login the user using a JWT.
 
 <pre class="lang-bash">
@@ -1031,7 +1031,7 @@ Let's examine the following token which corresponds to end-user `rabbit_admin`.
 </pre>
 
 These are the fields relevant for RabbitMQ:
-- `sub` ([Subject](https://tools.ietf.org/html/rfc7519#page-9)) this is the identify of the subject of the token. **RabbitMQ uses this field to identify the user**. This token corresponds to the `rabbit_admin` end user. If you logged into the management ui, you would see it in the top-right corner. If this were an AMPQ user, you would see it on each connection listed in the connections tab.  
+- `sub` ([Subject](https://tools.ietf.org/html/rfc7519#page-9)) this is the identify of the subject of the token. **RabbitMQ uses this field to identify the user**. This token corresponds to the `rabbit_admin` end user. If you logged into the Management UI, you would see it in the top-right corner. If this were an AMPQ user, you would see it on each connection listed in the connections tab.  
   UAA would add 2 more fields relative to the *subject*: a `user_id` with the same value as the `sub` field, and `user_name` with user's name. In UAA, the `sub`/`user_id` fields contains the user identifier, which is a GUID.
 
 - `client_id` (not part of the RFC-7662) identifies the OAuth client that obtained the JWT. You used `rabbit_client` client to obtain the JWT for `rabbit_admin` user. **RabbitMQ also [uses](https://github.com/rabbitmq/rabbitmq-auth-backend-oauth2/blob/master/src/rabbit_auth_backend_oauth2.erl#L169) this field to identify the user**.

--- a/site/oauth2-examples.md
+++ b/site/oauth2-examples.md
@@ -40,6 +40,7 @@ To understand the details of how to configure RabbitMQ with Oauth2, go to the [U
 	- [KeyCloak](oauth2-examples-keycloak.html)
 	- [https://auth0.com/](oauth2-examples-oauth0.html)
 	- [Azure Active Directory](oauth2-examples-azure.html)  
+    - [OAuth2 Proxy](oauth2-examples-proxy.html)
 * [Understanding the environment](#understand-the-environment)
 	- [RabbitMQ server](#rabbitmq-server)
 	- [UAA server](#uaa-server)
@@ -151,8 +152,18 @@ in `advanced.config`:
 
 ### <a id="identity-provider-initiated-logon" class="anchor" href="#identity-provider-initiated-logon">Identity-Provider initiated logon</a>
 
-When RabbitMQ is provided as a service from a web portal, it is easy to navigate to the RabbitMQ Management UI
-with a single click. The web portal retrieves a token before taking the user to the RabbitMQ Management UI web page.
+Alike Service-Provider initiated logon, with Idp-initiated logon users land to RabbitMQ management ui with a valid token.
+These two scenarios below are examples of Idp-initiated logon:
+
+* RabbitMQ is behind a web portal which conveniently allow users to navigate directly to RabbitMQ fully authenticated
+* There is an OAuth2 proxy in between users and RabbitMQ which intercepts their requests and forwards them to RabbitMQ injecting the token into the HTTP `Authorization` header  
+
+The latter scenario is demonstrated [here](oauth2-examples-proxy.html). The former scenario is covered in the following section.
+
+#### Idp-initiated logon via the login endpoint
+
+A web portal offers their authenticated users, the option to navigate to RabbitMQ by submitting a form with their OAuth  token in `access_token` form field as it is illustrated below:
+
 
 <pre class="lang-plain">
     [ Idp | WebPortal ] ----&gt; 2. /login [access_token: TOKEN]----   [ RabbitMQ Cluster ]            
@@ -161,9 +172,7 @@ with a single click. The web portal retrieves a token before taking the user to 
       1. rabbit_admin from a browser                                   3. validate token        
 </pre>
 
-How it works, firstly, the `rabbit_admin` user navigates to the web portal and clicks on the hyperlink associated with a RabbitMQ
-cluster. Next, the web portal obtains a token and redirects the user to RabbitMQ `/login` endpoint with the token within the HTTP form field `access_token`. Finally,
-RabbitMQ validates the token in the http request and if it is valid, it redirects the user to the overview page.
+If the access token is valid, RabbitMQ redirects the user to the overview page.
 
 By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**,
 add one entry to `advanced.config`. For example:
@@ -172,7 +181,6 @@ add one entry to `advanced.config`. For example:
  ...
  {rabbitmq_management, [
     {oauth_enabled, true},
-    {oauth_client_id, "rabbit_client_code"},
     {oauth_provider_url, "http://localhost:8080"},      
     {oauth_initiated_logon_type, idp_initiated},
     ...


### PR DESCRIPTION
This PR updates the management ui section and oauth2 examples in order to introduce a new capability added to the Oauth2 support in the management ui.

This PR is linked to the [PR](https://github.com/rabbitmq/rabbitmq-server/pull/7365) on the rabbitmq-server.  