### PR TITLE
Fix: Add double quotes in CLI command in the "Users and Authentication" section

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -285,7 +285,7 @@ to the default [virtual host](./vhosts) used by this plugin:
 ```bash
 # username and password are both "mqtt-test"
 rabbitmqctl add_user mqtt-test mqtt-test
-rabbitmqctl set_permissions -p / mqtt-test ".*" ".*" ".*"
+rabbitmqctl set_permissions -p "/" mqtt-test ".*" ".*" ".*"
 rabbitmqctl set_user_tags mqtt-test management
 ```
 


### PR DESCRIPTION
### **Problem Description:**
While setting up a new user following the documentation at the section "Users and Authentication" in the following [link](https://www.rabbitmq.com/docs/mqtt#authentication). I encountered an error when executing the command `rabbitmqctl set_permissions -p / mqtt-test ".*" ".*" ".*"`. The error presented was "Error (argument validation): too many arguments".

![image](https://github.com/rabbitmq/rabbitmq-website/assets/88160515/181c5d4b-2f5f-4161-8074-0bc01546c6ee)

### **Proposed Solution:**
To fix this issue, I added double quotes around the "/" character. This change resolves the error and allows the command to be executed as expected.