### PR TITLE
SEO updates in Queue topics - The approach I am taking

### DIFF
--- a/site/queues.md
+++ b/site/queues.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 ## What is a product-name; Queue?
 
-A queue in product-name; is an ordered collection of messages. Messages are enqueued and dequeued (delivered to consumers) in a ([FIFO ("first in, first out")](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner. Refer to [what is a queue?](##whatisaqueue) for a more detailed definition of a queue in general. 
+A queue in product-name; is an ordered collection of messages. Messages are enqueued and dequeued (delivered to consumers) in a ([FIFO ("first in, first out")](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner. Refer to [what is a queue?](#whatisaqueue) for a more detailed definition of a queue in general. 
 
 Many features in a messaging system are related to queues. Some RabbitMQ queue features such as priorities and [requeueing](./confirms.html) by consumers can affect the ordering as observed by consumers. 
 

--- a/site/queues.md
+++ b/site/queues.md
@@ -15,11 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# product-name; Queues
+# Queues
 
-## What is a product-name; Queue?
+## What is a Queue?
 
-A queue in product-name; is an ordered collection of messages. Messages are enqueued and dequeued (delivered to consumers) in a ([FIFO ("first in, first out")](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner. Refer to [what is a queue?](#whatisaqueue) for a more detailed definition of a queue in general. 
+A queue in product-name; is an ordered collection of messages. Messages are enqueued and dequeued (delivered to consumers) in a ([FIFO ("first in, first out")](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner. 
+
+To define a [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)) in generic terms, it is a sequential data structure with two primary operations: an item can be **enqueued** (added) at the tail and **dequeued** (consumed) from the head. 
+
+Queues play a major role in the messaging technology space. Many messaging protocols and tools assume that [publishers](./publishers.html) and [consumers](./consumers.html) communicate using a queue-like storage mechanism.
 
 Many features in a messaging system are related to queues. Some RabbitMQ queue features such as priorities and [requeueing](./confirms.html) by consumers can affect the ordering as observed by consumers. 
 
@@ -36,7 +40,6 @@ because many features still operate at the queue level, even for those protocols
 
 The information about RabbitMQ queues covered in this topic includes:
 
- * [What is a Queue?](#whatisaqueue)
  * [Queue Names](#names)
  * [Queue Properties](#properties)
  * [Message Ordering](#message-ordering) in a queue
@@ -52,12 +55,6 @@ The information about RabbitMQ queues covered in this topic includes:
 For topics related to consumers, see the [Consumers guide](./consumers.html).
 [Classic queues](./classic-queues.html), [quorum queues](./quorum-queues.html)
 and [streams](./streams.html) also have dedicated guides.
-
-## <a id="whatisaqueue" class="anchor" href="#whatisaqueue">What is a Queue?</a>
-
-A [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)) is a sequential data structure with two primary operations: an item can be **enqueued** (added) at the tail and **dequeued** (consumed) from the head. 
-
-Queues play a major role in the messaging technology space. Many messaging protocols and tools assume that [publishers](./publishers.html) and [consumers](./consumers.html) communicate using a queue-like storage mechanism.
 
 ## <a id="names" class="anchor" href="#names">Queue Names</a>
 

--- a/site/queues.md
+++ b/site/queues.md
@@ -15,59 +15,51 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Queues NOSYNTAX
+# product-name; Queues
 
-## Introduction
+## What is a product-name; Queue?
 
-This guide provides an overview of queues in RabbitMQ. Since
-many features in a messaging system are related to queues, it
-is not meant to be an exhaustive guide but rather an overview
-that provides links to other guides.
+A queue in product-name; is an ordered collection of messages. Messages are enqueued and dequeued (delivered to consumers) in a ([FIFO ("first in, first out")](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) manner. Refer to [what is a queue?](##whatisaqueue) for a more detailed definition of a queue in general. 
 
-This guide covers queues primarily in the context of [AMQP 0-9-1](tutorials/amqp-concepts.html),
-however, much of the content is applicable to other supported protocols.
+Many features in a messaging system are related to queues. Some RabbitMQ queue features such as priorities and [requeueing](./confirms.html) by consumers can affect the ordering as observed by consumers. 
 
-Some protocols (e.g. STOMP and MQTT) are based around the idea of topics.
-For them, queues act as data accumulation buffer for consumers.
+The information in this topic includes an overview of queues in RabbitMQ and also links out to other topics so you can learn more about using queues in RabbitMQ.
+
+This information primarily covers queues in the context of the [AMQP 0-9-1](tutorials/amqp-concepts.html) protocol, however, much of the content is applicable to other supported protocols.
+
+Some protocols (for example: STOMP and MQTT) are based around the idea of topics.
+For these protocols, queues act as a data accumulation buffer for consumers.
 However, it is still important to understand the role queues play
 because many features still operate at the queue level, even for those protocols.
 
-[Streams](./streams.html) is an alternative messaging data structure available in RabbitMQ.
-Streams provide different features from queues.
+[Streams](./streams.html) is an alternative messaging data structure available in RabbitMQ. Streams provide different features from queues.
 
-Some key topics covered in this guide are
+The information about RabbitMQ queues covered in this topic includes:
 
- * [Queue basics](#basics)
- * [Queue names](#names)
- * [Queue properties](#properties)
- * [Message ordering](#message-ordering) in a queue
- * [Queue durability](#durability) and how it relates to message persistence
- * [Replicated queue types](#distributed)
+ * [What is a Queue?](#whatisaqueue)
+ * [Queue Names](#names)
+ * [Queue Properties](#properties)
+ * [Message Ordering](#message-ordering) in a queue
+ * [Queue Durability](#durability) and how it relates to message persistence
+ * [Replicated Queue Types](#distributed)
  * [Temporary](#temporary-queues) and [exclusive](#exclusive-queues) queues
- * [Runtime resource](#runtime-characteristics) usage by queue replicas
- * [Optional queue arguments](#optional-arguments) ("x-arguments")
- * [Queue metrics](#metrics)
+ * [Runtime Resource](#runtime-characteristics) usage by queue replicas
+ * [Optional Queue Arguments](#optional-arguments) ("x-arguments")
+ * [Queue Metrics](#metrics)
  * [TTL](#ttl-and-limits) and length limits
- * [Priority queues](#priorities)
+ * [Priority Queues](#priorities)
 
 For topics related to consumers, see the [Consumers guide](./consumers.html).
 [Classic queues](./classic-queues.html), [quorum queues](./quorum-queues.html)
 and [streams](./streams.html) also have dedicated guides.
 
-## <a id="basics" class="anchor" href="#basics">The Basics</a>
+## <a id="whatisaqueue" class="anchor" href="#whatisaqueue">What is a Queue?</a>
 
-A [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)) is a sequential data structure
-with two primary operations: an item can be **enqueued** (added) at the tail and **dequeued** (consumed)
-from the head. Queues play a prominent role in the messaging technology space:
-many messaging protocols and tools assume that [publishers](./publishers.html) and [consumers](./consumers.html)
-communicate using a queue-like storage mechanism.
+A [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)) is a sequential data structure with two primary operations: an item can be **enqueued** (added) at the tail and **dequeued** (consumed) from the head. 
 
-Queues in RabbitMQ are [FIFO ("first in, first out")](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)).
-Some queue features, namely priorities and [requeueing](./confirms.html) by consumers, can affect
-the ordering as observed by consumers.
+Queues play a major role in the messaging technology space. Many messaging protocols and tools assume that [publishers](./publishers.html) and [consumers](./consumers.html) communicate using a queue-like storage mechanism.
 
-
-## <a id="names" class="anchor" href="#names">Names</a>
+## <a id="names" class="anchor" href="#names">Queue Names</a>
 
 Queues have names so that applications can reference them.
 
@@ -98,7 +90,7 @@ bindings (routing) for the queue, so that publishers can use well-known
 exchanges instead of the server-generated queue name directly.
 
 
-## <a id="properties" class="anchor" href="#properties">Properties</a>
+## <a id="properties" class="anchor" href="#properties">Queue Properties</a>
 
 Queues have properties that define how they behave. There is a set
 of mandatory properties and a map of optional ones:
@@ -185,7 +177,7 @@ Use operator policies to introduce guardrails for application-controlled paramet
 to resource use (e.g. peak disk space usage).
 
 
-## <a id="message-ordering" class="anchor" href="#message-ordering">Message Ordering</a>
+## <a id="message-ordering" class="anchor" href="#message-ordering">Message Ordering in RabbitMQ</a>
 
 Queues in RabbitMQ are ordered collections of messages.
 Messages are enqueued and dequeued (delivered to consumers) in the [FIFO manner](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)).


### PR DESCRIPTION
@michaelklishin and @dyozie can you please review this 1st PR for SEO updates in the OSS content just so you can see the approach that I am taking to these updates and the logic behind it. 

If you both agree with the approach etc, I will continue along this route for the other topics I need to update. @michaelklishin I will include you in all PR reviews, it is optional whether you want to review or not (perhaps a quick scan would be great), @dyozie, I will include you in the review of the first PR to get your feedback - many thanks.

SEO updates in Queues topic:

I approached it this way:
 - Used the product-name; constant in the H1 title
 - Used product-name; constant in the next H2 title (it is the most important heading in this topic - What is a RabbitMQ Queue?)
 - Then used product-name; constant in the short description.

And that is it, I have not used product-name; constant anymore in this topic, I don't think we need to, yes there will be instances in the topic of both the commercial product name and the OSS "RabbitMQ" product name but that is ok, I think users will understand that and to be honest I don't think they will even think twice about it if they are still in the topic and reading through it. The main goals we are trying to achieve here from an SEO perspective are: a) Clear, crisp titles, and short description particularly at the beginning of the topic and b) when this OSS topic is pulled into the different commercial doc sets (K8/OCI/OVA) we can quickly identify from the start of the topic what commercial RabbitMQ offering we're referring to (product-name; constant allowing us to do this (if it works) because it will be replaced by the specific product name when pulled into the commercial doc set)