### PR TITLE
docs: correct link added for Management API

### DIFF
--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -504,8 +504,9 @@ via the `GET /api/queues/{vhost}/{qname}` endpoint.
     </tr>
     <tr>
       <td>Other message stats</td>
-      <td><code>message_stats.*</code> (see <a href="https://rawcdn.githack.com/rabbitmq/rabbitmq-management/&version-server-tag;/priv/www/api/index.html">HTTP API reference</a>)
-    </td>
+      <td>
+        <code>message_stats.*</code> (see <a href="https://rawcdn.githack.com/rabbitmq/rabbitmq-server/&version-server-tag;/deps/rabbitmq_management/priv/www/api/index.html">HTTP API reference</a>)
+      </td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
- The older link was returning a 404 for the HTTP API reference. 