### PR TITLE
change redirect to stderr because golang log outputs stderr.

### DIFF
--- a/site/tutorials/tutorial-four-go.md
+++ b/site/tutorials/tutorial-four-go.md
@@ -487,7 +487,7 @@ If you want to save only 'warning' and 'error' (and not 'info') log
 messages to a file, just open a console and type:
 
 <pre class="lang-bash">
-go run receive_logs_direct.go warning error > logs_from_rabbit.log
+go run receive_logs_direct.go warning error 2> logs_from_rabbit.log
 </pre>
 
 If you'd like to see all the log messages on your screen, open a new


### PR DESCRIPTION
I followed the tutorial on the page below, but the logs were not written to the file. In the case of Golang, `log.Printf()` outputs to stderr, so I suggest changing the redirect to stderr.

https://www.rabbitmq.com/tutorials/tutorial-four-go.html

>
> If you want to save only 'warning' and 'error' (and not 'info') log messages to a file, just open a console and type:
> ~~~
> go run receive_logs_direct.go warning error > logs_from_rabbit.log
> ~~~