### PR TITLE
Fix plural in access control docs

### DIFF
--- a/site/access-control.md
+++ b/site/access-control.md
@@ -23,7 +23,7 @@ This document describes [authentication](#authentication) and [authorisation](#a
 in RabbitMQ. Together they allow the operator to control access to the system.
 
 Different users can be granted access only to specific [virtual hosts](./vhosts.html). Their
-permissions in each virtual hosts also can be limited.
+permissions in each virtual host also can be limited.
 
 RabbitMQ supports two major [authentication mechanisms](#mechanisms)
 as well as several [authentication and authorisation backends](#backends).


### PR DESCRIPTION
When refering to each instance of a list of things, the individual instance is singular.  Hence one should write "each virtual host" rather than "each virtual hosts".  This change fixes this issue.

This PR is intended to be helpful. If there's anything you'd like changed, please let me know and I'll be more than happy to update and resubmit.