### PR TITLE
Update Spring Integration URL in devtools.md

### DIFF
--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -50,7 +50,7 @@ would like to see added to this list.
 
  * &#x2713; [Spring AMQP project for Java](https://spring.io/projects/spring-amqp)
  * &#x2713; [Spring Cloud Data Flow](https://dataflow.spring.io/)
- * &#x2713; [Spring Integration](http://docs.spring.io/spring-integration/reference/html/amqp.html)
+ * &#x2713; [Spring Integration](http://docs.spring.io/spring-integration/reference/amqp.html)
 
 
 ## .NET {#dotnet-dev}


### PR DESCRIPTION
The URL for Spring Integration documentation has been updated to point to the correct reference link. The old URL was pointing to a non-existent page, and it has now been corrected.