### PR TITLE
Changing the Introduction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 title: RabbitMQ Documentation
 ---
 <!--
-Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the under the Apache License,
@@ -18,292 +18,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Documentation: Table of Contents
+import {
+    RabbitMQServerReleaseBranch,
+    RabbitMQServerVersion,
+} from '@site/src/components/RabbitMQServer';
 
-This page summarises the available RabbitMQ documentation for the [latest patch release](/release-information).
+# RabbitMQ <RabbitMQServerReleaseBranch/> Documentation
 
-## Installation
+Welcome to RabbitMQ documentation!
 
-See the [Downloads and Installation](./download.md) page
-for information on the most recent release and how to install it.
+:::note
+You are currently viewing the documentation for <strong>RabbitMQ
+<RabbitMQServerVersion/></strong>.
+:::
 
+<div class="docs-tips">
+<div class="docs-tip-version-menu">
+<h2>Documentation is Versioned</h2>
 
-## Tutorials
+<span class="docs-tips-large-screen">Use the drop-down menu on the top right of any page</span>
+<span class="docs-tips-small-screen">Click the *hamburger* icon at the top left and then click **Back to main menu**</span>
+to select the documentation version for the RabbitMQ release that you are
+using. We update each version of documentation with the latest patch
+information for that release.
+</div>
 
-See the [Get Started](/tutorials) page
-for our tutorials for various programming languages.
+<div class="docs-tip-toc-menu">
+<h2>Table of Contents</h2>
 
-The tutorials offer a gentle introduction to messaging, one of the protocols RabbitMQ supports,
-key messaging features, and some common usage scenarios.
+<span class="docs-tips-large-screen">Use the navigation on the left</span>
+<span class="docs-tips-small-screen">Click the *hamburger* icon at the top left</span>
+to browse through documentation for your release of RabbitMQ. This table of
+contents is structured so it can be used by the two main RabbitMQ users:
+Developers and Administrators.
+</div>
+</div>
 
-[AMQP 0-9-1 Overview](/tutorials/amqp-concepts) provides a brief overview
-for the original RabbitMQ protocol.
+## If you are a Developer
 
+You might want to start with [Getting Started](/tutorials) if you are new to
+RabbitMQ. These tutorials will guide you on how to use RabbitMQ.
 
-## Server and Key Plugins
+If you are familiar with RabbitMQ, go directly to the **How to Use RabbitMQ**
+information to start exploring it.
 
-RabbitMQ server documentation is organised in a number of guides:
+## If you are an Administrator
 
-### Installation and Provisioning
+The table of contents for administrators is structured this way:
 
- * [Packages and repositories](./download.md)
- * [Kubernetes Operator](/kubernetes/operator/operator-overview)
- * [Provisioning Tools](./download.md) (Docker image, Chef cookbook, Puppet module, etc)
- * [Package Signatures](./signatures.md)
- * [Supported Erlang/OTP Versions](./which-erlang.md)
- * [Supported RabbitMQ Versions](/release-information)
- * [Changelog](/release-information)
- * [Snapshot (Nightly) Builds](./snapshots.md)
-
-#### Operating Systems and Platforms
-
- * [Kubernetes](/kubernetes/operator/operator-overview)
- * [Debian and Ubuntu](./install-debian.md)
- * [Red Hat Enterprise Linux, CentOS, Fedora](./install-rpm.md)
- * [Windows Installer](./install-windows.md), [Windows Configuration](./windows-configuration.md)
- * [Generic UNIX Binary Build](./install-generic-unix.md)
- * [MacOS via Homebrew](./install-homebrew.md)
- * [Amazon EC2](./ec2.md)
- * [Solaris](./install-solaris.md)
-
-
-### Upgrading
-
- * Main [Upgrading guide](./upgrade.md)
- * [Schema Definitions](./definitions.md)
- * [Blue-green deployment-based upgrade](./blue-green-upgrade.md)
-
-
-### CLI tools
-
- * [RabbitMQ CLI Tools](./cli.md): general installation and usage topics
- * [rabbitmqctl](./man/rabbitmqctl.8.md): primary RabbitMQ CLI tool
- * [rabbitmq-diagnostics](./man/rabbitmq-diagnostics.8.md): [monitoring](./monitoring.md), [health checking](./monitoring.md#health-checks), observability tooling
- * [rabbitmq-plugins](./man/rabbitmq-plugins.8.md): plugin management
- * [rabbitmq-queues](./man/rabbitmq-queues.8.md): operations on quorum queues
- * [rabbitmq-streams](./man/rabbitmq-streams.8.md): operations on streams
- * [rabbitmq-upgrade](./man/rabbitmq-upgrade.8.md): operations related to [upgrades](./upgrade.md)
- * [rabbitmqadmin](./management-cli.md) ([HTTP API](./management.md)-based zero dependency management tool)
- * [man pages](./manpages.md)
-
-
-### Configuration
-
- * [Configuration](./configure.md)
- * [File and Directory Locations](./relocate.md)
- * [Logging](./logging.md)
- * [Policies and Runtime Parameters](./parameters.md)
- * [Schema Definitions](./definitions.md)
- * [Per Virtual Host Limits](./vhosts.md)
- * [Client Connection Heartbeats](./heartbeats.md)
- * [Inter-node Connection Heartbeats](./nettick.md)
- * [Runtime Tuning](./runtime.md)
- * [Queue and Message TTL](./ttl.md)
-
-
-### Authentication and authorisation:
-
- * [Access Control](./access-control.md): main authentication and authorisation guide
- * [AMQP 0-9-1 Authentication Mechanisms](./authentication.md)
- * [Virtual Hosts](./vhosts.md)
- * [Credentials and Passwords](./passwords.md)
- * x509 (TLS) [Certificate-based client authentication](https://github.com/rabbitmq/rabbitmq-server/tree/v3.13.x/deps/rabbitmq_auth_mechanism_ssl)
- * [OAuth 2 Support](./oauth2.md)
- * [OAuth 2 Examples](./oauth2-examples.md) for common identity providers
- * [LDAP](./ldap.md)
- * [Validated User ID](./validated-user-id.md)
- * [Authentication Failure Notifications](./auth-notification.md)
-
-
-### Networking and TLS
-
- * [Client Connections](./connections.md)
- * [Networking](./networking.md)
- * [Inter-protocol Conversions](./conversions.md)
- * [Troubleshooting Network Connectivity](./troubleshooting-networking.md)
- * [Using TLS for Client Connections](./ssl.md)
- * [Using TLS for Inter-node Traffic](./clustering-ssl.md)
- * [Troubleshooting TLS](./troubleshooting-ssl.md)
-
-
-### Monitoring, Audit, Application Troubleshooting:
-
- * [Management UI and HTTP API](./management.md)
- * [Monitoring](./monitoring.md), metrics and health checks
- * [Troubleshooting guidance](./troubleshooting.md)
- * [rabbitmqadmin](./management-cli.md), an HTTP API command line tool
- * [Client Connections](./connections.md)
- * [AMQP 0-9-1 Channels](./channels.md)
- * [Inter-protocol Conversions](./conversions.md)
- * [Internal Event Exchange](./event-exchange.md)
- * [Per Virtual Host Limits](./vhosts.md#limits)
- * [Per User Limits](./user-limits.md)
- * [Message Tracing](./firehose.md)
- * [Capturing Traffic with Wireshark](/amqp-wireshark)
-
-
-### Clustering
-
- * [Clustering](./clustering.md)
- * [Cluster Formation and Peer Discovery](./cluster-formation.md)
- * [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/clustering-compression-rabbitmq.html)
-
-### Replicated Queue Types, Streams, High Availability
-
- * [Quorum Queues](./quorum-queues.md): a modern highly available replicated queue type
- * [Migrating Mirrored Classic Queues to Quorum Queues](./migrate-mcq-to-qq.md)
- * [Streams](./streams.md): a messaging abstraction that allows for repeatable consumption
- * [RabbitMQ Stream plugin](./stream.md): the plugin and binary protocol behind RabbitMQ streams
-
-### Distributed RabbitMQ
-
- * [Replication and Distributed Feature Overview](./distributed.md)
- * [Reliability](./reliability.md) of distributed deployments, publishers and consumers
- * [Federation](./federation.md)
- * [Shovel](./shovel.md)
-
-
-### Guidance
-
- * [Monitoring](./monitoring.md)
- * [Production Checklist](./production-checklist.md)
- * [Backup and Restore](./backup.md)
- * [Troubleshooting guidance](./troubleshooting.md)
- * [Reliable Message Delivery](./reliability.md)
-
-
-### Message Store and Resource Management
-
- * [Memory Usage Analysis](./memory-use.md)
- * [Memory Management](./memory.md)
- * [Resource Alarms](./alarms.md)
- * [Free Disk Space Alarms](./disk-alarms.md)
- * [Runtime Tuning](./runtime.md)
- * [Flow Control](./flow-control.md)
- * [Message Store Configuration](./persistence-conf.md)
- * [Queue and Message TTL](./ttl.md)
- * [Queue Length Limits](./maxlength.md)
- * [Lazy Queues](./lazy-queues.md)
-
-
-### Queue and Consumer Features
-
- * [Queues guide](./queues.md)
- * [Consumers guide](./consumers.md)
- * [Queue and Message TTL](./ttl.md)
- * [Queue Length Limits](./maxlength.md)
- * [Lazy Queues](./lazy-queues.md)
- * [Dead Lettering](./dlx.md)
- * [Priority Queues](./priority.md)
- * [Consumer Cancellation Notifications](./consumer-cancel.md)
- * [Consumer Prefetch](./consumer-prefetch.md)
- * [Consumer Priorities](./consumer-priority.md)
- * [Streams](./streams.md)
-
-
-### Publisher Features
-
- * [Publishers guide](./publishers.md)
- * [Exchange-to-Exchange Bindings](./e2e.md)
- * [Alternate Exchanges](./ae.md)
- * [Sender-Selected Distribution](./sender-selected.md)
-
-
-### STOMP, MQTT, WebSockets
-
- * [Client Connections](./connections.md)
- * [Inter-protocol Conversions](./conversions.md)
- * [STOMP](./stomp.md)
- * [MQTT](./mqtt.md)
- * [STOMP over WebSockets](./web-stomp.md)
- * [MQTT over WebSockets](./web-mqtt.md)
-
-
-## Man Pages
-
- * [man Pages](./manpages.md)
-
-
-## Client Libraries and Features
-
-[RabbitMQ clients documentation](/client-libraries) is organised in a number
-of guides and API references. A separate set of [tutorials](/tutorials) for
-many popular programming languages are also available, as is an [AMQP 0-9-1 Overview](/tutorials/amqp-concepts).
-
-### Client Documentation Guides
-
- * [Java Client](/client-libraries/java-api-guide)
- * [.NET Client](/client-libraries/dotnet-api-guide)
- * [Ruby Client](http://rubybunny.info)
- * [JMS Client](/client-libraries/jms-client)
- * [Erlang Client](/client-libraries/erlang-client-user-guide)
- * [RabbitMQ extensions to AMQP 0-9-1](./extensions.md)
-
-### Client-Driven Features
-
- * [Client Connections](./connections.md)
- * [Consumers](./consumers.md)
- * [Publishers](./publishers.md)
- * [Channels](./channels.md)
- * [Publisher Confirms and Consumer Acknowledgements](./confirms.md)
- * [Queue and Message TTL](./ttl.md)
- * [Queue Length Limits](./maxlength.md)
- * [Lazy Queues](./lazy-queues.md)
- * [Exchange-to-Exchange Bindings](./e2e.md)
- * [Sender-Selected Distribution](./sender-selected.md)
- * [Priority Queues](./priority.md)
- * [Consumer Cancellation Notifications](./consumer-cancel.md)
- * [Consumer Prefetch](./consumer-prefetch.md)
- * [Consumer Priorities](./consumer-priority.md)
- * [Dead Lettering](./dlx.md)
- * [Alternate Exchanges](./ae.md)
- * [Message Tracing](./firehose.md)
- * [Capturing Traffic with Wireshark](/amqp-wireshark)
-
-
-## References
-
- * [Java](https://rabbitmq.github.io/rabbitmq-java-client/api/current/)
- * [.NET](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html)
- * [AMQP 0-9-1 URI Specification](./uri-spec.md)
- * [URI Query Parameters](./uri-query-parameters.md)
-
-See [Clients and Developer Tools](/client-libraries/devtools)
-for community client libraries.
-
-
-## Plugins
-
-Popular tier 1 (built-in) plugins:
-
- * [Management](./management.md)
- * [STOMP](./stomp.md)
- * [MQTT](./mqtt.md)
- * [STOMP over WebSockets](./web-stomp.md)
- * [MQTT over WebSockets](./web-mqtt.md)
- * [Federation](./federation.md)
- * [Shovel](./shovel.md)
- * [Internal Event Exchange](./event-exchange.md)
-
-See [Community Plugins](/community-plugins),
-[RabbitMQ GitHub repositories](https://github.com/rabbitmq/)
-and the [Plugins Guide](./plugins.md) for more information about plugins.
-
-
-## Development
-
- * [RabbitMQ GitHub repositories](https://github.com/rabbitmq/)
- * [Contributor Code of Conduct](https://github.com/rabbitmq/rabbitmq-server/blob/main/CODE_OF_CONDUCT.md)
- * How to [build RabbitMQ](./build-server.md) from source, or
- * from [GitHub](/github).
-
-
-## Protocols
-
- * AMQP 0-9-1: [Extensions](./extensions.md) | [Quick Reference](/amqp-0-9-1-quickref)
- * [STOMP](./stomp.md)
- * [MQTT](./mqtt.md)
- * [STOMP over WebSockets](./web-stomp.md)
- * [MQTT over WebSockets](./web-mqtt.md)
- * [AMQP 0-9-1 implementation details](/amqp-0-9-1-protocol).
- * [AMQP 0-9-1 Errata document](/amqp-0-9-1-errata).
+- The **How to Manage RabbitMQ** section provides documentation for configuring
+  and managing the RabbitMQ broker.
+- The **How to Monitor RabbitMQ** section includes information which will guide
+  you on how to setup monitoring for RabbitMQ and the applications that use it.

--- a/src/components/RabbitMQServer/index.js
+++ b/src/components/RabbitMQServer/index.js
@@ -36,6 +36,11 @@ export function RabbitMQServerProductName() {
   return 'RabbitMQ';
 }
 
+export function RabbitMQServerReleaseBranch(props = {}) {
+  const branch = getBranchOrDefault(props);
+  return branch;
+}
+
 export function RabbitMQServerVersion(props = {}) {
   const version = getLatestVersionForCurrentBranch(props);
   return version;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -116,7 +116,63 @@ html[data-theme='dark'] .mermaid-msg > rect {
   font-size: smaller !important;
 }
 
-/* Release Information table. */
+/* -------------------------------------------------------------------
+/* Docs introductino page.
+ * ------------------------------------------------------------------- */
+
+/*
+ * The arrow icons were created by krystonschwarze and licensed under the CC-BY
+ * terms. The files were downloaded from svgrepo.com:
+ * - https://www.svgrepo.com/svg/510811/arrow-left-sm
+ * - https://www.svgrepo.com/svg/510834/arrow-up-right-sm
+ *
+ * The files were modified to crop the margins around the arrows.
+ */
+
+.docs-tips-large-screen {
+  display: none;
+}
+
+.docs-tips-small-screen {
+  display: unset;
+}
+
+@media (min-width: 997px) {
+  .docs-tips {
+    margin-top: calc(var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
+
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 1em;
+  }
+
+  .docs-tips div {
+    background-repeat: no-repeat;
+    background-position: top 3px left;
+    background-size: var(--ifm-h2-font-size);
+    padding-left: calc(var(--ifm-h2-font-size) + 20px);
+  }
+
+  .docs-tip-version-menu {
+    background-image: url("/img/arrow-up-right.svg");
+  }
+
+  .docs-tip-toc-menu {
+    background-image: url("/img/arrow-left.svg");
+  }
+
+  .docs-tips-large-screen {
+    display: unset;
+  }
+
+  .docs-tips-small-screen {
+    display: none;
+  }
+}
+
+/* -------------------------------------------------------------------
+/* Release Information table.
+ * ------------------------------------------------------------------- */
 
 .release-information {
   --ri-color-latest: #d4f4b4;

--- a/static/img/arrow-left.svg
+++ b/static/img/arrow-left.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 12 12"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="arrow-left.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.029672"
+     inkscape:cx="199.57813"
+     inkscape:cy="166.5579"
+     inkscape:window-width="1916"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <g
+     id="Arrow / Arrow_Left_SM"
+     transform="translate(-6,-6)">
+    <path
+       id="Vector"
+       d="M 17,12 H 7 m 0,0 4,4 M 7,12 11,8"
+       stroke="#000000"
+       stroke-width="2"
+       stroke-linecap="round"
+       stroke-linejoin="round" />
+  </g>
+</svg>

--- a/static/img/arrow-up-right.svg
+++ b/static/img/arrow-up-right.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 12 12"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="arrow-up-right.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.029672"
+     inkscape:cx="166.5579"
+     inkscape:cy="167.52908"
+     inkscape:window-width="1916"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <g
+     id="Arrow / Arrow_Up_Right_SM"
+     transform="translate(-6,-6)">
+    <path
+       id="Vector"
+       d="m 8,16 8,-8 m 0,0 h -6 m 6,0 v 6"
+       stroke="#000000"
+       stroke-width="2"
+       stroke-linecap="round"
+       stroke-linejoin="round" />
+  </g>
+</svg>


### PR DESCRIPTION
Why:
The [current introduction page ](https://www.rabbitmq.com/docs/documentation) is a table of contents, now that we have a doc table of contents on the new site, we don't need to list links to all the docs on this page. Updating now to provide users with a docs welcome page to help them navigate around this new versioned documentation site. 