### PR TITLE
Add Kurtosis Starlark RabbitMQ package to the list of operations tools

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -222,6 +222,7 @@ Miscellaneous projects:
 [Chef RabbitMQ Cookbook](https://github.com/rabbitmq/chef-cookbook)
 [Puppet RabbitMQ Module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
 [RabbitMQ Docker image](https://registry.hub.docker.com/_/rabbitmq/)
+[Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
 
 
 ## <a id="database-integration" class="anchor" href="#database-integration">Database Integration</a>

--- a/site/download.md
+++ b/site/download.md
@@ -106,6 +106,7 @@ Other guides related to Kubernetes:
 
  * [Chef cookbook](https://github.com/rabbitmq/chef-cookbook)
  * [Puppet module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
+ * [Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
 
 
 ## Release Signing Key


### PR DESCRIPTION
This is a [Kurtosis Starlark Package](https://docs.kurtosis.com/quickstart) allowing you to spin up an n node RabbitMQ Cluster.