### PR TITLE
README.md: Clarify how the licenses are applied to the content

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,18 @@ npm run build
 This is important to run this command before pushing changes to GitHub to make
 sure the build is successful. This is the command that will be used to deploy
 the website in production.
+
+## Copyright and License
+
+© 2007-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to
+Broadcom Inc. and/or its subsidiaries.
+
+<img align="right" width="180" src="http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-nc-nd.eu.svg">
+
+The RabbitMQ documentation is dual-licensed under the Apache License 2.0 and
+the Mozilla Public License 2.0. Users can choose any of these licenses
+according to their needs. However, **the blog is excluded from this license and
+remains the intellectual property of Broadcom Inc.** Blog posts may not be
+restributed.
+
+SPDX-License-Identifier: Apache-2.0 OR MPL-2.0

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -117,7 +117,7 @@ html[data-theme='dark'] .mermaid-msg > rect {
 }
 
 /* -------------------------------------------------------------------
-/* Docs introductino page.
+ * Docs introductino page.
  * ------------------------------------------------------------------- */
 
 /*
@@ -171,7 +171,7 @@ html[data-theme='dark'] .mermaid-msg > rect {
 }
 
 /* -------------------------------------------------------------------
-/* Release Information table.
+ * Release Information table.
  * ------------------------------------------------------------------- */
 
 .release-information {
@@ -268,4 +268,43 @@ html[data-theme='dark'] .release-information {
 .release-legend dd {
   grid-column-start: 2;
   margin-left: 0.5em;
+}
+
+/* -------------------------------------------------------------------
+ * Trademark guildelines page.
+ * ------------------------------------------------------------------- */
+
+.logos-gallery {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.logos-gallery img {
+  display: block;
+  height: 35px;
+  border: none;
+  margin: 0px auto;
+}
+
+.logos-gallery figcaption {
+  text-align: center;
+}
+
+.logos-gallery p {
+  margin: 0.5em 0px;
+}
+
+.logos-gallery a {
+  font-style: normal;
+}
+
+@media (min-width: 997px) {
+  .logos-gallery {
+    flex-direction: row;
+  }
+
+  .logos-gallery img {
+    height: 50px;
+  }
 }

--- a/src/pages/trademark-guidelines.md
+++ b/src/pages/trademark-guidelines.md
@@ -1,9 +1,9 @@
 ---
 title: RabbitMQ Trademark Guidelines
-displayed_sidebar: docsSidebar
 ---
 <!--
-Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term "Broadcom"
+refers to Broadcom Inc. and/or its subsidiaries.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the under the Apache License,
@@ -21,375 +21,242 @@ limitations under the License.
 
 # RabbitMQ Trademark Guidelines
 
-<ol class="plain">
-  <li>
-    <p>
-      **PURPOSE.** VMware, Inc. (“VMware”) owns a number of
-      international trademarks and logos that identify the RabbitMQ community
-      and individual RabbitMQ projects (“RabbitMQ Marks”). These trademarks
-      include:
-    </p>
-    <ol class="alpha">
-      <li>
-        <p>
-          **Word: RABBITMQ**
-        </p>
-      </li>
-      <li>
-        <p>
-          **Logos:**
-        </p>
-        <img src="/img/rabbitmq-logo-with-name.svg" alt="This image displays the RabbitMQ logo, followed by the word RabbitMQ, followed by the trademark (TM)."/>
-      </li>
-    </ol>
-    <p>
-      This policy outlines VMware’s policy and guidelines about the use of
-      the RabbitMQ trademarks by members of the RabbitMQ development and
-      user community.
-    </p>
-  </li>
-  <li>
-    <p>
-      **
-        WHY HAVE TRADEMARK GUIDELINES?
-      ** The RabbitMQ Marks are a symbol of the
-      quality and community support associated with the RabbitMQ open
-      source software. Trademarks protect not only those using the marks,
-      but the entire community as well. Our community members need to know
-      that they can rely on the quality and capabilities represented by the
-      brand. We also want to provide a level playing field. No one should
-      use the RabbitMQ marks in ways that mislead or take advantage of the
-      community, or make unfair use of the trademarks. Also, use of the
-      RabbitMQ Marks should not be in a disparaging manner because we
-      prefer that our marks not be used to be rude about the RabbitMQ open
-      source project or its members.
-    </p>
-  </li>
-  <li>
-    <p>
-      **
-        OPEN SOURCE LICENSE VS. TRADEMARKS.
-      ** The Apache 2.0 license gives you
-      the right to use, copy, distribute and modify the RabbitMQ software.
-      However, open source licenses like the Apache 2.0 license do not
-      address trademarks. RabbitMQ Marks need to be used in a way
-      consistent with trademark law, and that is why we have prepared this
-      policy – to help you understand what branding is allowed or required
-      when using our software under the Apache license.
-    </p>
-  </li>
-  <li>
-    <p>
-      **
-        PROPER USE OF THE RabbitMQ MARKS.
-      ** We want to encourage a robust
-      community for the RabbitMQ open source project. Therefore, you may do
-      any of the following, as long as you do so in a way that does not
-      devalue, dilute, or disparage the RabbitMQ brand. In other words,
-      when you do these things, you should behave responsibly and
-      reasonably in the interest of the community, but you do not need a
-      trademark license from us to do them.
-    </p>
-    <ol class="alpha">
-      <li>
-        <p>
-          **
-            Nominative Use.
-          ** You may engage in “nominative use” of the
-          RabbitMQ name, but this does not allow you to use the logo.
-          Nominative use is sometimes called “fair use” of a trademark, and
-          does not require a trademark license from us.  Here are examples:
-        </p>
-        <ol class="roman">
-          <li>
-            <p>
-              You may use the RabbitMQ Marks in connection with development
-              of tools, add-ons, or utilities that are compatible with
-              bit-for-bit identical copies of official RabbitMQ software.
-              For example:  For example, if you are developing a Foobar
-              tool for RabbitMQ, acceptable project titles would be “Foobar
-              for RabbitMQ".
-            </p>
-          </li>
-          <li>
-            <p>
-              You may use the RabbitMQ Marks in connection with your
-              noncommercial redistribution of (1) bit-for-bit identical
-              copies of official RabbitMQ software, and (2) unmodified
-              copies of official RabbitMQ source packages.  For example, if
-              your Foobar product included a full redistribution of
-              official RabbitMQ Software or source code packages:
-              "RabbitMQ-powered Foobar Product". We strongly discourage,
-              and likely would consider it a trademark problem, to use a
-              name such as “RabbitMQ Foobar.”
-            </p>
-          </li>
-          <li>
-            <p>
-              If you offer maintenance, support, or hosting services for
-              RabbitMQ software, you may accurately state that in your
-              marketing materials or portfolio, without using the RabbitMQ
-              logo.
-            </p>
-          </li>
-          <li>
-            <p>
-              You may modify the RabbitMQ software and state that your
-              modified software is “based on the RabbitMQ software” or a
-              similar accurate statement, without using the RabbitMQ logo.
-            </p>
-          </li>
-          <li>
-            <p>
-              You may engage in community advocacy. The RabbitMQ software
-              is developed by and for its community. We will allow the use
-              of the word trademark in this context, provided:
-            </p>
-            <ol class="plain">
-              <li>
-                <p>
-                  The trademark is used in a manner consistent with this
-                  policy
-                </p>
-              </li>
-              <li>
-                <p>
-                  There is no commercial purpose behind the use
-                </p>
-              </li>
-              <li>
-                <p>
-                  There is no suggestion that your project is approved,
-                  sponsored, or affiliated with VMware.
-                </p>
-              </li>
-              <li>
-                <p>
-                  User or Development Groups. You may create RabbitMQ user
-                  or development groups, and publicize meetings or
-                  discussions for those groups.  Please consider joining
-                  our official group.
-                </p>
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>
-        <p>
-          **
-            Attribution.
-          ** Identify the trademarks as trademarks of VMware, as
-          set forth in Section 7.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Redistribution of Binaries.
-          ** If you redistribute binaries that you have downloaded
-          from the RabbitMQ repository, you should retain the logos and
-          name of the product.  However, if you make any changes to the
-          binaries (other than configuration or installation changes that
-          do not involve changes to the source code), or if you re-build
-          binaries from our source code, you should not use our logos.  Our
-          logos represent our quality control, so they should be retained
-          where the product has been built by us, but not otherwise.  Our
-          source code does not include logo image files, to remind you to
-          follow this rule.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Capitalization.
-          ** “RabbitMQ” should always be capitalized and one
-          words.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Adjectives.
-          ** Use the RabbitMQ mark as an adjective, not a noun or
-          verb.
-        </p>
-      </li>
-    </ol>
-  </li>
-  <li>
-    <p>
-      **
-        IMPROPER USE OF THE TRADEMARKS AND LOGOS.
-      ** Use of the logos is
-      reserved solely for use by VMware in its unaltered form. Examples of
-      unauthorized use of the RabbitMQ trademarks include:
-    </p>
-    <ol class="alpha">
-      <li>
-        <p>
-          **
-            Commercial Use:
-          ** You may not use the RabbitMQ Marks in connection
-          with commercial redistribution of RabbitMQ software (commercial
-          redistribution includes, but is not limited to, redistribution in
-          connection with any commercial business activities or
-          revenue-generating business activities) regardless of whether the
-          RabbitMQ software is unmodified.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Entity Names.
-          ** You may not form a company, use a company name, or
-          create a software product name that includes the “RabbitMQ”
-          trademark, or implies any foundational or authorship role. If you
-          have a software product that works with RabbitMQ, it is suggested
-          you use terms such as ‘&lt;product name> for RabbitMQ’ or
-          ‘&lt;product name>, RabbitMQ Edition.” If you wish to form an
-          entity for a user or developer group, please contact us and we
-          will be glad to discuss a license for a suitable name.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Class or Quality.
-          ** You may not imply that you are providing a
-          class or quality of RabbitMQ (e.g., "enterprise-class" or
-          "commercial quality") in a way that implies RabbitMQ is not of
-          that class, grade or quality, nor that other parties are not of
-          that class, grade, or quality.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Combinations.
-          ** Use of the RabbitMQ Marks to identify software that
-          combines any portion of the RabbitMQ software with any other
-          software, unless the combined distribution is an official
-          RabbitMQ distribution. For example, you may not distribute a
-          combination of the RabbitMQ  software with software released by
-          the Foobar project under the name “RabbitMQ Foobar Distro”.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            False or Misleading Statements.
-          ** You may not make false or
-          misleading statements regarding your use of RabbitMQ (e.g., "we
-          wrote the majority of the code" or "we are major contributors" or
-          "we are committers").
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Domain Names.
-          ** You must not use RabbitMQ or any confusingly
-          similar phrase in a domain name. For instance
-          “www.rabbitmqhost.com” is not allowed. If you wish to use such a
-          domain name for a non-commercial user or developer group to
-          engage in community advocacy, please contact us and we will be
-          glad to discuss a license for a suitable domain name.  Because of
-          the many persons who, unfortunately, seek to spoof, swindle or
-          deceive the community by using confusing domain names, we must be
-          very strict about this rule.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Merchandise.
-          ** You must not manufacture, sell or give away
-          merchandise items, such as T-shirts and mugs, bearing the
-          RabbitMQ logo, or create any mascot for the project.  If you wish
-          to use the logo to do this for a non-commerical user or developer
-          group to engage in community advocacy, please contact us and we
-          will be glad to discuss a license to do this.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Variations, takeoffs or abbreviations.
-          ** You may not use a
-          variation of the RabbitMQ name or logo for any purpose other than
-          common usage of these in community communications. For example,
-          the following are not acceptable:
-        </p>
-        <ol class="roman">
-          <li><p>RMQ</p></li>
-          <li><p>MyRabbitMQ</p></li>
-          <li><p>RabbitMQ Messaging</p></li>
-          <li><p>RabbitMQ Guru</p></li>
-        </ol>
-      </li>
-      <li>
-        <p>
-          **
-            Endorsement or Sponsorship.
-          ** You may not use the RabbitMQ
-          trademarks in a manner that would imply VMware’s affiliation
-          with or endorsement, sponsorship, or support of a product or
-          service.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Rebranding.
-          ** You may not change the trademark on unmodified
-          RabbitMQ software to your own brand.  You may not hold yourself
-          out as the source of the RabbitMQ software, except to the extent
-          you have modified it as allowed under the Apache 2.0 license, and
-          you make it clear that you are the source only of the
-          modification.
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Combination Marks.
-          ** Do not use our trademarks in combination with
-          any other marks or logos (for example Foobar RabbitMQ, or the
-          name of your company or product typeset to look like the RabbitMQ
-          logo).
-        </p>
-      </li>
-      <li>
-        <p>
-          **
-            Web Tags.
-          ** Do not use the RabbitMQ trademark in a title or metatag
-          of a web page to influence search engine rankings or result
-          listings, rather than for discussion or advocacy of the RabbitMQ
-          project.
-        </p>
-      </li>
-    </ol>
-  </li>
-  <li>
-    <p>
-      **
-        PROPER NOTICE AND ATTRIBUTION.
-      ** The appropriate trademark symbol
-      (i.e.,  ®) should appear at least with the first use of the RabbitMQ
-      trademarks (for example, RABBITMQ®). When you use a RabbitMQ
-      trademark you should include a statement attributing the trademark to
-      VMware. For example, "RabbitMQ is a trademark of VMware,
-      Inc. in the U.S. and other countries."
-    </p>
-  </li>
-  <li>
-    <p>
-      **
-        MORE QUESTIONS?
-      ** If you have questions about this policy, please
-      contact us at <a href="mailto:rabbitmq-core@groups.vmware.com">rabbitmq-core@groups.vmware.com</a>.
-    </p>
-  </li>
-</ol>
+## Purpose
+
+Broadcom, Inc. (“Broadcom”) owns a number of international trademarks and logos
+that identify the RabbitMQ community and individual RabbitMQ projects
+(“RabbitMQ Marks”). These trademarks include the word and the logos that
+follow.
+
+### Word
+
+RabbitMQ
+
+### Logos
+
+<div class="logos-gallery">
+<figure>
+<img src="/img/rabbitmq-logo.svg" alt="This image displays the RabbitMQ logo alone." />
+<figcaption>
+The RabbitMQ logo alone.
+
+[SVG](/img/rabbitmq-logo.svg)
+</figcaption>
+</figure>
+<figure>
+<img src="/img/rabbitmq-logo-with-name.svg" alt="This image displays the RabbitMQ logo, followed by the word RabbitMQ, followed by the trademark (TM)." />
+<figcaption>
+The RabbitMQ logo with the word “RabbitMQ” and the trademark.
+
+[SVG](/img/rabbitmq-logo-with-name.svg)
+</figcaption>
+</figure>
+</div>
+
+This policy outlines Broadcom’s policy and guidelines about the use of the
+RabbitMQ trademarks by members of the RabbitMQ development and user community.
+
+## Why Have Trademark Guidelines?
+
+The RabbitMQ Marks are a symbol of the quality and community support associated
+with the RabbitMQ open source software. Trademarks protect not only those using
+the marks, but the entire community as well. Our community members need to know
+that they can rely on the quality and capabilities represented by the brand. We
+also want to provide a level playing field. No one should use the RabbitMQ
+marks in ways that mislead or take advantage of the community, or make unfair
+use of the trademarks. Also, use of the RabbitMQ Marks should not be in a
+disparaging manner because we prefer that our marks not be used to be rude
+about the RabbitMQ open source project or its members.
+
+## Open Source License vs. Trademarks
+
+The Apache 2.0 license gives you the right to use, copy, distribute and modify
+the RabbitMQ software. However, open source licenses like the Apache 2.0
+license do not address trademarks. RabbitMQ Marks need to be used in a way
+consistent with trademark law, and that is why we have prepared this policy –
+to help you understand what branding is allowed or required when using our
+software under the Apache license.
+
+## Proper Use of the RabbitMQ Marks
+
+We want to encourage a robust community for the RabbitMQ open source project.
+Therefore, you may do any of the following, as long as you do so in a way that
+does not devalue, dilute, or disparage the RabbitMQ brand. In other words, when
+you do these things, you should behave responsibly and reasonably in the
+interest of the community, but you do not need a trademark license from us to
+do them.
+
+### Nominative Use
+
+You may engage in “nominative use” of the RabbitMQ name, but this does not
+allow you to use the logo. Nominative use is sometimes called “fair use” of a
+trademark, and does not require a trademark license from us. Here are examples:
+
+1. You may use the RabbitMQ Marks in connection with development of tools,
+   add-ons, or utilities that are compatible with bit-for-bit identical copies
+   of official RabbitMQ software. For example, if you are developing a Foobar
+   tool for RabbitMQ, acceptable project titles would be “Foobar for RabbitMQ".
+
+2. You may use the RabbitMQ Marks in connection with your noncommercial
+   redistribution of (1) bit-for-bit identical copies of official RabbitMQ
+   software, and (2) unmodified copies of official RabbitMQ source packages.
+   For example, if your Foobar product included a full redistribution of
+   official RabbitMQ Software or source code packages: "RabbitMQ-powered Foobar
+   Product". We strongly discourage, and likely would consider it a trademark
+   problem, to use a name such as “RabbitMQ Foobar.”
+
+3. If you offer maintenance, support, or hosting services for RabbitMQ
+   software, you may accurately state that in your marketing materials or
+   portfolio, without using the RabbitMQ logo.
+
+4. You may modify the RabbitMQ software and state that your modified software
+   is “based on the RabbitMQ software” or a similar accurate statement, without
+   using the RabbitMQ logo.
+
+5. You may engage in community advocacy. The RabbitMQ software is developed by
+   and for its community. We will allow the use of the word trademark in this
+   context, provided:
+
+    1. The trademark is used in a manner consistent with this policy
+    2. There is no commercial purpose behind the use
+    3. There is no suggestion that your project is approved, sponsored, or
+       affiliated with Broadcom.
+    4. User or Development Groups. You may create RabbitMQ user or development
+       groups, and publicize meetings or discussions for those groups. Please
+       consider joining our official group.
+
+### Attribution
+
+Identify the trademarks as trademarks of Broadcom, as set forth in [Section
+6](#proper-notice-and-attribution).
+
+### Redistribution of Binaries
+
+If you redistribute binaries that you have downloaded from the RabbitMQ
+repository, you should retain the logos and name of the product. However, if
+you make any changes to the binaries (other than configuration or installation
+changes that do not involve changes to the source code), or if you re-build
+binaries from our source code, you should not use our logos. Our logos
+represent our quality control, so they should be retained where the product has
+been built by us, but not otherwise. Our source code does not include logo
+image files, to remind you to follow this rule.
+
+### Capitalization
+
+“RabbitMQ” should always be capitalized and one words.
+
+### Adjectives
+
+Use the RabbitMQ mark as an adjective, not a noun or verb.
+
+## Improper Use of the Trademarks and Logos
+
+Use of the logos is reserved solely for use by Broadcom in its unaltered form.
+Examples of unauthorized use of the RabbitMQ trademarks include:
+
+### Commercial Use
+
+You may not use the RabbitMQ Marks in connection with commercial redistribution
+of RabbitMQ software (commercial redistribution includes, but is not limited
+to, redistribution in connection with any commercial business activities or
+revenue-generating business activities) regardless of whether the RabbitMQ
+software is unmodified.
+
+### Entity Names
+
+You may not form a company, use a company name, or create a software product
+name that includes the “RabbitMQ” trademark, or implies any foundational or
+authorship role. If you have a software product that works with RabbitMQ, it is
+suggested you use terms such as ‘&lt;product name> for RabbitMQ’ or
+‘&lt;product name>, RabbitMQ Edition.” If you wish to form an entity for a user
+or developer group, please contact us and we will be glad to discuss a license
+for a suitable name.
+
+### Class or Quality
+
+You may not imply that you are providing a class or quality of RabbitMQ (e.g.,
+"enterprise-class" or "commercial quality") in a way that implies RabbitMQ is
+not of that class, grade or quality, nor that other parties are not of that
+class, grade, or quality.
+
+### Combinations
+
+Use of the RabbitMQ Marks to identify software that combines any portion of the
+RabbitMQ software with any other software, unless the combined distribution is
+an official RabbitMQ distribution. For example, you may not distribute a
+combination of the RabbitMQ software with software released by the Foobar
+project under the name “RabbitMQ Foobar Distro”.
+
+### False or Misleading Statements
+
+You may not make false or misleading statements regarding your use of RabbitMQ
+(e.g., "we wrote the majority of the code" or "we are major contributors" or
+"we are committers").
+
+### Domain Names
+
+You must not use RabbitMQ or any confusingly similar phrase in a domain name.
+For instance `www.rabbitmqhost.com` is not allowed. If you wish to use such a
+domain name for a non-commercial user or developer group to engage in community
+advocacy, please contact us and we will be glad to discuss a license for a
+suitable domain name. Because of the many persons who, unfortunately, seek to
+spoof, swindle or deceive the community by using confusing domain names, we
+must be very strict about this rule.
+
+### Merchandise
+
+You must not manufacture, sell or give away merchandise items, such as T-shirts
+and mugs, bearing the RabbitMQ logo, or create any mascot for the project. If
+you wish to use the logo to do this for a non-commerical user or developer
+group to engage in community advocacy, please contact us and we will be glad to
+discuss a license to do this.
+
+### Variations, takeoffs or abbreviations
+
+You may not use a variation of the RabbitMQ name or logo for any purpose other
+than common usage of these in community communications. For example, the
+following are not acceptable:
+
+* RMQ
+* MyRabbitMQ
+* RabbitMQ Messaging
+* RabbitMQ Guru
+
+### Endorsement or Sponsorship
+
+You may not use the RabbitMQ trademarks in a manner that would imply Broadcom’s
+affiliation with or endorsement, sponsorship, or support of a product or
+service.
+
+### Rebranding
+
+You may not change the trademark on unmodified RabbitMQ software to your own
+brand. You may not hold yourself out as the source of the RabbitMQ software,
+except to the extent you have modified it as allowed under the Apache 2.0
+license, and you make it clear that you are the source only of the
+modification.
+
+### Combination Marks
+
+Do not use our trademarks in combination with any other marks or logos (for
+example Foobar RabbitMQ, or the name of your company or product typeset to look
+like the RabbitMQ logo).
+
+### Web Tags
+
+Do not use the RabbitMQ trademark in a title or metatag of a web page to
+influence search engine rankings or result listings, rather than for discussion
+or advocacy of the RabbitMQ project.
+
+## Proper Notice and Attribution
+
+The appropriate trademark symbol (i.e., ®) should appear at least with the
+first use of the RabbitMQ trademarks (for example, RabbitMQ®). When you use a
+RabbitMQ trademark you should include a statement attributing the trademark to
+Broadcom. For example, "RabbitMQ is a trademark of Broadcom, Inc. in the U.S.
+and other countries."
+
+## More Questions?
+
+If you have questions about this policy, please contact us at
+[rabbitmq-core@groups.vmware.com](mailto:rabbitmq-core@groups.vmware.com).


### PR DESCRIPTION
Mainly, the blog is not covered by the APL 2.0 and the MPL 2.0 licenses. It remains the intellectual property of Broadcom and can't be redistributed.