### PR TITLE
Mention Prometheus TLS port (15691) in Networking page 

### DIFF
--- a/site/install-debian.md
+++ b/site/install-debian.md
@@ -731,35 +731,10 @@ the files and directories must be owned by this user.
 
 ## <a id="ports" class="anchor" href="#ports">Port Access</a>
 
-RabbitMQ nodes bind to ports (open server TCP sockets) in order to accept client and CLI tool connections.
-Other processes and tools such as SELinux may prevent RabbitMQ from binding to a port. When that happens,
-the node will fail to start.
-
-CLI tools, client libraries and RabbitMQ nodes also open connections (client TCP sockets).
-Firewalls can prevent nodes and CLI tools from communicating with each other.
-Make sure the following ports are accessible:
-
- * 4369: [epmd](http://erlang.org/doc/man/epmd.html), a peer discovery service used by RabbitMQ nodes and CLI tools
- * 5672, 5671: used by AMQP 0-9-1 and 1.0 clients without and with TLS
- * 25672: used for inter-node and CLI tools communication (Erlang distribution server port)
-   and is allocated from a dynamic range (limited to a single port by default,
-   computed as AMQP port + 20000). Unless external connections on these ports are really necessary (e.g.
-   the cluster uses [federation](federation.html) or CLI tools are used on machines outside the subnet),
-   these ports should not be publicly exposed. See [networking guide](networking.html) for details.
- * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
-   and is allocated from a dynamic range (computed as server distribution port + 10000 through
-   server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672: [HTTP API](management.html) clients, [management UI](management.html) and [rabbitmqadmin](management-cli.html)
-   (only if the [management plugin](management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](web-mqtt.html) is enabled)
- * 15692: Prometheus metrics (only if the [Prometheus plugin](prometheus.html) is enabled)
-
-It is possible to [configure RabbitMQ](configure.html)
-to use [different ports and specific network interfaces](networking.html).
-
+RabbitMQ nodes bind to ports (open server TCP sockets) in order to accept client
+and CLI tool connections. Other processes and tools such as SELinux may prevent
+RabbitMQ from binding to a port. When that happens, the node will fail to start.
+Refer to the [Networking Guide](networking.html#ports) for more details.
 
 ## <a id="default-user-access" class="anchor" href="#default-user-access">Default User Access</a>
 

--- a/site/install-generic-unix.md
+++ b/site/install-generic-unix.md
@@ -150,35 +150,10 @@ The configuration files will be looked for in `/etc/rabbitmq/`.
 
 ## <a id="ports" class="anchor" href="#ports">Port Access</a>
 
-RabbitMQ nodes bind to ports (open server TCP sockets) in order to accept client and CLI tool connections.
-Other processes and tools such as SELinux may prevent RabbitMQ from binding to a port. When that happens,
-the node will fail to start.
-
-CLI tools, client libraries and RabbitMQ nodes also open connections (client TCP sockets).
-Firewalls can prevent nodes and CLI tools from communicating with each other.
-Make sure the following ports are accessible:
-
- * 4369: [epmd](http://erlang.org/doc/man/epmd.html), a peer discovery service used by RabbitMQ nodes and CLI tools
- * 5672, 5671: used by AMQP 0-9-1 and 1.0 clients without and with TLS
- * 25672: used for inter-node and CLI tools communication (Erlang distribution server port)
-   and is allocated from a dynamic range (limited to a single port by default,
-   computed as AMQP port + 20000). Unless external connections on these ports are really necessary (e.g.
-   the cluster uses [federation](federation.html) or CLI tools are used on machines outside the subnet),
-   these ports should not be publicly exposed. See [networking guide](networking.html) for details.
- * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
-   and is allocated from a dynamic range (computed as server distribution port + 10000 through
-   server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672: [HTTP API](./management.html) clients, [management UI](./management.html) and [rabbitmqadmin](./management-cli.html)
-   (only if the [management plugin](./management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](./stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](./mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](./web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](./web-mqtt.html) is enabled)
- * 15692: Prometheus metrics (only if the [Prometheus plugin](./prometheus.html) is enabled)
-
-It is possible to [configure RabbitMQ](configure.html)
-to use [different ports and specific network interfaces](networking.html).
-
+RabbitMQ nodes bind to ports (open server TCP sockets) in order to accept client
+and CLI tool connections. Other processes and tools such as SELinux may prevent
+RabbitMQ from binding to a port. When that happens, the node will fail to start.
+Refer to the [Networking Guide](networking.html#ports) for more details.
 
 ## <a id="default-user-access" class="anchor" href="#default-user-access">Default User Access</a>
 

--- a/site/install-rpm.md
+++ b/site/install-rpm.md
@@ -807,35 +807,10 @@ the files and directories must be owned by this user.
 
 ## <a id="ports" class="anchor" href="#ports"></a>
 
-RabbitMQ nodes bind to ports (open server TCP sockets) in order to accept client and CLI tool connections.
-Other processes and tools such as SELinux may prevent RabbitMQ from binding to a port. When that happens,
-the node will fail to start.
-
-CLI tools, client libraries and RabbitMQ nodes also open connections (client TCP sockets).
-Firewalls can prevent nodes and CLI tools from communicating with each other.
-Make sure the following ports are accessible:
-
- * 4369: [epmd](http://erlang.org/doc/man/epmd.html), a peer discovery service used by RabbitMQ nodes and CLI tools
- * 5672, 5671: used by AMQP 0-9-1 and 1.0 clients without and with TLS
- * 25672: used for inter-node and CLI tools communication (Erlang distribution server port)
-   and is allocated from a dynamic range (limited to a single port by default,
-   computed as AMQP port + 20000). Unless external connections on these ports are really necessary (e.g.
-   the cluster uses [federation](federation.html) or CLI tools are used on machines outside the subnet),
-   these ports should not be publicly exposed. See [networking guide](networking.html) for details.
- * 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes
-   and is allocated from a dynamic range (computed as server distribution port + 10000 through
-   server distribution port + 10010). See [networking guide](networking.html) for details.
- * 15672: [HTTP API](management.html) clients, [management UI](management.html) and [rabbitmqadmin](management-cli.html)
-   (only if the [management plugin](management.html) is enabled)
- * 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](stomp.html) is enabled)
- * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](mqtt.html) is enabled
- * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](web-stomp.html) is enabled)
- * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](web-mqtt.html) is enabled)
- * 15692: Prometheus metrics (only if the [Prometheus plugin](prometheus.html) is enabled)
-
-It is possible to [configure RabbitMQ](configure.html)
-to use [different ports and specific network interfaces](networking.html).
-
+RabbitMQ nodes bind to ports (open server TCP sockets) in order to accept client
+and CLI tool connections. Other processes and tools such as SELinux may prevent
+RabbitMQ from binding to a port. When that happens, the node will fail to start.
+Refer to the [Networking Guide](networking.html#ports) for more details.
 
 ## <a id="default-user-access" class="anchor" href="#default-user-access">Default User Access</a>
 

--- a/site/networking.md
+++ b/site/networking.md
@@ -183,7 +183,7 @@ Make sure the following ports are accessible:
  * 1883, 8883: [MQTT clients](http://mqtt.org/) without and with TLS, if the [MQTT plugin](./mqtt.html) is enabled
  * 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](./web-stomp.html) is enabled)
  * 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](./web-mqtt.html) is enabled)
- * 15692: Prometheus metrics (only if the [Prometheus plugin](./prometheus.html) is enabled)
+ * 15692, 15691: Prometheus metrics, without and with TLS (only if the [Prometheus plugin](./prometheus.html) is enabled)
 
 It is possible to [configure RabbitMQ](configure.html)
 to use [different ports and specific network interfaces](networking.html).


### PR DESCRIPTION
### Notes
RabbitMQ Prometheus supports TLS endpoint: https://www.rabbitmq.com/prometheus.html#tls. But this is not mentioned in the Networking Guide. This PR adds that.

I also update the installation guides to refer to networking.html#ports page to avoid duplication.