### PR TITLE
Add more training and consulting providers

### DIFF
--- a/src/pages/commercial-offerings.md
+++ b/src/pages/commercial-offerings.md
@@ -54,6 +54,8 @@ The following companies provide free, virtual, or instructor-led courses for Rab
  - [VMware](https://tanzu.academy/courses/rabbitmq-icm)
  - [Erlang Solutions](https://www.erlang-solutions.com/products/rabbitmq.html)
  - [LearnQuest](http://www.learnquest.com/course-detail.aspx?cnum=rabbitmq-e1xc)
+ - [Seventh State](https://seventhstate.io/)
+ - [Coders 51](https://www.coders51.com/)
 
 These <strong>training courses</strong> cover learning messaging with RabbitMQ, use cases, patterns,
 best practice design, and architecture.
@@ -63,7 +65,7 @@ best practice design, and architecture.
 [Erlang Solutions](https://www.erlang-solutions.com/products/rabbitmq.html),
 [XPlatform Consulting](http://www.xplatformconsulting.com/rabbitmq/),
 [NobleProg](https://www.nobleprog.com/consulting/rabbitmq),
-[AceMQ](https://acemq.com/rabbitmq/), [CSS Commerce](https://csscommerce.com/integration-message-queue-specialists/), [Visual Integrator](https://www.visualintegrator.com/rmq/), and others provide **professional consulting services**
+[AceMQ](https://acemq.com/rabbitmq/), [CSS Commerce](https://csscommerce.com/integration-message-queue-specialists/), [Visual Integrator](https://www.visualintegrator.com/rmq/), [Seventh State](https://seventhstate.io/), [Coders 51](https://www.coders51.com/), and others provide **professional consulting services**
 to address specific issues such as on-site troubleshooting, design review,
 deployment planning, project delivery and other value-adding services
 tailored to suit your needs.


### PR DESCRIPTION
Request from @HowardTwine to add these companies as providers of both training and consulting, slack conversation below:
<img width="636" alt="Screenshot 2024-03-19 at 16 40 54" src="https://github.com/rabbitmq/rabbitmq-website/assets/92340956/dc97b4cb-28b7-4ce6-a6c1-0b05d3693cd3">

@dumbbell can you please review and merge if all ok, thanks. 