### PR TITLE
Update tutorial-three-go.md

### DIFF
--- a/site/tutorials/tutorial-three-go.md
+++ b/site/tutorials/tutorial-three-go.md
@@ -471,7 +471,7 @@ func main() {
 If you want to save logs to a file, just open a console and type:
 
 <pre class="lang-bash">
-go run receive_logs.go > logs_from_rabbit.log
+go run receive_logs.go &> logs_from_rabbit.log
 </pre>
 
 If you wish to see the logs on your screen, spawn a new terminal and run:


### PR DESCRIPTION
In Go, `log.Printf` uses STDERR, so need to capture both STDOUT + STDERR for the logging to actually show up in a file.