### PR TITLE
docusaurus.config.js: Use CSS class, not Javascript, to open OneTrust popup

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -346,7 +346,7 @@ const config = {
                 href: 'https://www.vmware.com/help/privacy/california-privacy-rights.html',
               },
               {
-                html: '<a class="footer__link-item" href="javascript:void(0);" onclick="OpenOneTrustPopup();">Cookie Settings</a>',
+                html: '<a class="footer__link-item ot-sdk-show-settings">Cookie Settings</a>',
               },
             ],
           },
@@ -416,11 +416,6 @@ const config = {
       tagName: 'script',
       attributes: {},
       innerHTML: "function setGTM(w, d, s, l, i) { w[l] = w[l] || []; w[l].push({  'gtm.start': new Date().getTime(),  event: 'gtm.js' }); var f = d.getElementsByTagName(s)[0],  j = d.createElement(s),  dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f); } if (document.cookie.indexOf('OptanonConsent') > -1 && document.cookie.indexOf('groups=') > -1) { setGTM(window, document, 'script', 'dataLayer', 'GTM-TT84L8K'); } else { waitForOnetrustActiveGroups(); } var timer; function waitForOnetrustActiveGroups() { if (document.cookie.indexOf('OptanonConsent') > -1 && document.cookie.indexOf('groups=') > -1) {  clearTimeout(timer);  setGTM(window, document, 'script', 'dataLayer', 'GTM-TT84L8K'); } else {  timer = setTimeout(waitForOnetrustActiveGroups, 250); } }",
-    },
-    {
-      tagName: 'script',
-      attributes: {},
-      innerHTML: "function OpenOneTrustPopup() { document.getElementsByClassName('ot-floating-button__open')[0].click(); }",
     },
   ],
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -128,6 +128,14 @@ html[data-theme='dark'] .mermaid-msg > rect {
   display: none;
 }
 
+.ot-sdk-show-settings {
+  cursor: pointer;
+}
+
+.ot-sdk-show-settings:hover {
+  text-decoration: var(--ifm-link-hover-decoration);
+}
+
 /* -------------------------------------------------------------------
  * Docs introduction page.
  * ------------------------------------------------------------------- */


### PR DESCRIPTION
@jacksoncvm suggested that we can simply set the `ot-sdk-show-settings` CSS class on the link to achieve the same goal of opening the OneTrust popup without any Javascript.

Indeed it works well. We only set a few more CSS properties to keep the same behavior when the mouse pointer hovers the link.