### PR TITLE
docusaurus.config.js: Mention RabbitMQ 3.13.0 in the announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -192,6 +192,13 @@ const config = {
           },
         ],
       },
+      announcementBar: {
+        id: 'new-release',
+        content: '<strong style="font-size: var(--ifm-h4-font-size);"><a href="/blog/2024/03/11/rabbitmq-3.13.0-announcement">RabbitMQ 3.13.0 is released!</a></strong>',
+        backgroundColor: 'var(--ifm-color-primary-contrast-background)',
+        textColor: 'var(--ifm-font-color-base)',
+        isCloseable: true,
+      },
       footer: {
         style: 'dark',
         links: [


### PR DESCRIPTION
## How

The link points to the announcement on the blog.

The colors are the ones used by the "contrasty" blocks on the homepage. This allows to distinguish the announcement bar from the main menu, without dragging too much attention to it (because it is displayed on all pages by default).