### PR TITLE
fix: wrong argument types and recommended consume method in php tutorial

### DIFF
--- a/site/tutorials/tutorial-five-php.md
+++ b/site/tutorials/tutorial-five-php.md
@@ -211,13 +211,15 @@ foreach ($binding_keys as $binding_key) {
 echo " [*] Waiting for logs. To exit press CTRL+C\n";
 
 $callback = function ($msg) {
-    echo ' [x] ', $msg->delivery_info['routing_key'], ':', $msg->body, "\n";
+    echo ' [x] ', $msg->getRoutingKey(), ':', $msg->getBody(), "\n";
 };
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while ($channel->is_open()) {
-    $channel->wait();
+try {
+    $channel->consume();
+} catch (\Throwable $exception) {
+    echo $exception->getMessage();
 }
 
 $channel->close();

--- a/site/tutorials/tutorial-four-php.md
+++ b/site/tutorials/tutorial-four-php.md
@@ -313,13 +313,15 @@ foreach ($severities as $severity) {
 echo " [*] Waiting for logs. To exit press CTRL+C\n";
 
 $callback = function ($msg) {
-    echo ' [x] ', $msg->delivery_info['routing_key'], ':', $msg->body, "\n";
+    echo ' [x] ', $msg->getRoutingKey(), ':', $msg->getBody(), "\n";
 };
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while ($channel->is_open()) {
-    $channel->wait();
+try {
+    $channel->consume();
+} catch (\Throwable $exception) {
+    echo $exception->getMessage();
 }
 
 $channel->close();

--- a/site/tutorials/tutorial-one-php.md
+++ b/site/tutorials/tutorial-one-php.md
@@ -55,7 +55,7 @@ on behalf of the consumer.
 > <pre class="lang-javascript">
 > {
 >     "require": {
->         "php-amqplib/php-amqplib": ">=3.0"
+>         "php-amqplib/php-amqplib": "^3.2"
 >     }
 > }
 > </pre>
@@ -64,7 +64,7 @@ on behalf of the consumer.
 >you can run the following:
 >
 > <pre class="lang-bash">
-> composer.phar install
+> php composer.phar install
 > </pre>
 >
 >There's also a [Composer installer for Windows](https://github.com/composer/windows-setup).
@@ -194,8 +194,10 @@ $callback = function ($msg) {
 
 $channel->basic_consume('hello', '', false, true, false, false, $callback);
 
-while ($channel->is_open()) {
-    $channel->wait();
+try {
+    $channel->consume();
+} catch (\Throwable $exception) {
+    echo $exception->getMessage();
 }
 </pre>
 

--- a/site/tutorials/tutorial-six-php.md
+++ b/site/tutorials/tutorial-six-php.md
@@ -252,7 +252,7 @@ function fib($n)
 
 echo " [x] Awaiting RPC requests\n";
 $callback = function ($req) {
-    $n = intval($req->body);
+    $n = intval($req->getBody());
     echo ' [.] fib(', $n, ")\n";
 
     $msg = new AMQPMessage(
@@ -268,11 +268,13 @@ $callback = function ($req) {
     $req->ack();
 };
 
-$channel->basic_qos(null, 1, null);
+$channel->basic_qos(null, 1, false);
 $channel->basic_consume('rpc_queue', '', false, false, false, false, $callback);
 
-while ($channel->is_open()) {
-    $channel->wait();
+try {
+    $channel->consume();
+} catch (\Throwable $exception) {
+    echo $exception->getMessage();
 }
 
 $channel->close();

--- a/site/tutorials/tutorial-three-php.md
+++ b/site/tutorials/tutorial-three-php.md
@@ -309,13 +309,15 @@ $channel->queue_bind($queue_name, 'logs');
 echo " [*] Waiting for logs. To exit press CTRL+C\n";
 
 $callback = function ($msg) {
-    echo ' [x] ', $msg->body, "\n";
+    echo ' [x] ', $msg->getBody(), "\n";
 };
 
 $channel->basic_consume($queue_name, '', false, true, false, false, $callback);
 
-while ($channel->is_open()) {
-    $channel->wait();
+try {
+    $channel->consume();
+} catch (\Throwable $exception) {
+    echo $exception->getMessage();
 }
 
 $channel->close();

--- a/site/tutorials/tutorial-two-php.md
+++ b/site/tutorials/tutorial-two-php.md
@@ -93,8 +93,8 @@ messages from the queue and perform the task, so let's call it `worker.php`:
 
 <pre class="lang-php">
 $callback = function ($msg) {
-  echo ' [x] Received ', $msg->body, "\n";
-  sleep(substr_count($msg->body, '.'));
+  echo ' [x] Received ', $msg->getBody(), "\n";
+  sleep(substr_count($msg->getBody(), '.'));
   echo " [x] Done\n";
 };
 
@@ -214,8 +214,8 @@ from the worker, once we're done with a task.
 
 <pre class="lang-php">
 $callback = function ($msg) {
-  echo ' [x] Received ', $msg->body, "\n";
-  sleep(substr_count($msg->body, '.'));
+  echo ' [x] Received ', $msg->getBody(), "\n";
+  sleep(substr_count($msg->getBody(), '.'));
   echo " [x] Done\n";
   $msg->ack();
 };
@@ -357,7 +357,7 @@ a new message to a worker until it has processed and acknowledged the
 previous one. Instead, it will dispatch it to the next worker that is not still busy.
 
 <pre class="lang-php">
-$channel->basic_qos(null, 1, null);
+$channel->basic_qos(null, 1, false);
 </pre>
 
 > #### Note about queue size
@@ -418,17 +418,19 @@ $channel->queue_declare('task_queue', false, true, false, false);
 echo " [*] Waiting for messages. To exit press CTRL+C\n";
 
 $callback = function ($msg) {
-    echo ' [x] Received ', $msg->body, "\n";
-    sleep(substr_count($msg->body, '.'));
+    echo ' [x] Received ', $msg->getBody(), "\n";
+    sleep(substr_count($msg->getBody(), '.'));
     echo " [x] Done\n";
     $msg->ack();
 };
 
-$channel->basic_qos(null, 1, null);
+$channel->basic_qos(null, 1, false);
 $channel->basic_consume('task_queue', '', false, false, false, false, $callback);
 
-while ($channel->is_open()) {
-    $channel->wait();
+try {
+    $channel->consume();
+} catch (\Throwable $exception) {
+    echo $exception->getMessage();
 }
 
 $channel->close();


### PR DESCRIPTION
A few small fixes in PHP tutorial:

* fix wrong argument type `basic_qos`
* recommended method for consuming messages
* object orientied way to get message properties
* require more recent library version