### PR TITLE
doc(tutorials): improve go instructions

### DIFF
--- a/tutorials/tutorial-one-go.md
+++ b/tutorials/tutorial-one-go.md
@@ -57,11 +57,11 @@ on behalf of the consumer.
 > First, install amqp using `go get`:
 >
 > ```go
+> go mod init <your-module-name>
 > go get github.com/rabbitmq/amqp091-go
 > ```
 
-Now we have amqp installed, we can write some
-code.
+Now we have amqp installed, we can write some code.
 
 ### Sending
 
@@ -98,12 +98,14 @@ func failOnError(err error, msg string) {
 }
 ```
 
-then connect to RabbitMQ server
+then create the main function and connect to RabbitMQ server
 
 ```go
-conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
-failOnError(err, "Failed to connect to RabbitMQ")
-defer conn.Close()
+func main() {
+  conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+  failOnError(err, "Failed to connect to RabbitMQ")
+  defer conn.Close()
+}
 ```
 
 The connection abstracts the socket connection, and takes care of
@@ -191,6 +193,8 @@ func failOnError(err error, msg string) {
   }
 }
 ```
+
+Create a new directory for the receiver, like `receiver/receive.go, to avoid [DuplicateDecl](https://pkg.go.dev/golang.org/x/tools/internal/typesinternal#DuplicateDecl) error.
 
 Setting up is the same as the publisher; we open a connection and a
 channel, and declare the queue from which we're going to consume.


### PR DESCRIPTION
The goal is to improve the instructions by adding how to init a mod with Go, creating the `main` function, and adding a note to create a new directory for the receiver. This is necessary because, in GoLang, we cannot have two files with the same function name in the same directory. We cannot create two files with the same `func main(){}` name in this case.

It can improve the tutorial's clarity and prevent the reader from having problems with the module and the package. Because you need to be inside a module to run `go get`.