### PR TITLE
Upgrade to Docusaurus 3.2.1

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -360,20 +360,6 @@ const config = {
           content: 'https://tags.tiqcdn.com/utag/vmware/microsites-privacy/prod/utag.js',
         },
       ],
-      headTags: [
-        {
-          tagName: 'script',
-          attributes: { src: '//www.vmware.com/files/templates/inc/utag_data.js' },
-        },
-        {
-          tagName: 'script',
-          attributes: { src: '//tags.tiqcdn.com/utag/vmware/microsites-privacy/prod/utag.sync.js' },
-        },
-        {
-          tagName: 'script',
-          innerHTML: "function OptanonWrapper() { { window.dataLayer.push({ event: 'OneTrustGroupsUpdated' }); } }",
-        },
-      ],
     }),
 
   headTags: [
@@ -383,6 +369,23 @@ const config = {
         rel: 'stylesheet',
         href: 'https://fonts.googleapis.com/css?family=Raleway:400,700',
       },
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        href: '//www.vmware.com/files/templates/inc/utag_data.js',
+      },
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        href: '//tags.tiqcdn.com/utag/vmware/microsites-privacy/prod/utag.sync.js',
+      },
+    },
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: "function OptanonWrapper() { { window.dataLayer.push({ event: 'OneTrustGroupsUpdated' }); } }",
     },
   ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "rabbitmq-website",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.2.0",
-        "@docusaurus/preset-classic": "^3.2.0",
-        "@docusaurus/theme-mermaid": "^3.2.0",
+        "@docusaurus/core": "^3.2.1",
+        "@docusaurus/preset-classic": "^3.2.1",
+        "@docusaurus/theme-mermaid": "^3.2.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^1.2.1",
         "prism-react-renderer": "^2.1.0",
@@ -18,8 +18,8 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.2.0",
-        "@docusaurus/types": "^3.2.0"
+        "@docusaurus/module-type-aliases": "^3.2.1",
+        "@docusaurus/types": "^3.2.1"
       },
       "engines": {
         "node": ">=18.0"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.2.0",
-    "@docusaurus/preset-classic": "^3.2.0",
-    "@docusaurus/theme-mermaid": "^3.2.0",
+    "@docusaurus/core": "^3.2.1",
+    "@docusaurus/preset-classic": "^3.2.1",
+    "@docusaurus/theme-mermaid": "^3.2.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^2.1.0",
@@ -24,8 +24,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.2.0",
-    "@docusaurus/types": "^3.2.0"
+    "@docusaurus/module-type-aliases": "^3.2.1",
+    "@docusaurus/types": "^3.2.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This patch also fixes our usage of `headTags`. The documentation for `headTags` was fixed in Docusaurus 3.2.1 (facebook/docusaurus#10014). The fact that they didn't work for us was not related to a problem in Docusuaurs (#facebook/docusaurus#9792), but an incorrect use on our side.