### PR TITLE
document disabling modification of operator policies in HTTP API and Web UI

### DIFF
--- a/site/parameters.md
+++ b/site/parameters.md
@@ -492,3 +492,11 @@ PUT /api/operator-policies/%2f/transient-queue-ttl
         </td>
     </tr>
 </table>
+
+Modification of operator policies via the HTTP API and Web UI can be disabled
+in configuration. This makes operator policies read-only for all users via the
+HTTP API and Web UI.
+
+<pre>
+management.restrictions.operator_policy_changes.disabled = true
+</pre>


### PR DESCRIPTION
Document how modification of operator policies via the HTTP API and Web UI can be disabled with configuration.

* https://github.com/rabbitmq/rabbitmq-server/pull/7165