### PR TITLE
Update which-erlang.md

### DIFF
--- a/site/which-erlang.md
+++ b/site/which-erlang.md
@@ -51,6 +51,35 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       <ul>
         <li>3.12.6</li>
         <li>3.12.5</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>25.0</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>26.1.x</li>
+      </ul>
+    </td>
+        <td>
+      <ul class="notes">
+        <li>
+          The 3.12 release series is compatible wtih Erlang 26.
+        </li>
+        <li>
+          OpenSSL 3 support in Erlang is considered to
+          be mature enough for production.
+        </li>
+        <li>
+          Erlang 26.1 <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
+        </li>
+      </ul>
+    </td>
+  <tr>
+    <td>
+      <ul>
         <li>3.12.4</li>
         <li>3.12.3</li>
         <li>3.12.2</li>
@@ -65,7 +94,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
     </td>
     <td>
       <ul>
-        <li>26.1.x</li>
         <li>26.0.x</li>
       </ul>
     </td>
@@ -77,9 +105,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
         <li>
           OpenSSL 3 support in Erlang is considered to
           be mature enough for production.
-        </li>
-        <li>
-          Erlang 26.1 will <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
         </li>
       </ul>
     </td>


### PR DESCRIPTION
This update make the Erlang versions match what is in the release notes for RabbitMQ `3.12.0`->`3.12.6`.