### PR TITLE
Fixed Markdown formatting issue with html character entities

### DIFF
--- a/tutorials/tutorial-five-dotnet.md
+++ b/tutorials/tutorial-five-dotnet.md
@@ -166,7 +166,7 @@ channel.ExchangeDeclare(exchange: "topic_logs", type: ExchangeType.Topic);
 // declare a server-named queue
 var queueName = channel.QueueDeclare().QueueName;
 
-if (args.Length &lt; 1)
+if (args.Length < 1)
 {
     Console.Error.WriteLine("Usage: {0} [binding_key...]",
                             Environment.GetCommandLineArgs()[0]);

--- a/tutorials/tutorial-five-elixir.md
+++ b/tutorials/tutorial-five-elixir.md
@@ -172,7 +172,7 @@ if length(System.argv) == 0 do
   IO.puts "Usage: mix run receive_logs_topic.exs [binding_key]..."
   System.halt(1)
 end
-for binding_key &lt;- System.argv do
+for binding_key <- System.argv do
   AMQP.Queue.bind(channel, queue_name, "topic_logs", routing_key: binding_key)
 end
 

--- a/tutorials/tutorial-five-go.md
+++ b/tutorials/tutorial-five-go.md
@@ -186,7 +186,7 @@ func main() {
 
 func bodyFrom(args []string) string {
         var s string
-        if (len(args) &lt; 3) || os.Args[2] == "" {
+        if (len(args) < 3) || os.Args[2] == "" {
                 s = "hello"
         } else {
                 s = strings.Join(args[2:], " ")
@@ -196,7 +196,7 @@ func bodyFrom(args []string) string {
 
 func severityFrom(args []string) string {
         var s string
-        if (len(args) &lt; 2) || os.Args[1] == "" {
+        if (len(args) < 2) || os.Args[1] == "" {
                 s = "anonymous.info"
         } else {
                 s = os.Args[1]
@@ -253,7 +253,7 @@ func main() {
         )
         failOnError(err, "Failed to declare a queue")
 
-        if len(os.Args) &lt; 2 {
+        if len(os.Args) < 2 {
                 log.Printf("Usage: %s [binding_key]...", os.Args[0])
                 os.Exit(0)
         }
@@ -289,7 +289,7 @@ func main() {
         }()
 
         log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-        &lt;-forever
+        <-forever
 }
 ```
 

--- a/tutorials/tutorial-five-java.md
+++ b/tutorials/tutorial-five-java.md
@@ -176,7 +176,7 @@ public class ReceiveLogsTopic {
     channel.exchangeDeclare(EXCHANGE_NAME, "topic");
     String queueName = channel.queueDeclare().getQueue();
 
-    if (argv.length &lt; 1) {
+    if (argv.length < 1) {
         System.err.println("Usage: ReceiveLogsTopic [binding_key]...");
         System.exit(1);
     }

--- a/tutorials/tutorial-four-dotnet.md
+++ b/tutorials/tutorial-four-dotnet.md
@@ -212,7 +212,7 @@ channel.ExchangeDeclare(exchange: "direct_logs", type: ExchangeType.Direct);
 // declare a server-named queue
 var queueName = channel.QueueDeclare().QueueName;
 
-if (args.Length &lt; 1)
+if (args.Length < 1)
 {
     Console.Error.WriteLine("Usage: {0} [info] [warning] [error]",
                             Environment.GetCommandLineArgs()[0]);

--- a/tutorials/tutorial-four-elixir.md
+++ b/tutorials/tutorial-four-elixir.md
@@ -144,7 +144,7 @@ we're interested in.
 ```elixir
 {:ok, %{queue: queue_name}} = AMQP.Queue.declare(channel, "", exclusive: true)
 
-for {severity, true} &lt;- severities do
+for {severity, true} <- severities do
   binding_key = severity |> to_string
   AMQP.Queue.bind(channel, queue_name, "direct_logs", routing_key: binding_key)
 end
@@ -180,7 +180,7 @@ message =
 
 AMQP.Exchange.declare(channel, "direct_logs", :direct)
 
-for {severity, true} &lt;- severities do
+for {severity, true} <- severities do
   severity = severity |> to_string
   AMQP.Basic.publish(channel, "direct_logs", severity, message)
   IO.puts " [x] Sent '[#{severity}] #{message}'"
@@ -217,7 +217,7 @@ AMQP.Exchange.declare(channel, "direct_logs", :direct)
 
 {:ok, %{queue: queue_name}} = AMQP.Queue.declare(channel, "", exclusive: true)
 
-for {severity, true} &lt;- severities do
+for {severity, true} <- severities do
   binding_key = severity |> to_string
   AMQP.Queue.bind(channel, queue_name, "direct_logs", routing_key: binding_key)
 end

--- a/tutorials/tutorial-four-go.md
+++ b/tutorials/tutorial-four-go.md
@@ -193,7 +193,7 @@ q, err := ch.QueueDeclare(
 )
 failOnError(err, "Failed to declare a queue")
 
-if len(os.Args) &lt; 2 {
+if len(os.Args) < 2 {
   log.Printf("Usage: %s [info] [warning] [error]", os.Args[0])
   os.Exit(0)
 }
@@ -277,7 +277,7 @@ func main() {
 
 func bodyFrom(args []string) string {
         var s string
-        if (len(args) &lt; 3) || os.Args[2] == "" {
+        if (len(args) < 3) || os.Args[2] == "" {
                 s = "hello"
         } else {
                 s = strings.Join(args[2:], " ")
@@ -287,7 +287,7 @@ func bodyFrom(args []string) string {
 
 func severityFrom(args []string) string {
         var s string
-        if (len(args) &lt; 2) || os.Args[1] == "" {
+        if (len(args) < 2) || os.Args[1] == "" {
                 s = "info"
         } else {
                 s = os.Args[1]
@@ -344,7 +344,7 @@ func main() {
         )
         failOnError(err, "Failed to declare a queue")
 
-        if len(os.Args) &lt; 2 {
+        if len(os.Args) < 2 {
                 log.Printf("Usage: %s [info] [warning] [error]", os.Args[0])
                 os.Exit(0)
         }
@@ -380,7 +380,7 @@ func main() {
         }()
 
         log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-        &lt;-forever
+        <-forever
 }
 ```
 

--- a/tutorials/tutorial-four-java.md
+++ b/tutorials/tutorial-four-java.md
@@ -203,7 +203,7 @@ public class ReceiveLogsDirect {
     channel.exchangeDeclare(EXCHANGE_NAME, "direct");
     String queueName = channel.queueDeclare().getQueue();
 
-    if (argv.length &lt; 1) {
+    if (argv.length < 1) {
         System.err.println("Usage: ReceiveLogsDirect [info] [warning] [error]");
         System.exit(1);
     }

--- a/tutorials/tutorial-one-go.md
+++ b/tutorials/tutorial-one-go.md
@@ -250,7 +250,7 @@ go func() {
 }()
 
 log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-&lt;-forever
+<-forever
 ```
 
 [Here's the whole receive.go script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/go/receive.go).

--- a/tutorials/tutorial-seven-dotnet.md
+++ b/tutorials/tutorial-seven-dotnet.md
@@ -177,7 +177,7 @@ sample that uses a dictionary to correlate the publishing sequence number
 with the string body of the message:
 
 ```csharp
-var outstandingConfirms = new ConcurrentDictionary&lt;ulong, string&gt;();
+var outstandingConfirms = new ConcurrentDictionary<ulong, string>();
 // ... code for confirm callbacks will come later
 var body = "...";
 outstandingConfirms.TryAdd(channel.NextPublishSeqNo, body);
@@ -189,13 +189,13 @@ to clean this dictionary when confirms arrive and do something like logging a wa
 when messages are nack-ed:
 
 ```csharp
-var outstandingConfirms = new ConcurrentDictionary&lt;ulong, string&gt;();
+var outstandingConfirms = new ConcurrentDictionary<ulong, string>();
 
 void CleanOutstandingConfirms(ulong sequenceNumber, bool multiple)
 {
     if (multiple)
     {
-        var confirmed = outstandingConfirms.Where(k =&gt; k.Key &lt;= sequenceNumber);
+        var confirmed = outstandingConfirms.Where(k => k.Key <= sequenceNumber);
         foreach (var entry in confirmed)
         {
             outstandingConfirms.TryRemove(entry.Key, out _);

--- a/tutorials/tutorial-seven-java.md
+++ b/tutorials/tutorial-seven-java.md
@@ -182,10 +182,10 @@ to clean this map when confirms arrive and do something like logging a warning
 when messages are nack-ed:
 
 ```java
-ConcurrentNavigableMap<Long, String&gt; outstandingConfirms = new ConcurrentSkipListMap<&gt;();
+ConcurrentNavigableMap<Long, String> outstandingConfirms = new ConcurrentSkipListMap<>();
 ConfirmCallback cleanOutstandingConfirms = (sequenceNumber, multiple) -> {
     if (multiple) {
-        ConcurrentNavigableMap<Long, String&gt; confirmed = outstandingConfirms.headMap(
+        ConcurrentNavigableMap<Long, String> confirmed = outstandingConfirms.headMap(
           sequenceNumber, true
         );
         confirmed.clear();

--- a/tutorials/tutorial-six-dotnet.md
+++ b/tutorials/tutorial-six-dotnet.md
@@ -277,7 +277,7 @@ public class RpcClient : IDisposable
     private readonly IConnection connection;
     private readonly IModel channel;
     private readonly string replyQueueName;
-    private readonly ConcurrentDictionary&lt;string, TaskCompletionSource&lt;string>> callbackMapper = new();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<string>> callbackMapper = new();
 
     public RpcClient()
     {
@@ -302,14 +302,14 @@ public class RpcClient : IDisposable
                              autoAck: true);
     }
 
-    public Task&lt;string&gt; CallAsync(string message, CancellationToken cancellationToken = default)
+    public Task<string>; CallAsync(string message, CancellationToken cancellationToken = default)
     {
         IBasicProperties props = channel.CreateBasicProperties();
         var correlationId = Guid.NewGuid().ToString();
         props.CorrelationId = correlationId;
         props.ReplyTo = replyQueueName;
         var messageBytes = Encoding.UTF8.GetBytes(message);
-        var tcs = new TaskCompletionSource&lt;string&gt;();
+        var tcs = new TaskCompletionSource<string>();
         callbackMapper.TryAdd(correlationId, tcs);
 
         channel.BasicPublish(exchange: string.Empty,
@@ -332,7 +332,7 @@ public class Rpc
     public static async Task Main(string[] args)
     {
         Console.WriteLine("RPC Client");
-        string n = args.Length &gt; 0 ? args[0] : "30";
+        string n = args.Length > 0 ? args[0] : "30";
         await InvokeAsync(n);
 
         Console.WriteLine(" Press [enter] to exit.");

--- a/tutorials/tutorial-six-go.md
+++ b/tutorials/tutorial-six-go.md
@@ -273,7 +273,7 @@ func main() {
         }()
 
         log.Printf(" [*] Awaiting RPC requests")
-        &lt;-forever
+        <-forever
 }
 ```
 
@@ -313,7 +313,7 @@ func failOnError(err error, msg string) {
 
 func randomString(l int) string {
         bytes := make([]byte, l)
-        for i := 0; i &lt; l; i++ {
+        for i := 0; i < l; i++ {
                 bytes[i] = byte(randInt(65, 90))
         }
         return string(bytes)
@@ -396,7 +396,7 @@ func main() {
 
 func bodyFrom(args []string) int {
         var s string
-        if (len(args) &lt; 2) || os.Args[1] == "" {
+        if (len(args) < 2) || os.Args[1] == "" {
                 s = "30"
         } else {
                 s = strings.Join(args[1:], " ")

--- a/tutorials/tutorial-three-go.md
+++ b/tutorials/tutorial-three-go.md
@@ -307,7 +307,7 @@ func main() {
 
 func bodyFrom(args []string) string {
         var s string
-        if (len(args) &lt; 2) || os.Args[1] == "" {
+        if (len(args) < 2) || os.Args[1] == "" {
                 s = "hello"
         } else {
                 s = strings.Join(args[1:], " ")
@@ -401,7 +401,7 @@ func main() {
         }()
 
         log.Printf(" [*] Waiting for logs. To exit press CTRL+C")
-        &lt;-forever
+        <-forever
 }
 ```
 

--- a/tutorials/tutorial-three-java.md
+++ b/tutorials/tutorial-three-java.md
@@ -207,7 +207,7 @@ public class EmitLog {
          Channel channel = connection.createChannel()) {
         channel.exchangeDeclare(EXCHANGE_NAME, "fanout");
 
-        String message = argv.length &lt; 1 ? "info: Hello World!" :
+        String message = argv.length < 1 ? "info: Hello World!" :
                             String.join(" ", argv);
 
         channel.basicPublish(EXCHANGE_NAME, "", null, message.getBytes("UTF-8"));

--- a/tutorials/tutorial-three-spring-amqp.md
+++ b/tutorials/tutorial-three-spring-amqp.md
@@ -294,7 +294,7 @@ public class Tut3Sender {
 		if (dots.getAndIncrement() == 3) {
 			dots.set(1);
 		}
-		for (int i = 0; i &lt; dots.get(); i++) {
+		for (int i = 0; i < dots.get(); i++) {
 			builder.append('.');
 		}
 		builder.append(count.incrementAndGet());

--- a/tutorials/tutorial-two-go.md
+++ b/tutorials/tutorial-two-go.md
@@ -89,7 +89,7 @@ Here is the `bodyFrom` function:
 ```go
 func bodyFrom(args []string) string {
 	var s string
-	if (len(args) &lt; 2) || os.Args[1] == "" {
+	if (len(args) < 2) || os.Args[1] == "" {
 		s = "hello"
 	} else {
 		s = strings.Join(args[1:], " ")
@@ -127,7 +127,7 @@ go func() {
 }()
 
 log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-&lt;-forever
+<-forever
 ```
 
 Note that our fake task simulates execution time.
@@ -266,7 +266,7 @@ go func() {
 }()
 
 log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-&lt;-forever
+<-forever
 ```
 
 Using this code, you can ensure that even if you terminate a worker using
@@ -476,7 +476,7 @@ func main() {
 
 func bodyFrom(args []string) string {
         var s string
-        if (len(args) &lt; 2) || os.Args[1] == "" {
+        if (len(args) < 2) || os.Args[1] == "" {
                 s = "hello"
         } else {
                 s = strings.Join(args[1:], " ")
@@ -557,7 +557,7 @@ func main() {
         }()
 
         log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
-        &lt;-forever
+        <-forever
 }
 ```
 


### PR DESCRIPTION
## Trivial / obvious fix

Some tutorials contained example code that used the html character entities `&lt;` and `&gt;` instead of `< >`.
Similarly to #1807 this PR aims to fix some of these issues.

Other possible erronous files that I was not sure about and therefore did not edit:
- tutorial-five-javascript.md
- Many php tutorials
- Many objective-C tutorials
- Other Markdown files containing &lt; and &gt;