### PR TITLE
Fix RABBITMQ_MNESIA_DIR description in relocate docs

### DIFF
--- a/site/relocate.md
+++ b/site/relocate.md
@@ -111,7 +111,7 @@ file and directories have sufficient permissions
   <tr>
     <td>RABBITMQ_MNESIA_DIR</td>
     <td>
-      The directory where this RabbitMQ node's data is stored. This s
+      The directory where this RabbitMQ node's data is stored. This includes
       a schema database, message stores, cluster member information and other
       persistent node state.
     </td>


### PR DESCRIPTION
While reading through the relocate docs, I noticed that a word seemed to be missing from the `RABBITMQ_MNESIA_DIR` description.  A quick `git grep` showed what the missing word should be from a similar description in the configure docs.  This change makes the description for this environment variable internally consistent.

This PR is submitted in the hope that it is useful. If you wish for any changes, please let me know and I'll be happy to update as necessary and resubmit.