### PR TITLE
Fix broken rpm html link

### DIFF
--- a/site/news.xml
+++ b/site/news.xml
@@ -54,7 +54,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -88,7 +88,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -119,7 +119,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -150,7 +150,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -184,7 +184,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -215,7 +215,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -250,7 +250,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -311,7 +311,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -346,7 +346,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -390,7 +390,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -424,7 +424,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>
@@ -459,7 +459,7 @@ limitations under the License.
         </p>
         <p>
           Binary builds and packages of the new release can be found on <a href="https://github.com/rabbitmq/rabbitmq-server/releases/">GitHub</a>,
-          <a href="/install-debian.html">Debian</a> and <a href="/intall-rpm.html">dnf (yum) repositories</a>.
+          <a href="/install-debian.html">Debian</a> and <a href="/install-rpm.html">dnf (yum) repositories</a>.
           See <a href="https://rabbitmq.com/download.html">RabbitMQ installation guides</a> to learn more.
         </p>
         <p>


### PR DESCRIPTION
Fix the broken link in https://www.rabbitmq.com/news.html 

`<a href="/intall-rpm.html">dnf (yum) repositories</a>` -->  https://www.rabbitmq.com/intall-rpm.html  ❌ 

to

`<a href="/install-rpm.html">dnf (yum) repositories</a>` -->  https://www.rabbitmq.com/install-rpm.html  ✅ 

@pivotal-cla This is an Obvious Fix