### PR TITLE
Updating commercial doc links, making them point to the 3.13 commercial docs

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -41,7 +41,7 @@ and more. [Cluster Formation and Peer Discovery](./cluster-formation) is a close
 that focuses on peer discovery and cluster formation automation-related topics. For queue contents
 (message) replication, see the [Quorum Queues](./quorum-queues) guide.
 
-[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/clustering-compression-rabbitmq.html) feature.
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/clustering-compression-rabbitmq.html) feature.
 
 A RabbitMQ cluster is a logical grouping of one or
 several nodes, each  sharing users, virtual hosts,

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -34,7 +34,7 @@ Every node in a cluster has its own replica of all definitions. When a part of d
 the update is performed on all nodes in a single transaction. This means that
 in practice, definitions can be exported from any cluster node with the same result.
 
-[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) supports [Warm Standby Replication](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) to a remote cluster,
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) supports [Warm Standby Replication](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/standby-replication.html) to a remote cluster,
 which makes it easy to run a warm standby cluster for disaster recovery.
 
 Definition import on node boot is the recommended way of [pre-configuring nodes at deployment time](#import-on-boot).

--- a/docs/download.md
+++ b/docs/download.md
@@ -94,7 +94,7 @@ Other guides related to Kubernetes:
 
  * [VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
  * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
- * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/installation.html)
+ * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/installation.html)
  * [Amazon MQ for RabbitMQ](https://aws.amazon.com/amazon-mq/)
  * [Amazon EC2](./ec2)
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -73,7 +73,7 @@ such as
  * [Heartbeats](#heartbeats) (a.k.a. keepalives)
  * [proxies and load balancers](#intermediaries)
 
-[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) commercial offerings provide an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) feature. The previous documentation link goes to the Tanzu RabbitMQ for Kubernetes commercial offering.
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) commercial offerings provide an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/clustering-compression-rabbitmq.html) feature. The previous documentation link goes to the Tanzu RabbitMQ for Kubernetes commercial offering.
 
 A methodology for [troubleshooting of networking-related issues](./troubleshooting-networking)
 is covered in a separate guide.

--- a/kubernetes/operator/using-on-openshift.md
+++ b/kubernetes/operator/using-on-openshift.md
@@ -5,7 +5,7 @@ displayed_sidebar: kubernetesSidebar
 # Using the RabbitMQ Kubernetes Operators on Openshift
 
 ## Overview {#overview}
-This documentation details the Openshift-specific considerations when deploying the RabbitMQ Kubernetes Operators, which are the [Cluster operator](./using-operator) and the [Messaging Topology Operator](./using-topology-operator). It is important to note that these considerations are also applicable to the commercial [VMware Tanzu RabbitMQ Standby Replication Operator](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html#requirements-for-warm-standby-replication) (note, this operator is exclusive to the VMware Tanzu RabbitMQ for Kubernetes commercial offering only).
+This documentation details the Openshift-specific considerations when deploying the RabbitMQ Kubernetes Operators, which are the [Cluster operator](./using-operator) and the [Messaging Topology Operator](./using-topology-operator). It is important to note that these considerations are also applicable to the commercial [VMware Tanzu RabbitMQ Standby Replication Operator](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/standby-replication.html#requirements-warm-standby-replication) (note, this operator is exclusive to the VMware Tanzu RabbitMQ for Kubernetes commercial offering only).
 
 For the most part, the user experience is the same when
 using these operators on Openshift; the following guide details the additional work required to leverage Openshift's

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -318,9 +318,9 @@ flowchart TD
                   are available. These commercial offerings include all of the
                   features of RabbitMQ, with some additional management and
                   advanced features like <Link
-                  to="https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html">warm
+                  to="https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/standby-replication.html">warm
                   standby replication</Link> and <Link
-                  to="https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/clustering-compression-rabbitmq.html">intra-cluster
+                  to="https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/clustering-compression-rabbitmq.html">intra-cluster
                   data compression</Link>. These features are a must for
                   heavy workloads.</p>
                 <p>For a list of the commercial offerings, take a look at

--- a/versioned_docs/version-3.13/clustering.md
+++ b/versioned_docs/version-3.13/clustering.md
@@ -41,7 +41,7 @@ and more. [Cluster Formation and Peer Discovery](./cluster-formation) is a close
 that focuses on peer discovery and cluster formation automation-related topics. For queue contents
 (message) replication, see the [Quorum Queues](./quorum-queues) guide.
 
-[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/clustering-compression-rabbitmq.html) feature.
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) provides an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/clustering-compression-rabbitmq.html) feature.
 
 A RabbitMQ cluster is a logical grouping of one or
 several nodes, each  sharing users, virtual hosts,

--- a/versioned_docs/version-3.13/definitions.md
+++ b/versioned_docs/version-3.13/definitions.md
@@ -34,7 +34,7 @@ Every node in a cluster has its own replica of all definitions. When a part of d
 the update is performed on all nodes in a single transaction. This means that
 in practice, definitions can be exported from any cluster node with the same result.
 
-[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) supports [Warm Standby Replication](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) to a remote cluster,
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/index.html) supports [Warm Standby Replication](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/standby-replication.html) to a remote cluster,
 which makes it easy to run a warm standby cluster for disaster recovery.
 
 Definition import on node boot is the recommended way of [pre-configuring nodes at deployment time](#import-on-boot).

--- a/versioned_docs/version-3.13/download.md
+++ b/versioned_docs/version-3.13/download.md
@@ -94,7 +94,7 @@ Other guides related to Kubernetes:
 
  * [VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
  * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
- * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/installation.html)
+ * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/installation.html)
  * [Amazon MQ for RabbitMQ](https://aws.amazon.com/amazon-mq/)
  * [Amazon EC2](./ec2)
 

--- a/versioned_docs/version-3.13/networking.md
+++ b/versioned_docs/version-3.13/networking.md
@@ -73,7 +73,7 @@ such as
  * [Heartbeats](#heartbeats) (a.k.a. keepalives)
  * [proxies and load balancers](#intermediaries)
 
-[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) commercial offerings provide an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/1/rmq/standby-replication.html) feature. The previous documentation link goes to the Tanzu RabbitMQ for Kubernetes commercial offering.
+[VMware Tanzu RabbitMQ](https://docs.vmware.com/en/VMware-RabbitMQ-for-Kubernetes/index.html) commercial offerings provide an [Intra-cluster Compression](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/clustering-compression-rabbitmq.html) feature. The previous documentation link goes to the Tanzu RabbitMQ for Kubernetes commercial offering.
 
 A methodology for [troubleshooting of networking-related issues](./troubleshooting-networking)
 is covered in a separate guide.


### PR DESCRIPTION
**Why?**

The current links to commercial VMware Tanzu RabbitMQ docs are pointing to the 1.5 docs. We are about to release the commercial 3.13 releases so the doc URLs have now changed (both for rebranding and to include the new version number in the URLs). 

**This PR is not to be merged until the 3.13 VMware Tanzu RabbitMQ commercial docs are live, I will include an update here when that happens.**

Thanks 
