### PR TITLE
Update default exchange restrictions

### DIFF
--- a/site/specification.xml
+++ b/site/specification.xml
@@ -1068,7 +1068,7 @@ limitations under the License.
           </rule>
 
           <rule>
-            <status value="ok"/>
+            <status value="doesn't"/>
             <type>MUST</type>
             <xref>queue / bind / exchange / default-exchange</xref>
             <type/>
@@ -1146,7 +1146,7 @@ limitations under the License.
           </rule>
 
           <rule>
-            <status value="ok"/>
+            <status value="doesn't"/>
             <type>MUST</type>
             <xref>queue / unbind / exchange / default-exchange</xref>
             <type/>

--- a/site/tutorials/amqp-concepts.md
+++ b/site/tutorials/amqp-concepts.md
@@ -160,6 +160,9 @@ other words, the default exchange makes it seem like it
 is possible to deliver messages directly to queues, even
 though that is not technically what is happening.
 
+The default exchange, in RabbitMQ, does not allow bind/unbind operations.
+Binding operations to the default exchange will result in an error.
+
 ### <a id="exchange-direct" class="anchor" href="#exchange-direct">Direct Exchange</a>
 
 A direct exchange delivers messages to queues based on the


### PR DESCRIPTION
RabbitMQ does not allow binding operations on the default exchange. Such
operations result in a 403 - Not Allowed error, at the time of this
writing.

We conform with the spec in the creation of the default exchange, and
default bindings i.e. every queue is implicitly bound to the default
exchange with routing key equal to queue name.
