### PR TITLE
Fix typos: managament to management, maintenence to maintenance

### DIFF
--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -51,7 +51,7 @@ There is a dedicated **KeyCloak realm** called `Test` configured as follows:
 
 * You configured an [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
 * And a [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
-* And three clients: `rabbitmq-client-code` for the rabbitmq managament UI, `mgt_api_client` to access via the
+* And three clients: `rabbitmq-client-code` for the rabbitmq management UI, `mgt_api_client` to access via the
 management api and `producer` to access via AMQP protocol.
 
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -274,7 +274,7 @@ shutdown during rolling upgrades. This is covered below.
 
 ### After Restarting All Nodes {#after-restarting}
 
-After performing a rolling upgrade and putting the last node out of [maintenence mode](#maintenance-mode),
+After performing a rolling upgrade and putting the last node out of [maintenance mode](#maintenance-mode),
 perform the following steps:
 
  * Enable all [feature flags](./feature-flags) in the cluster using `rabbitmqctl enable_feature_flag all`

--- a/versioned_docs/version-3.13/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-3.13/oauth2-examples-keycloak.md
@@ -51,7 +51,7 @@ There is a dedicated **KeyCloak realm** called `Test` configured as follows:
 
 * You configured an [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
 * And a [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
-* And three clients: `rabbitmq-client-code` for the rabbitmq managament UI, `mgt_api_client` to access via the
+* And three clients: `rabbitmq-client-code` for the rabbitmq management UI, `mgt_api_client` to access via the
 management api and `producer` to access via AMQP protocol.
 
 

--- a/versioned_docs/version-3.13/upgrade.md
+++ b/versioned_docs/version-3.13/upgrade.md
@@ -274,7 +274,7 @@ shutdown during rolling upgrades. This is covered below.
 
 ### After Restarting All Nodes {#after-restarting}
 
-After performing a rolling upgrade and putting the last node out of [maintenence mode](#maintenance-mode),
+After performing a rolling upgrade and putting the last node out of [maintenance mode](#maintenance-mode),
 perform the following steps:
 
  * Enable all [feature flags](./feature-flags) in the cluster using `rabbitmqctl enable_feature_flag all`


### PR DESCRIPTION
Similar to https://github.com/rabbitmq/rabbitmq-website/pull/1916, I've found two more typos 🤣

managament -> management
maintenence -> maintenance