### PR TITLE
Fix devtools page bullet points format

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -219,20 +219,18 @@ Miscellaneous projects:
 
 ## <a id="operations" class="anchor" href="#operations">Provisioning (Chef, Puppet, Docker, etc)</a>
 
-[Chef RabbitMQ Cookbook](https://github.com/rabbitmq/chef-cookbook)
-[Puppet RabbitMQ Module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
-[RabbitMQ Docker image](https://registry.hub.docker.com/_/rabbitmq/)
-[Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
-
+* [Chef RabbitMQ Cookbook](https://github.com/rabbitmq/chef-cookbook)
+* [Puppet RabbitMQ Module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
+* [RabbitMQ Docker image](https://registry.hub.docker.com/_/rabbitmq/)
+* [Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
 
 ## <a id="database-integration" class="anchor" href="#database-integration">Database Integration</a>
 
-[Oracle Stored Procedures for RabbitMQ](https://github.com/pmq/rabbitmq-oracle-stored-procedures) integration.
-[RabbitMQ component for SQL Server Integration Services (SSIS)](https://github.com/kzhen/SSISRabbitMQ).
-[RabbitMQ integration with PostgreSQL](https://github.com/aweber/pgsql-listen-exchange)'s LISTEN notifications.
-[RabbitMQ Riak Exchange](https://github.com/jbrisbin/riak-exchange): a custom exchange type for RabbitMQ that uses Riak as a backing store.
-[Riak RabbitMQ postcommit Hook](https://github.com/jbrisbin/riak-rabbitmq-commit-hooks): a postcommit hook for Riak that sends any modified entries to RabbitMQ.
-
+* [Oracle Stored Procedures for RabbitMQ](https://github.com/pmq/rabbitmq-oracle-stored-procedures) integration.
+* [RabbitMQ component for SQL Server Integration Services (SSIS)](https://github.com/kzhen/SSISRabbitMQ).
+* [RabbitMQ integration with PostgreSQL](https://github.com/aweber/pgsql-listen-exchange)'s LISTEN notifications.
+* [RabbitMQ Riak Exchange](https://github.com/jbrisbin/riak-exchange): a custom exchange type for RabbitMQ that uses Riak as a backing store.
+* [Riak RabbitMQ postcommit Hook](https://github.com/jbrisbin/riak-rabbitmq-commit-hooks): a postcommit hook for Riak that sends any modified entries to RabbitMQ.
 
 ## <a id="rabbitmq-cli" class="anchor" href="#rabbitmq-cli">CLI Tools</a>
 


### PR DESCRIPTION
Two of the lists on the devtools page show on one line instead of bullet points like the other lists.  This PR fixes the format.