### PR TITLE
Fix wording in amqp-concepts tutorial

### DIFF
--- a/tutorials/amqp-concepts/index.md
+++ b/tutorials/amqp-concepts/index.md
@@ -317,7 +317,7 @@ stored in memory when possible.
 The same distinction is made for [messages at publishing time](/docs/publishers#message-properties).
 
 In environments and use cases where durability is important, applications
-must use durable queues *and* make sure that publish mark published messages as persisted.
+must use durable queues *and* make sure that publishers mark published messages as persisted.
 
 This topic is covered in more detailed in the [Queues guide](/docs/queues#durability).
 


### PR DESCRIPTION
This change improves readability by aligning the wording in [AMQP 0-9-1 Model Explained](https://www.rabbitmq.com/tutorials/amqp-concepts) with the language used in `rabbitmq-website/docs/queues.md`.

https://github.com/rabbitmq/rabbitmq-website/blob/a15004b47e6d0f1c116dbdab738c54437b3fe26f/docs/queues.md?plain=1#L218-L219
