### PR TITLE
remove fail_if_no_peer_cert

### DIFF
--- a/docs/uri-query-parameters.md
+++ b/docs/uri-query-parameters.md
@@ -144,8 +144,7 @@ against the hostname `myhost`.
         {cacertfile, "path-to-ca-certificate"},
         {certfile, "path-to-certificate"},
         {keyfile, "path-to-keyfile"},
-        {verify, verify_peer},
-        {fail_if_no_peer_cert, true}
+        {verify, verify_peer}
     ]}
 ]}
 ```


### PR DESCRIPTION
Remove fail_if_no_peer_cert from amqp_client options as it is no longer valid with Erlang 26 and will stop the connection from working