### PR TITLE
add the signal-flow to Go clients.

### DIFF
--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -133,6 +133,7 @@ Miscellaneous projects:
  * &#x2713; [RabbitMQ Stream Go client](https://github.com/rabbitmq/rabbitmq-stream-go-client)
  * Rabbit Hole, [RabbitMQ HTTP API client for Go](https://github.com/michaelklishin/rabbit-hole)
  * [amqpc](https://github.com/gocardless/amqpc), a load testing tool for RabbitMQ clusters
+ * [signal-flow](https://github.com/harpy-wings/signal-flow) Simplifying AMQP client experience
 
 
 ## iOS and Android {#ios-android}


### PR DESCRIPTION

- Add the [signal-flow](https://github.com/harpy-wings/signal-flow) to Go clients.

The primary focus of this project is to provide a straightforward interface that addresses the most common needs of projects, prioritizing simplicity over advanced features like streaming.