### PR TITLE
Add note to AzureAD documentation about variability of role ID prefix

### DIFF
--- a/site/oauth2-examples-azure.md
+++ b/site/oauth2-examples-azure.md
@@ -75,6 +75,8 @@ App roles are defined by using the [Azure portal](https://portal.azure.com) duri
     * **Value**: `Application_ID.tag:administrator` (where *Application_ID* is the value of the *Application (client) ID* noted earlier in this tutorial)
     * **Description**: briefly describe what this role aims to (here just to give admin access to the RabbitMQ Management UI)
     * **Do you want to enable this app role**: `yes` (check the box)
+  
+    <g-emoji class="g-emoji" alias="bulb" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f4a1.png">💡</g-emoji> You can use any other predefined constant instead of `Application_ID`. See full documentation [here](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial#about-permissions).
 
 4. Click on **Apply**.
 
@@ -89,7 +91,7 @@ App roles are defined by using the [Azure portal](https://portal.azure.com) duri
     * **Value**: `Application_ID.configure:*/*` (where *Application_ID* is the value of the *Application (client) ID* noted earlier in this tutorial)
     * **Description**: briefly describe what this role aims to (here to give permissions to configure all resources on all the vhosts available on the RabbitMQ instance)
     * **Do you want to enable this app role**: `yes` (check the box)
-
+ 
 3. Click on **Apply**.
 
 ## Assign App Roles to users


### PR DESCRIPTION
From current documentation it seems, that ClientID as AppRole prefix is mandatory. 

Problem is, this can lead to headcaches for anyone who tries to create AAD application by Terraform / ARM / any manifest declaration outside of portal. You have to be able to declare your app with all roles before you know Client ID.

Solution is well documented, but this "step-by-step" tutorial is hiding it.