### PR TITLE
Make it easier to find information about the logging levels in logging.md

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -77,6 +77,8 @@ if the environment variable is set, the configuration key `log.file` will not ha
 RabbitMQ starts logging early on node start. See the [Configuration guide](./configure)
 for a general overview of how to configure RabbitMQ.
 
+The full list of available configuration options can be found in the [example rabbitmq.conf -file](https://github.com/rabbitmq/rabbitmq-server/blob/v3.13.x/deps/rabbit/docs/rabbitmq.conf.example).
+
 ### Logging to a File {#logging-to-a-file}
 
 Logging to a file is one of the most common options for RabbitMQ installations. In modern releases,


### PR DESCRIPTION
This PR creates interlinks to the _Logging Levels_ section in logging.md and moves the mention/link to the example config file to the summary of _Configuration_ section.

### In more detail

The old links (on lines [110](https://github.com/rabbitmq/rabbitmq-website/compare/main...MiriPii:rabbitmq-website:patch-1?expand=1#diff-1a5e57d66b08bec5a71860d67f06912a004f03368c36910099d4ffae12970c7dL110) and [220](https://github.com/rabbitmq/rabbitmq-website/compare/main...MiriPii:rabbitmq-website:patch-1?expand=1#diff-1a5e57d66b08bec5a71860d67f06912a004f03368c36910099d4ffae12970c7dL220))suggest that the list of available logging levels can be found from the [example rabbitmq.conf -file](https://github.com/rabbitmq/rabbitmq-server/blob/v3.13.x/deps/rabbit/docs/rabbitmq.conf.example) which is false.

However, the logging.md already has a separate section on the topic with a clear table of the available logging levels and it would be helpful to guide the reader into that section instead.