### PR TITLE
docusaurus.config.js: Name current version as "3.13"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,6 +69,14 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
+          // Pretend that the current/latest is 3.13.x. This should be
+          // commentted out as soon as we want to publish docs for the next
+          // branch (and 3.13.x docs should be branched).
+          versions: {
+            current: {
+              label: '3.13', // "Next" by default.
+            },
+          },
           sidebarPath: './sidebarsDocs.js',
 
           // Please change this to your repo.


### PR DESCRIPTION
## Why

We don't have a need to publish docs for the future of version RabbitMQ yet. We also have a quite some work planned to reorganize the 3.13 docs. So let's name the current version as 3.13 and branch the docs later when everything settles.