### PR TITLE
Add stream replication port info

### DIFF
--- a/site/networking.md
+++ b/site/networking.md
@@ -168,7 +168,7 @@ Make sure the following ports are accessible:
  * 4369: [epmd](http://erlang.org/doc/man/epmd.html), a peer discovery service used by RabbitMQ nodes and CLI tools
  * 5672, 5671: used by AMQP 0-9-1 and AMQP 1.0 clients without and with TLS
  * 5552, 5551: used by the [RabbitMQ Stream protocol](streams.html) clients without and with TLS
- * 6000 through 6500: used by [RabbitMQ Stream](stream.html) replication
+ * 6000 through 6500: used by for Stream Core and [RabbitMQ Stream Plugin](stream.html) replication
  * 25672: used for inter-node and CLI tools communication (Erlang distribution server port)
    and is allocated from a dynamic range (limited to a single port by default,
    computed as AMQP port + 20000). Unless external connections on these ports are really necessary (e.g.

--- a/site/streams.md
+++ b/site/streams.md
@@ -519,6 +519,7 @@ will most likely need operator involvement to be recovered.
 ## <a id="configuration" class="anchor" href="#configuration">Configuring Streams</a>
 
 For stream protocol port, TLS and other configuration, see the [Stream plugin guide](stream.html).
+For required stream replication ports see the [Networking guide](networking.html#ports).
 
 
 ## <a id="resource-use" class="anchor" href="#resource-use">How Streams Use Resources</a>


### PR DESCRIPTION
We consulted the documentation, but only found later during testing that for stream replication requires specific stream replication ports. Since AMQP ports are used for the core stream it was unexpected that another port range was added for stream replication. Next time we will check the network guide for sure.

May not concern all developers, but usually network ports have to be explicitly enabled. So hoping that entry makes the requirement more obvious for people that use and support the product.