### PR TITLE
Fix typo in command of migrate-mcq-to-qq.md doc

### DIFF
--- a/docs/migrate-mcq-to-qq.md
+++ b/docs/migrate-mcq-to-qq.md
@@ -243,7 +243,7 @@ Now the modified schema can be loaded into the new virtual host from the Managem
 UI or by running the following command from the CLI:
 
 ```bash
-rabbitadmin import -V NEW_VHOST NEW_VHOST.json
+rabbitmqadmin import -V NEW_VHOST NEW_VHOST.json
 ```
 
 ### Point Consumers to use Quorum Queues in the New Virtual Host


### PR DESCRIPTION
Hello folks!

Recently, I tried to perform the migration guide from the mirrored classic to quorum queues in one of my company's clusters, and I observed a minor typo in the command that imports the new schema that contains the quorum type in the queues.

`rabbitmqadmin import -V NEW_VHOST NEW_VHOST.json
`

I observed it and I decided to fix it...

Thank you in advance as well as for the migration guide, it was quite helpful!!