### PR TITLE
Fix Docker Image Url

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -73,7 +73,7 @@ Other guides related to Kubernetes:
 
 ## Docker
 
- * Docker community-maintained [RabbitMQ Docker image](https://registry.hub.docker.com/_/rabbitmq/) ([on GitHub](https://github.com/docker-library/rabbitmq/))
+ * Docker community-maintained [RabbitMQ Docker image](https://hub.docker.com/_/rabbitmq/) ([on GitHub](https://github.com/docker-library/rabbitmq/))
 
 
 ## Cloud


### PR DESCRIPTION
Pointing to the correct URL for the RabbitMQ Docker image