### PR TITLE
Classic Queue version at queue declare

### DIFF
--- a/site/classic-queues.md
+++ b/site/classic-queues.md
@@ -171,6 +171,10 @@ The default version can be set through configuration by setting
 only affects newly declared queues. Pre-existing queues will remain on version 1,
 until explicitly migrated or deleted and redeclared.
 
+The queue version can also be set by supplying the `x-queue-version`
+queue declaration argument with an integer specifying the desired
+version.
+
 ## <a id="resource-use" class="anchor" href="#resource-use">Resource Use with Classic Queues</a>
 
 Classic queues aim to provide reasonably good throughput in the majority

--- a/site/persistence-conf.md
+++ b/site/persistence-conf.md
@@ -123,6 +123,10 @@ The default version can be set through configuration by setting
 classic_queue.default_version = 2
 </pre>
 
+The queue version can also be set by supplying the `x-queue-version`
+queue declaration argument with an integer specifying the desired
+version.
+
 ## <a id="cq-v1" class="anchor" href="#cq-v1">How Classic Queue v1 Persistence Overview</a>
 
 First, some background: both persistent and transient messages


### PR DESCRIPTION
The RabbitMQ website does not have any mention of being able to set the queue version for Classic Queues at queue declaration. This change adds a short description on how to do so through `x-queue-version`, which is only mentioned in the following [RabbitMQ 3.12 Performance Improvements blog post](https://blog.rabbitmq.com/posts/2023/05/rabbitmq-3.12-performance-improvements/). This way of controlling the feature was however available since the launch of CQv2 in 3.10.0 as far as I can tell.

The phrasing used is lifted from the [lazy queues documentation](https://www.rabbitmq.com/lazy-queues.html#configuration) to try and maintain consistency across the website.