### PR TITLE
Update access-control.md

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -199,11 +199,18 @@ echo '2a55f70a841f18b97c3a7db939b7adc9e34a0f1b' | rabbitmqctl add_user 'username
 rabbitmqctl add_user 'username' '2a55f70a841f18b97c3a7db939b7adc9e34a0f1b'
 ```
 
-On Windows, `rabbitmqctl` becomes `rabbitmqctl.bat` and shell escaping would be different:
+On Windows, `rabbitmqctl` becomes `rabbitmqctl.bat` and shell escaping is different based on your shell:
 
 ```powershell
+# powershell
 # password is provided as a command line argument
-rabbitmqctl.bat add_user username '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
+rabbitmqctl.bat add_user 'username' '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
+```
+
+```batch
+rem cmd.exe
+rem password is provided as a command line argument
+rabbitmqctl.bat add_user "username" "9a55f70a841f18b97c3a7db939b7adc9e34a0f1d"
 ```
 
 ### Listing Users

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,6 +1,10 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ---
 title: Authentication, Authorisation, Access Control
 ---
+
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
@@ -201,17 +205,20 @@ rabbitmqctl add_user 'username' '2a55f70a841f18b97c3a7db939b7adc9e34a0f1b'
 
 On Windows, `rabbitmqctl` becomes `rabbitmqctl.bat` and shell escaping is different based on your shell:
 
+<Tabs>
+<TabItem value="powershell" label="PowerShell" default>
 ```powershell
-# powershell
 # password is provided as a command line argument
 rabbitmqctl.bat add_user 'username' '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
 ```
-
+</TabItem>
+<TabItem value="cmd" label="cmd">
 ```batch
-rem cmd.exe
 rem password is provided as a command line argument
 rabbitmqctl.bat add_user "username" "9a55f70a841f18b97c3a7db939b7adc9e34a0f1d"
 ```
+</TabItem>
+</Tabs>
 
 ### Listing Users
 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -203,7 +203,7 @@ On Windows, `rabbitmqctl` becomes `rabbitmqctl.bat` and shell escaping would be 
 
 ```powershell
 # password is provided as a command line argument
-rabbitmqctl.bat add_user 'username' '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
+rabbitmqctl.bat add_user username '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
 ```
 
 ### Listing Users

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -358,6 +358,7 @@ const config = {
         darkTheme: prismThemes.dracula,
         additionalLanguages: [
           'bash',
+          'batch',
           'csharp',
           'elixir',
           'erlang',


### PR DESCRIPTION
In Windows adding a user via the command line, omit the 'single quotation marks'.

I ended up with a user having these quotation marks included in the name, and it took me 4 hours of fiddling with all kinds of unrelated settings only to find out that the username had quotation marks included in the name... And me wondering why  all access was always being denied...