### PR TITLE
Add introduction pages behind all top-level sections

### DIFF
--- a/docs/manage-rabbitmq.md
+++ b/docs/manage-rabbitmq.md
@@ -1,0 +1,29 @@
+---
+title: How to Manage RabbitMQ
+---
+<!--
+Copyright (c) 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers
+to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# How to Manage RabbitMQ
+
+This section is mainly for **administrators** who want to operate a single
+RabbitMQ instance and clusters of RabbitMQ nodes. It provides documentation for
+configuring and managing the RabbitMQ broker.
+
+The next section, [How to Monitor RabbitMQ](./monitoring), is also useful to
+setup monitoring RabbitMQ and the applications that use it.

--- a/docs/use-rabbitmq.md
+++ b/docs/use-rabbitmq.md
@@ -1,0 +1,30 @@
+---
+title: How to Use RabbitMQ
+---
+<!--
+Copyright (c) 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers
+to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# How to Use RabbitMQ
+
+This section is mainly for **developers** who are creating applications that
+exchanges messages through RabbitMQ.
+
+If you are new to RabbitMQ, you might want to start with [Getting
+Started](/tutorials). These tutorials will guide you on how to use RabbitMQ.
+The rest of this section contains the reference documentation about RabbitMQ
+features and use cases.

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -124,6 +124,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'How to Use RabbitMQ',
+      link: {type: 'doc', id: 'use-rabbitmq'},
       items: [
         {
           type: 'category',
@@ -389,6 +390,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'How to Manage RabbitMQ',
+      link: {type: 'doc', id: 'manage-rabbitmq'},
       items: [
         {
           type: 'doc',


### PR DESCRIPTION
## Why

This will allow external links pointing directly to those sections. Otherwise, the links would have to point to e.g. the first entry in each section.