### PR TITLE
Add missing leading dot to driver cmd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use [Python virtual environment](https://docs.python.org/3/library/venv.html) to
 python3 -m venv .venv
 source .venv/bin/activate
 pip install lxml markdown
-/driver.py [www|next|previous]
+./driver.py [www|next|previous]
 ```
 
 


### PR DESCRIPTION
While reading the project README I noticed that there was a leading dot `.` missing from the commands to use when running the driver in a python virtual environment.  With this change, the commands can be used as-is from the README.

This PR is intended to be helpful.  If there's anything you'd like changed, please let me know and I'll be more than happy to update and resubmit.