### PR TITLE
Update tutorial-six-python.md

### DIFF
--- a/site/tutorials/tutorial-six-python.md
+++ b/site/tutorials/tutorial-six-python.md
@@ -312,7 +312,8 @@ class FibonacciRpcClient(object):
                 correlation_id=self.corr_id,
             ),
             body=str(n))
-        self.connection.process_data_events(time_limit=None)
+	while self.response is None:
+            self.connection.process_data_events(time_limit=None)
         return int(self.response)
 
 


### PR DESCRIPTION
A while loop if necessary here (as it was before eae5cf8443b9a846e920225c) because otherwise if the client receive a message with the wrong correlation_id, then the `self.response` will be `None` and there will be `Exception` due to `return int(None)` in the next section.