### PR TITLE
Federation: queue-type and resource-cleanup-mode

### DIFF
--- a/docs/federation-reference.md
+++ b/docs/federation-reference.md
@@ -195,6 +195,35 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     </tr>
 
     <tr>
+      <td><code>queue-type</code></td>
+      <td>
+        The queue type of the <a href="./federated-exchanges#implementation">upstream queue</a>. 
+
+        Defaults to `classic`. Set to `quorum` for high availability.
+
+        Changing the queue type will delete and recreate the upstream queue by default.
+        This may lead to messages getting lost (if they were in the upstream queue)
+        or missed (when they are published while there's no upstream queue to collect them).
+        You can set <code>resource-cleanup-mode</code> to <code>never</code> to avoid that.
+        This requires manually deleting the old upstream queue so that it can be recreated with
+        the new type.
+
+        Available since: 3.13.1
+      </td>
+    </tr>
+
+    <tr>
+      <td><code>resource-cleanup-mode</code></td>
+      <td>
+        Whether to delete the <a href="./federated-exchanges#implementation">upstream queue</a> when federation stops.
+
+        By default, the upstream queue is deleted immediately when federation link stops.
+        Set to `never` to keep the upstream queue around and collect messages even when
+        changing federation configuration.
+      </td>
+    </tr>
+
+    <tr>
       <td><code>expires</code></td>
       <td>
         The expiry time (in milliseconds) after which

--- a/docs/federation-reference.md
+++ b/docs/federation-reference.md
@@ -197,7 +197,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     <tr>
       <td>`queue-type`</td>
       <td>
-        The queue type of the [internal upstream queue](./federated-exchanges#implementation) used by exchange federation.
+        The queue type of the [internal upstream queue](./federated-exchanges#details) used by exchange federation.
 
         Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues/).
 
@@ -214,7 +214,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     <tr>
       <td>`resource-cleanup-mode`</td>
       <td>
-        Whether to delete the [internal upstream queue](./federated-exchanges#implementation) when federation links stop.
+        Whether to delete the [internal upstream queue](./federated-exchanges#details) when federation links stop.
 
         By default, the internal upstream queue is deleted immediately when a federation link stops.
         Set to `never` to keep the upstream queue around and collect messages even when
@@ -226,7 +226,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
       <td><code>expires</code></td>
       <td>
         The expiry time (in milliseconds) after which
-        an <a href="./federated-exchanges#implementation">upstream queue</a> for
+        an <a href="./federated-exchanges#details">upstream queue</a> for
         a federated exchange may be deleted if a connection to the upstream is lost.
         The default is <code>'none'</code>, meaning no expiration will be applied to the queue.
 
@@ -240,7 +240,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     <tr>
       <td><code>message-ttl</code></td>
       <td>
-        The expiry time for messages in the <a href="./federated-exchanges#implementation">upstream queue</a>
+        The expiry time for messages in the <a href="./federated-exchanges#details">upstream queue</a>
         for a federated exchange (see <code>expires</code>), in milliseconds.
         Default is <code>'none'</code>, meaning messages should never expire.
         This does not apply to federated queues.

--- a/docs/federation-reference.md
+++ b/docs/federation-reference.md
@@ -195,16 +195,16 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     </tr>
 
     <tr>
-      <td><code>queue-type</code></td>
+      <td>`queue-type`</td>
       <td>
-        The queue type of the <a href="./federated-exchanges#implementation">upstream queue</a>. 
+        The queue type of the [upstream queue](./federated-exchanges#implementation).
 
         Defaults to `classic`. Set to `quorum` for high availability.
 
         Changing the queue type will delete and recreate the upstream queue by default.
         This may lead to messages getting lost (if they were in the upstream queue)
         or missed (when they are published while there's no upstream queue to collect them).
-        You can set <code>resource-cleanup-mode</code> to <code>never</code> to avoid that.
+        You can set `resource-cleanup-mode` key to `never` to avoid that.
         This requires manually deleting the old upstream queue so that it can be recreated with
         the new type.
 
@@ -213,9 +213,9 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     </tr>
 
     <tr>
-      <td><code>resource-cleanup-mode</code></td>
+      <td>`resource-cleanup-mode`</td>
       <td>
-        Whether to delete the <a href="./federated-exchanges#implementation">upstream queue</a> when federation stops.
+        Whether to delete the [upstream queue](./federated-exchanges#implementation) when federation stops.
 
         By default, the upstream queue is deleted immediately when federation link stops.
         Set to `never` to keep the upstream queue around and collect messages even when

--- a/docs/federation-reference.md
+++ b/docs/federation-reference.md
@@ -197,27 +197,26 @@ The following upstream parameters are only applicable to <a href="./federated-ex
     <tr>
       <td>`queue-type`</td>
       <td>
-        The queue type of the [upstream queue](./federated-exchanges#implementation).
+        The queue type of the [internal upstream queue](./federated-exchanges#implementation) used by exchange federation.
 
-        Defaults to `classic`. Set to `quorum` for high availability.
+        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues/).
 
         Changing the queue type will delete and recreate the upstream queue by default.
-        This may lead to messages getting lost (if they were in the upstream queue)
-        or missed (when they are published while there's no upstream queue to collect them).
-        You can set `resource-cleanup-mode` key to `never` to avoid that.
+        This may lead to messages getting lost or not routed anywhere during the re-declaration.
+        To avoid that, set `resource-cleanup-mode` key to `never`.
         This requires manually deleting the old upstream queue so that it can be recreated with
         the new type.
 
-        Available since: 3.13.1
+        Available since: `3.13.1`
       </td>
     </tr>
 
     <tr>
       <td>`resource-cleanup-mode`</td>
       <td>
-        Whether to delete the [upstream queue](./federated-exchanges#implementation) when federation stops.
+        Whether to delete the [internal upstream queue](./federated-exchanges#implementation) when federation links stop.
 
-        By default, the upstream queue is deleted immediately when federation link stops.
+        By default, the internal upstream queue is deleted immediately when a federation link stops.
         Set to `never` to keep the upstream queue around and collect messages even when
         changing federation configuration.
       </td>


### PR DESCRIPTION
* queue-type is a new field added in 3.13.1
* resource-cleanup-mode has been there for a long time but was not documented