### PR TITLE
Fix small typo in pyhon tutorial four

### DIFF
--- a/site/tutorials/tutorial-four-python.md
+++ b/site/tutorials/tutorial-four-python.md
@@ -319,7 +319,7 @@ print(' [*] Waiting for logs. To exit press CTRL+C')
 
 
 def callback(ch, method, properties, body):
-    print(f" [x] {method.routing_key}:{body}"")
+    print(f" [x] {method.routing_key}:{body}")
 
 
 channel.basic_consume(


### PR DESCRIPTION
Remove extra `"` in on of the last source code examples