### PR TITLE
Fix typo in vhosts.md

### DIFF
--- a/docs/vhosts.md
+++ b/docs/vhosts.md
@@ -136,7 +136,7 @@ demonstrated above:
 rabbitmqctl update_vhost_metadata qa1 --description "QA environment for issue 1662" --default-queue-type quorum --tags qa,project-a,qa-1662
 ```
 
-To inspect virtual host metadata, use `rabbitmqctl list_vhots` and provide the additional column(s):
+To inspect virtual host metadata, use `rabbitmqctl list_vhosts` and provide the additional column(s):
 
 ```bash
 rabbitmqctl -q --formatter=pretty_table list_vhosts name description tags default_queue_type


### PR DESCRIPTION
I copy-paste some commands from docs and find typo