### PR TITLE
Add MQTT 5.0 docs

### DIFF
--- a/site/connections.md
+++ b/site/connections.md
@@ -28,7 +28,7 @@ RabbitMQ supports several protocols:
  * [AMQP 0-9-1](./specification.html) with [extensions](extensions.html)
  * [AMQP 1.0](https://www.amqp.org/resources/download)
  * [RabbitMQ Stream Protocol](stream.html)
- * [MQTT](mqtt.html) 3.1.1
+ * [MQTT](mqtt.html) 3.1 through 5.0
  * [STOMP](stomp.html) 1.0 through 1.2
 
 Note that despite the similarities in naming, AMQP 0-9-1 and AMQP 1.0 are different protocols, not
@@ -146,9 +146,9 @@ AMQP 1.0 has a model that includes connections, sessions and links.
 After successfully opening a connection and authenticating, an application opens one or more sessions. It then
 attaches links to the session in order to publish and consume messages.
 
-#### MQTT 3.1
+#### MQTT
 
-MQTT 3.1 connections follow the flow described above. MQTT supports optional authentication.
+MQTT connections follow the flow described above. MQTT supports optional authentication.
 When it is used, RabbitMQ uses a pre-configured set of credentials.
 
 #### STOMP

--- a/site/heartbeats.md
+++ b/site/heartbeats.md
@@ -160,13 +160,11 @@ header when connecting. See [STOMP specification](https://stomp.github.io/stomp-
 
 ## <a id="mqtt" class="anchor" href="#mqtt">Heartbeats in MQTT</a>
 
-[MQTT 3.1.1 includes heartbeats](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html#_Toc385349238) under a different name
-("keepalives").  RabbitMQ MQTT plugin fully supports this
-feature.
+[MQTT includes heartbeats](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901045) under a different name ("keepalives").
+RabbitMQ MQTT plugin fully supports this feature.
 
-Keepalives in MQTT are opt-in. To enable them, set the
-`keepalive` interval when connecting. Please
-consult your MQTT client's documentation for examples.
+Keepalives in MQTT are opt-in. To enable them, set the `keepalive` interval when connecting.
+Please consult your MQTT client's documentation for examples.
 
 ## <a id="shovel-and-federation" class="anchor" href="#shovel-and-federation">Heartbeats in Shovel and Federation Plugins</a>
 

--- a/site/man/rabbitmqctl.8.html
+++ b/site/man/rabbitmqctl.8.html
@@ -2240,8 +2240,9 @@ mv \
       <dd>MQTT protocol version, which can be on of the following:
         <ul class="Bl-bullet Bl-compact">
           <li>{'MQTT', N/A}</li>
-          <li>{'MQTT', 3.1.0}</li>
-          <li>{'MQTT', 3.1.1}</li>
+          <li>{'MQTT', {3,1,0}}</li>
+          <li>{'MQTT', {3,1,1}}</li>
+          <li>{'MQTT', {5,0}}</li>
         </ul>
       </dd>
       <dt id="channels~2"><a class="permalink" href="#channels~2"><code class="Cm">channels</code></a></dt>

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -462,7 +462,7 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
     <tr>
       <th>rabbitmq_mqtt</th>
       <td>
-        MQTT 3.1.1 support.
+        MQTT support.
 
         <ul>
           <li><a href="mqtt.html">Documentation for the MQTT plugin</a></li>

--- a/site/protocols.md
+++ b/site/protocols.md
@@ -59,7 +59,7 @@ targeted towards clients in constrained devices. It has
 well defined messaging semantics for publish / subscribe,
 but not for other messaging idioms.
 
-RabbitMQ supports MQTT 3.1 via a [plugin](mqtt.html).
+RabbitMQ supports MQTT versions 3.1, 3.1.1, and 5.0 via a [plugin](mqtt.html).
 
 
 ## <a id="amqp-10" class="anchor" href="#amqp-10">AMQP 1.0</a>

--- a/site/publishers.md
+++ b/site/publishers.md
@@ -127,20 +127,26 @@ There are several common types of publisher errors that are handled using differ
 
 In AMQP 1.0 publishing happens within a context of a link.
 
-### MQTT 3.1
+### MQTT
 
-In MQTT 3.1.1, messages are published on a connection to a topic. Topics perform both routing and storage.
-In RabbitMQ, a topic is backed by a [queue](queues.html) internally.
+In MQTT, messages are published on a connection to a topic.
+The server side MQTT connection process routes messages via the [topic exchange](tutorials/amqp-concepts.html#exchange-topic) to [queues](queues.html).
 
-When publisher chooses to use QoS 1, published messages are acknowledged by the routing node
-using a [PUBACK frame](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718043),
-the publisher acknowledgement mechanism in MQTT 3.1.
+When publisher chooses to use QoS 1, published messages are acknowledged by RabbitMQ
+using a [PUBACK packet](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901121).
 
 Publishers can provide a hint to the server that the published message on the topic
-must be retained (stored for future delivery to new subscribers). Only the latest published message for each topic
+must be [retained](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901104) (stored for future delivery to new subscribers). Only the latest published message for each topic
 can be retained.
 
-Other than closing the connection, there is no mechanism by which the server can communicate
+The MQTT 5.0 PUBACK packet includes a [reason code](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901124) that tells the publisher whether publishing was successful.
+Reason codes returned by RabbitMQ include:
+
+ * `0 - Success`: **All** the queues the message was routed to successfully accepted the message.
+ * `16 - No matching subscribers`: RabbitMQ could not route the message to any queue (because there are no bindings defined to the topic exchange).
+ * `131 - Implementation specific error`: RabbitMQ rejected the message (for example when a target classic queue is unavailable).
+
+In MQTT 3.1 and 3.1.1, other than closing the connection, there is no mechanism by which the server can communicate
 a publishing error to the client.
 
 See the [MQTT](mqtt.html) and [MQTT-over-WebSockets](web-mqtt.html) guides to learn more.


### PR DESCRIPTION
Also, add sections for
* scalability check list
* MQTT QoS queue type that got added in 3.12
* metrics

Delete outdated documentation, e.g. client ID tracking in Ra.