### PR TITLE
Update tutorial-six-php.md replaced deprecated property

### DIFF
--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -260,7 +260,7 @@ $callback = function ($req) {
         array('correlation_id' => $req->get('correlation_id'))
     );
 
-    $req->delivery_info['channel']->basic_publish(
+    $req->getChannel()->basic_publish(
         $msg,
         '',
         $req->get('reply_to')


### PR DESCRIPTION
PHP amqplib delivery_info property marked as deprecated

See:
php-amqplib/php-amqplib#799
https://github.com/php-amqplib/php-amqplib/blob/master/PhpAmqpLib/Message/AMQPMessage.php#LL57C11-L57C11