### PR TITLE
Document Top-Op sync period feature

### DIFF
--- a/link-local-manpages
+++ b/link-local-manpages
@@ -4,7 +4,7 @@
 # running in driver mode. This does that, assuming you have a
 # public-umbrella as a peer of rabbitmq-website.
 
-SERVER=../rabbitmq-public-umbrella/rabbitmq-server
+SERVER="${1:-../rabbitmq-server}"
 
 if [ ! -d ${SERVER} ] ; then
     echo ${SERVER} not found

--- a/site/kubernetes/operator/install-topology-operator.md
+++ b/site/kubernetes/operator/install-topology-operator.md
@@ -206,10 +206,24 @@ The following table listes the Topology Operator environment variables that are 
     </td>
     <td>
       The default value is false because this variable should NOT be used in production. When it is set to true, it exposes a set of debug endpoints
-      on the Operator Pod's metrics port for CPU and [memory profiling of the Operator with pprof](./debug-operator.md#operator-resource-usage-profiling).
+      on the Operator Pod's metrics port for CPU and <a href="debug-operator.html" target="_blank">memory profiling of
+      the Operator with pprof</a>.
     </td>
     <td>
       The pprof debug endpoint will not be exposed on the Operator Pod.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      SYNC_PERIOD
+    </td>
+    <td>
+      Configure the operator to reconcile all owned objects periodically. It accepts string values with a time suffix e.g. "15m". It accepts any value
+      parseable by <a href="https://pkg.go.dev/time#ParseDuration" target="_blank">time.ParseDuration</a> function. By default, sync period is disabled,
+      and reconciliation happens only when owned resources are updated.
+    </td>
+    <td>
+      Reconciliation will only happen when a resource is updated.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## Summary

- Document sync period feature in Topology Operator
- Small change to `link-local-manpages` since public umbrella is archived in favour of mono-repo 🐒

