### PR TITLE
access-control: Add a clarifying block on how to read auth table

### DIFF
--- a/versioned_docs/version-3.13/access-control.md
+++ b/versioned_docs/version-3.13/access-control.md
@@ -445,6 +445,14 @@ basis. The user is granted the respective permission for
 operations on all resources with names matching the regular
 expressions.
 
+So, for example, in the table above the <code>queue.bind</code>
+operation specifies that <em>write</em> is needed on <code>queue</code>
+and <em>read</em> is needed on <code>exchange</code>.
+So to allow a user to bind queue named <code>queueA</code> and
+exchange named <code>exchangeB</code> the user will need a <em>write</em>
+regex matching <code>queueA</code> and a <em>read</em> regex matching
+<code>exchangeB</code> in the correct vhost.
+
 For convenience RabbitMQ maps AMQP 0-9-1's
 default exchange's blank name to 'amq.default' when
 performing permission checks.


### PR DESCRIPTION
I struggled for a bit to understand how to read the authorisation table and what the regexes should actually be when trying to limit user permissions to specific queues and exchanges.  This PR adds a small block explaining the `queue.bind` row, which I picked as it needs two permissions on both a queue and a exchange, which I felt was suitably complex to highlight how to read and apply the table on different resources but not overly complicated.  Most the guides I found used the same queue and exchange patterns for all 3 permissions fields, or just used `.*` for everything, so this is meant to fill that void for new users for whom the regex patterns haven't clicked yet.

I tried to match the formatting style, let me know if I didn't get it right.  Thanks.
