### PR TITLE
SEO updates in lazy queue content

### DIFF
--- a/site/lazy-queues.md
+++ b/site/lazy-queues.md
@@ -1,40 +1,43 @@
-# Lazy Queues
+# Classic Queues Operating in "Lazy" Queue Mode (A Lazy Queue)
 
-## <a id="interstitial" class="anchor" href="#interstitial">Wait, There's a Better Way: Next Generation Classic Queue Storage</a>
+## What is a Lazy Queue
 
-This guide covers lazy mode of classic queues.
+A "lazy queue" is a classic queue which is running in `lazy` mode. When the "lazy" queue mode is set, 
+messages in classic queues are moved to disk as early as practically possible. 
+These messages are loaded into RAM only when they are requested by consumers.
 
+The other queue mode is the `default` mode. 
+If no mode is specified during declaration, then the `default` mode is used.
 
-[Quorum queues](quorum-queues.html) is an alternative, more modern queue type
+It is important to read [There is a Better Way: The Next Generation of Classic Queue Storage is to use Quorum Queues](#interstitial)] next.
+
+## <a id="interstitial" class="anchor" href="#interstitial">There is a Better Way: The Next Generation of Classic Queue Storage is to use Quorum Queues</a>
+
+**Before going into further detail about lazy queues, review the following information and recommendation and take appropriate next steps based on it.**
+
+ - Classic queues operated in `lazy` mode until **RabbitMQ 3.12**. It is important to know that from **RabbitMQ 3.12** and onwards, this `lazy` queue mode is ignored. By default, in **RabbitMQ 3.12**, classic queues
+work in a similar manner to how classic queues worked with `lazy` mode running on them. Classic queues in **RabbitMQ 3.12** may however 
+keep a small number of messages in memory (up to 2048 at the time of writing) based on the consumption rate. 
+
+ - Quorum queues should be your default choice for a replicated queue type.**
+Classic queue mirroring will be removed in a future version of RabbitMQ. 
+Classic queues will remain a supported non-replicated queue type.
+
+ - **The recommendation is:** If you are using **RabbitMQ 3.11** and earlier versions, either
+upgrade to **RabbitMQ 3.12** now and switch to quorum queues if possible (refer to [Migrate your product-name; Mirrored Classic Queues to Quorum Queues](./migrate-mcq-to-qq.md) if you want to do this)
+or turn on `lazy` queue mode for classic queues to avoid running into memory issues.
+
+[Quorum queues](quorum-queues.html) an the alternative to classic queues. Quorum Queues are a more modern queue type
 that offers high availability via replication and focuses on data safety.
-As of RabbitMQ 3.10, quorum queues [support message TTL](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-release-overview/) and
+From RabbitMQ 3.10 onwwards, quorum queues [support message TTL](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-release-overview/) and
 provide [higher throughput and more stable latency](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/) compared to mirrored classic queues.
 
-[Streams](streams.html) is a messaging data structure available as of [RabbitMQ 3.9](changelog.html),
-and is also replicated.
+[Streams](streams.html) are another messaging data structure available as of [RabbitMQ 3.9](changelog.html),
+and is also replicated. 
 
-Quorum queues should be the **default choice** for a replicated queue type.
-Classic queue mirroring will be **removed in a future version** of RabbitMQ:
-classic queues will remain a supported non-replicated queue type.
+## <a id="overview" class="anchor" href="#overview">A Deeper Dive into Lazy Queues</a>
 
-## <a id="overview" class="anchor" href="#overview">Overview</a>
-
-Until **RabbitMQ 3.12**, classic queues could operate in **lazy mode**.
-As of RabbitMQ 3.12 the queue mode is ignored and classic queues
-behave in a similar manner to lazy queues. They may however
-keep a small number of messages in memory (up to 2048 at the
-time of writing) based on the consumption rate.
-
-We recommend users of **RabbitMQ 3.11** and below to either
-upgrade to **RabbitMQ 3.12** or enable **lazy mode** to avoid
-running into memory issues.
-
-Classic queues operating in **lazy mode**
-move their contents to disk as early as practically possible,
-and only load them in RAM when requested by consumers,
-therefore the lazy denomination.
-
-One of the main goals of lazy queues is to be able to support very
+One of the main reasons for using lazy queues is to support very
 long queues (many millions of messages).  Queues can become very long
 for various reasons:
 
@@ -55,7 +58,7 @@ Even though recent versions of RabbitMQ improved the paging algorithm,
 the situation is still not ideal for use cases where you have
 many millions on messages in the queue that might need to be paged out.
 
-Lazy queues attempt to move messages to disk as early as practically possible.
+Running classic queues in `lazy` queue mode attempts to move the messages above to disk as early as practically possible.
 This means significantly fewer messages are kept in RAM in the majority of cases under normal operation.
 This comes at a cost of increased disk I/O.
 


### PR DESCRIPTION
Hi @acogoluegnes,

Can you please review this PR. The main of this PR is to do the following: 

1. Provide a clear crisp title (returned in search engine result pages (SERPs)
2. Define a classic queue in "lazy" queue mode (otherwise known as a lazy queue) - do this is the first few sentences (this is what readers will see in the SERPs)
3. Make crystal clear the recommendation is to use quorum queues instead 
4. Next is a "Deeper Dive" into lazy queues

I didn't change any other information in this topic.

Question on this content: 

_By default, queues keep an in-memory cache of messages that is filled up as messages are published into RabbitMQ. The idea of this cache is to be able to deliver messages to consumers as fast as possible. Note that persistent messages can be written to disk as they enter the broker and kept in RAM at the same time._

Q. 1. _By default, queues_  I presume you are just referring to classic queues here?
Q.2  _queues keep an in-memory cache of messages......._ is this non-persistent messages? if so should we specify this as we refer to persistent messages in the next sentence. 

Many thanks in advance