### PR TITLE
Fix advanced.config example on quorum queue page

### DIFF
--- a/site/quorum-queues.md
+++ b/site/quorum-queues.md
@@ -730,7 +730,7 @@ The following `advanced.config` example modifies all values listed above:
  %% five replicas by default, only makes sense for nine node clusters
  {rabbit, [{quorum_cluster_size, 5},
            {quorum_commands_soft_limit, 512}]}
-]
+].
 </pre>
 
 


### PR DESCRIPTION
Add missing point to advanced.config example so it can be copied and pasted.