### PR TITLE
Added MassTransit under .NET Developer Tools.

### DIFF
--- a/site/devtools.md
+++ b/site/devtools.md
@@ -62,6 +62,7 @@ Higher level frameworks:
  * [EasyNetQ](http://easynetq.com), an easy to use, opinionated .NET API for RabbitMQ
  * [NServiceBus](http://particular.net/nservicebus), the most popular open-source service bus for .NET.
  * [Brighter](https://www.goparamore.io/), a Command Processor & Dispatcher implementation with support for task queues
+ * [MassTransit](https://masstransit.io/), an open-source distributed application framework for .NET.
 
 Miscellaneous projects:
 


### PR DESCRIPTION
MassTransit, the most downloaded open-source service bus for .NET, was somehow missing from the documentation. This PR adds it.