### PR TITLE
Remove duplicate item

### DIFF
--- a/versioned_docs/version-3.13/plugins.md
+++ b/versioned_docs/version-3.13/plugins.md
@@ -522,14 +522,6 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
     </td>
   </tr>
 
-
-  <tr>
-    <th>rabbitmq_mqtt</th>
-    <td>
-      MQTT support.
-    </td>
-  </tr>
-
   <tr>
     <th>rabbitmq_tracing</th>
     <td>


### PR DESCRIPTION
There are two `rabbitmq_mqtt` in the list and I think it's good to remove the second one which has less information.

![image](https://github.com/rabbitmq/rabbitmq-website/assets/39259397/823c999b-08d2-414b-8b4e-f802ee0450e4)

- https://github.com/rabbitmq/rabbitmq-website/blob/main/versioned_docs/version-3.13/plugins.md?plain=1#L471-L479
- https://github.com/rabbitmq/rabbitmq-website/blob/main/versioned_docs/version-3.13/plugins.md?plain=1#L526-L531