### PR TITLE
Typo fix: overriden should be overridden

### DIFF
--- a/docs/classic-queues.md
+++ b/docs/classic-queues.md
@@ -29,7 +29,7 @@ Classic queues uses the **non-replicated** FIFO queue implementation.
 If data safety is a priority, the recommendation is to use [quorum queues](./quorum-queues) and [streams](./streams) instead of classic queues.
 
 Classic queues are the default queue type
-as long as the default queue type is not overriden for the virtual host.
+as long as the default queue type is not overridden for the virtual host.
 
 There are [two versions](#versions) (implementations) of classic queue message storage
 and indexing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,7 +155,7 @@ When the `--offline` flag is used, the command will rely on [environment variabl
 to determine where to find the plugins directory of the local node.
 
 For example, it will respect and use the `RABBITMQ_PLUGINS_DIR` environment variable value
-just like a RabbitMQ node would. When `RABBITMQ_PLUGINS_DIR` is overriden for server nodes,
+just like a RabbitMQ node would. When `RABBITMQ_PLUGINS_DIR` is overridden for server nodes,
 it must also be set identically for the local OS user that invokes CLI tools.
 
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -173,7 +173,7 @@ installed RabbitMQ version changes between upgrades.
 
 ### rabbitmq-plugins {#offline-mode}
 
-When plugin directories are overriden using an environment variable, the same variable
+When plugin directories are overridden using an environment variable, the same variable
 must also be set identically for the local OS user that invokes CLI tools.
 
 If this is not done, [`rabbitmq-plugins` in offline mode](./cli#offline-mode) will not


### PR DESCRIPTION
Hi it's me again 🤣, I've found this additional typo.