### PR TITLE
doc: restricting TLS to specific IPv4

### DIFF
--- a/site/networking.md
+++ b/site/networking.md
@@ -132,10 +132,11 @@ to [use IPv6 for inter-node communication and CLI tool connections](#distributio
 
 ### <a id="single-stack-ipv4" class="anchor" href="#single-stack-ipv4">Listening on IPv4 Interfaces Only</a>
 
-In this example RabbitMQ will listen on an IPv4 interface only:
+In this example RabbitMQ will listen on an IPv4 interface with specified IP address only:
 
 <pre class="lang-ini">
-listeners.tcp.1 = 192.168.1.99:5672
+listeners.tcp.1 = 192.168.1.99:5672 # Plain AMQP
+listeners.ssl.1 = 192.168.1.99:5671 # TLS (AMQPS)
 </pre>
 
 It is possible to deactivate non-TLS connections by deactivating all regular TCP listeners.


### PR DESCRIPTION
Added example how to restrict the listener to specified IPv4 on TLS.