### PR TITLE
rebranding and updates to add OVA and OCI commercial offerings

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -29,7 +29,7 @@ queues or streams are used.
 
 It is better to rely on other disaster recovery solutions,
 or use a separate standby cluster for disaster recovery.
-[VMware RabbitMQ](https://www.vmware.com/products/rabbitmq.html) offers a number of extensions for
+[VMware Tanzu RabbitMQ](https://www.vmware.com/products/rabbitmq.html) offers a number of extensions for
 warm standby replication to a dedicated disaster
 recovery cluster.
 

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -41,7 +41,7 @@ and more. [Cluster Formation and Peer Discovery](./cluster-formation) is a close
 that focuses on peer discovery and cluster formation automation-related topics. For queue contents
 (message) replication, see the [Quorum Queues](./quorum-queues) guide.
 
-[VMware RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/clustering-compression-rabbitmq.html) feature.
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/clustering-compression-rabbitmq.html) feature.
 
 A RabbitMQ cluster is a logical grouping of one or
 several nodes, each  sharing users, virtual hosts,

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -34,7 +34,7 @@ Every node in a cluster has its own replica of all definitions. When a part of d
 the update is performed on all nodes in a single transaction. This means that
 in practice, definitions can be exported from any cluster node with the same result.
 
-[VMware RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) supports [Warm Standby Replication](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) to a remote cluster,
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) supports [Warm Standby Replication](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) to a remote cluster,
 which makes it easy to run a warm standby cluster for disaster recovery.
 
 Definition import on node boot is the recommended way of [pre-configuring nodes at deployment time](#import-on-boot).

--- a/docs/download.md
+++ b/docs/download.md
@@ -56,7 +56,7 @@ They are marked as pre-releases on GitHub.
 
 ## VMware Tanzu RabbitMQ® (Commercial Editions)
 
- * [VMware Tanzu RabbitMQ®](https://docs.vmware.com/en/VMware-RabbitMQ/index.html). This edition includes Tanzu RabbitMQ OVA and Tanzu RabbitMQ OCI.
+ * [VMware Tanzu RabbitMQ®](https://docs.vmware.com/en/VMware-RabbitMQ/index.html). Tanzu RabbitMQ is available in many packages including OVA and OCI.
  * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html)
  * [VMware Tanzu RabbitMQ® for Tanzu Application Services](https://docs.vmware.com/en/VMware-RabbitMQ-for-Tanzu-Application-Service/index.html)
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -54,10 +54,12 @@ You can contribute to open source RabbitMQ by helping the community test [previe
 They are marked as pre-releases on GitHub.
 
 
-## VMware RabbitMQ® (Commercial Edition)
+## VMware Tanzu RabbitMQ® (Commercial Editions)
 
- * [VMware RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
- * [VMware RabbitMQ® on Kubernetes](/kubernetes/tanzu/installation)
+ * [VMware Tanzu RabbitMQ®](https://docs.vmware.com/en/VMware-RabbitMQ/index.html). This edition includes Tanzu RabbitMQ OVA and Tanzu RabbitMQ OCI.
+ * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html)
+ * [VMware Tanzu RabbitMQ® for Tanzu Application Services](https://docs.vmware.com/en/VMware-RabbitMQ-for-Tanzu-Application-Service/index.html)
+
 
 ## Kubernetes
 
@@ -90,9 +92,9 @@ Other guides related to Kubernetes:
 
 ## Cloud
 
- * [VMware RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
+ * [VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
  * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
- * [VMware RabbitMQ® on Kubernetes](/kubernetes/tanzu/installation)
+ * [VMware Tanzu RabbitMQ® on Kubernetes](/kubernetes/tanzu/installation)
  * [Amazon MQ for RabbitMQ](https://aws.amazon.com/amazon-mq/)
  * [Amazon EC2](./ec2)
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -73,7 +73,7 @@ such as
  * [Heartbeats](#heartbeats) (a.k.a. keepalives)
  * [proxies and load balancers](#intermediaries)
 
-[VMware RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) feature.
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) commercial offerings provide an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) feature. The previous documentation link goes to the Tanzu RabbitMQ for Kubernetes commercial offering.
 
 A methodology for [troubleshooting of networking-related issues](./troubleshooting-networking)
 is covered in a separate guide.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -605,9 +605,9 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
   </tbody>
 </table>
 
-## Additional Plugins in VMware RabbitMQ® {#commercial-plugins}
+## Additional Plugins in VMware Tanzu RabbitMQ® {#commercial-plugins}
 
-The table below lists of plugins only available in [VMware RabbitMQ®](https://tanzu.vmware.com/rabbitmq).
+The table below lists of plugins only available in [Tanuz RabbitMQ®](https://tanzu.vmware.com/rabbitmq).
 
 <table class="plugins">
   <thead>

--- a/kubernetes/operator/using-on-openshift.md
+++ b/kubernetes/operator/using-on-openshift.md
@@ -5,7 +5,7 @@ displayed_sidebar: kubernetesSidebar
 # Using the RabbitMQ Kubernetes Operators on Openshift
 
 ## Overview {#overview}
-This documentation details the Openshift-specific considerations when deploying the RabbitMQ Kubernetes Operators, which are the [Cluster operator](./using-operator) and the [Messaging Topology Operator](./using-topology-operator). It is important to note that these considerations are also applicable to the commercial [VMware RabbitMQ Standby Replication Operator](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html#requirements-for-warm-standby-replication) (note, this operator is exclusive to the VMware RabbitMQ for Kubernetes commercial offering only).
+This documentation details the Openshift-specific considerations when deploying the RabbitMQ Kubernetes Operators, which are the [Cluster operator](./using-operator) and the [Messaging Topology Operator](./using-topology-operator). It is important to note that these considerations are also applicable to the commercial [VMware Tanzu RabbitMQ Standby Replication Operator](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html#requirements-for-warm-standby-replication) (note, this operator is exclusive to the VMware Tanzu RabbitMQ for Kubernetes commercial offering only).
 
 For the most part, the user experience is the same when
 using these operators on Openshift; the following guide details the additional work required to leverage Openshift's

--- a/kubernetes/tanzu/installation.md
+++ b/kubernetes/tanzu/installation.md
@@ -1,5 +1,5 @@
 ---
-title: Installing VMware RabbitMQ for Kubernetes
+title: Installing VMware Tanzu RabbitMQ for Kubernetes
 displayed_sidebar: kubernetesSidebar
 ---
 <!--
@@ -19,12 +19,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Installing VMware RabbitMQ for Kubernetes
+# Installing VMware Tanzu RabbitMQ for Kubernetes
 
 ## Overview
 
-This guide covers installation of [VMware RabbitMQ](https://tanzu.vmware.com/rabbitmq) to Kubernetes
-using the [Carvel toolchain](https://carvel.dev/#install), e.g. from TanzuNet:
+This guide covers installation of [VMware Tanzu RabbitMQ](https://tanzu.vmware.com/rabbitmq) for Kubernetes
+using the [Carvel toolchain](https://carvel.dev/#install), for example from TanzuNet:
 
 * [imgpkg](https://network.pivotal.io/products/imgpkg/)
 * [kapp](https://network.pivotal.io/products/kapp/)
@@ -44,7 +44,7 @@ This guide assumes you have the following:
 
 ### Installing to a Local Registry
 
-First download the VMware RabbitMQ release tarball (`.tar` file) from [VMware Tanzu Network](https://network.pivotal.io/products/p-rabbitmq-for-kubernetes/).
+First download the Tanzu RabbitMQ release tarball (`.tar` file) from [VMware Tanzu Network](https://network.pivotal.io/products/p-rabbitmq-for-kubernetes/).
 
 The file then must be placed on the filesystem of a machine within the network hosting the target registry.
 On that machine, load the tarball into the registry by running:
@@ -100,7 +100,7 @@ kubectl create secret generic tanzu-registry-creds \
 
 ## Installing the Bundle
 
-VMware RabbitMQ uses TLS certificates for admission Webhooks in the cluster.
+Tanzu RabbitMQ uses TLS certificates for admission Webhooks in the cluster.
 
 There are two ways of installing the components of :
 
@@ -176,7 +176,7 @@ everything that can be managed via [definitions](/docs/definitions))
 using the [RabbitMQ Topology Operator](../operator/using-topology-operator).
 
 To do so, render `overlays/rabbitmqcluster.yml` with a manifest of the `RabbitmqCluster` object,
-the resultant cluster will use the bundled VMware RabbitMQ container image.
+the resultant cluster will use the bundled Tanzu RabbitMQ container image.
 
 This example creates a very minimalistic RabbitmqCluster:
 

--- a/src/pages/commercial-offerings.md
+++ b/src/pages/commercial-offerings.md
@@ -46,7 +46,7 @@ based on the [RabbitMQ Operators for Kubernetes](https://www.rabbitmq.com/kubern
 
 ### VMware Tanzu RabbitMQ® 
 
-[VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq), again go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ includes both Tanzu RabbitMQ OVA and Tanzu RabbitMQ OCI.
+[VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq), again go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ is available in many packages including OVA and OCI.
 
 
 

--- a/src/pages/commercial-offerings.md
+++ b/src/pages/commercial-offerings.md
@@ -34,17 +34,20 @@ Contact VMware to get a quote [here](https://tanzu.vmware.com/rabbitmq).
 
 The enterprise releases include the following:
 
-### VMware RabbitMQ® for Tanzu Application Service
+### VMware Tanzu RabbitMQ® for Tanzu Application Service
 
-[VMware RabbitMQ® for Tanzu Application Service (formerly known as VMware Tanzu™ RabbitMQ® for VMs)](https://tanzu.vmware.com/services-marketplace/messaging-and-integration/rabbitmq)
-gives developers self-service access to on-demand RabbitMQ clusters
+[VMware Tanzu RabbitMQ® for Tanzu Application Service (formerly known as VMware Tanzu™ RabbitMQ® for VMs)](https://tanzu.vmware.com/rabbitmq), go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ for Tanzu Application Service gives developers self-service access to on-demand RabbitMQ clusters
 running on [VMware Tanzu™ Application Service](https://tanzu.vmware.com/application-service) (formerly known as Pivotal Cloud Foundry).
 
-### VMware RabbitMQ®  for Kubernetes
+### VMware Tanzu RabbitMQ® for Kubernetes
 
-[VMware RabbitMQ® for Kubernetes](https://tanzu.vmware.com/content/blog/introducing-rabbitmq-for-kubernetes)
-simplifies the operational experience to make RabbitMQ available on a Kubernetes-based platform,
+[VMware Tanzu RabbitMQ® for Kubernetes](https://tanzu.vmware.com/rabbitmq), again go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ® for Kubernetes simplifies the operational experience to make RabbitMQ available on a Kubernetes-based platform,
 based on the [RabbitMQ Operators for Kubernetes](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html).
+
+### VMware Tanzu RabbitMQ® 
+
+[VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq), again go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ includes both Tanzu RabbitMQ OVA and Tanzu RabbitMQ OCI.
+
 
 
 ## Training {#training}

--- a/src/pages/commercial-offerings.md
+++ b/src/pages/commercial-offerings.md
@@ -32,23 +32,21 @@ VMware offers **a range of commercial support, enterprise releases, training, an
 The enterprise edition of RabbitMQ includes all the features of the open source version plus additional key features such as Warm Standby Replication and Intra-cluster Compression under a commercial license.
 Contact VMware to get a quote [here](https://tanzu.vmware.com/rabbitmq).
 
-The enterprise releases include the following:
+The enterprise releases are listed below. For more information about them, go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on the [VMware Tanzu RabbitMQ product page](https://tanzu.vmware.com/rabbitmq)]. 
 
 ### VMware Tanzu RabbitMQ® for Tanzu Application Service
 
-[VMware Tanzu RabbitMQ® for Tanzu Application Service (formerly known as VMware Tanzu™ RabbitMQ® for VMs)](https://tanzu.vmware.com/rabbitmq), go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ for Tanzu Application Service gives developers self-service access to on-demand RabbitMQ clusters
+Tanzu RabbitMQ® for Tanzu Application Service gives developers self-service access to on-demand RabbitMQ clusters
 running on [VMware Tanzu™ Application Service](https://tanzu.vmware.com/application-service) (formerly known as Pivotal Cloud Foundry).
 
 ### VMware Tanzu RabbitMQ® for Kubernetes
 
-[VMware Tanzu RabbitMQ® for Kubernetes](https://tanzu.vmware.com/rabbitmq), again go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ® for Kubernetes simplifies the operational experience to make RabbitMQ available on a Kubernetes-based platform,
+Tanzu RabbitMQ® for Kubernetes simplifies the operational experience to make RabbitMQ available on a Kubernetes-based platform,
 based on the [RabbitMQ Operators for Kubernetes](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html).
 
 ### VMware Tanzu RabbitMQ® 
 
-[VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq), again go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on this page for more information. Tanzu RabbitMQ is available in many packages including OVA and OCI.
-
-
+Tanzu RabbitMQ is available in many packages including OVA and OCI.
 
 ## Training {#training}
 

--- a/src/pages/commercial-offerings.md
+++ b/src/pages/commercial-offerings.md
@@ -32,7 +32,7 @@ VMware offers **a range of commercial support, enterprise releases, training, an
 The enterprise edition of RabbitMQ includes all the features of the open source version plus additional key features such as Warm Standby Replication and Intra-cluster Compression under a commercial license.
 Contact VMware to get a quote [here](https://tanzu.vmware.com/rabbitmq).
 
-The enterprise releases are listed below. For more information about them, go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on the [VMware Tanzu RabbitMQ product page](https://tanzu.vmware.com/rabbitmq)]. 
+The enterprise releases are listed below. For more information about them, go to the **Ways to run Tanzu RabbitMQ and open source RabbitMQ distributions** table on the [VMware Tanzu RabbitMQ product page](https://tanzu.vmware.com/rabbitmq). 
 
 ### VMware Tanzu RabbitMQ® for Tanzu Application Service
 


### PR DESCRIPTION
A) Rebranding updates: Update all references of "VMware RabbitMQ" to "VMware Tanzu RabbitMQ". After the first instance of "VMware Tanzu RabbitMQ" in a topic, you can then use "Tanzu RabbitMQ" in all subsequent instances in that topic except in offering names where I kept the full name "VMware Tanzu RabbitMQ". Once these updates are merged into main, I will do another search to ensure I have missed none. 

B) Adding information about the VMware Tanzu  RabbitMQ OVA and OCI commercial offerings to OSS docs.
