### PR TITLE
fix: add instruction to specify queue type explicitly

### DIFF
--- a/blog/2023-03-02-quorum-queues-migration/index.md
+++ b/blog/2023-03-02-quorum-queues-migration/index.md
@@ -337,6 +337,12 @@ The following changes needs to be made to this file before loading it back into 
 7. Policies that apply federation rules to exchanges need to be
    removed for the period of the migration, to avoid duplicate
    messages.
+8. Add `x-queue-type` declarations back for all quorum queues. If you follow the
+   advice that clients should declare their queues before starting consumption,
+   DeclareQueue invocations after the first one will fail with `Exception (406) Reason: "PRECONDITION_FAILED - inequivalent 
+   arg 'x-queue-type' for queue '$QUEUE_NAME' in vhost '$VHOST': received none but current is the value 
+   'quorum' of type 'longstr'"`
+
 
 Now the modified schema can be loaded into the new virtual host from
 UI or using CLI tools:


### PR DESCRIPTION
This caused issues for me attempting to follow these instructions.

Actual log message:

```
 {"@timestamp":"2024-06-05T10:21:54.700488885-07:00","app.name":"rabbitmq-monitor","app.version":"v1.0.1-7-g8248984","deployment.namespace":"rabbitmq-monitor--bento1a","error.error":"Exception (406) Reason: \"PRECONDITION_FAILED - inequivalent arg 'x-queue-type' for queue 'rabbitmq-monitor-round-trip' in vhost 'development': received none but current is the value 'quorum' of type 'longstr'\"","error.kind":"error","error.message":"Exception (406) Reason: \"PRECONDITION_FAILED - inequivalent arg 'x-queue-type' for queue 'rabbitmq-monitor-round-trip' in vhost 'development': received none but current is the value 'quorum' of type 'longstr'\"","level":"ERROR","message":"service down unexpectedly","module":"github.com/getoutreach/stencil-golang/pkg","modulever":"v0.0.0-20230811193316-312178c3fbc3","service_name":"rabbitmq-monitor"}
```

RabbitMQ 3.12.7
Erlang 25.3.2.7

Configuration:

```
# Common settings
management_agent.disable_metrics_collector = false
listeners.tcp.default = 5672
management.tcp.port = 15672
loopback_users.guest = false
## Username
default_user = CHANGE_ME
default_pass = CHANGE_ME
## Clustering
cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
cluster_formation.k8s.address_type = hostname
cluster_formation.k8s.service_name = flagship-rabbitmq-internal
cluster_formation.k8s.hostname_suffix = .flagship-rabbitmq-internal.bento1a.svc.cluster.local
cluster_formation.node_cleanup.interval = 10
cluster_formation.node_cleanup.only_log_warning = true
cluster_partition_handling = autoheal
queue_master_locator = min-masters
## Memory Threshold
total_memory_available_override_value = 536870912
vm_memory_high_watermark.relative = 0.9
management.load_definitions = /app/load_definitions.json
```

Definitions:

```
{
  "users": [
    {
      "name": "[REDACTED]",
      "password_hash": "[REDACTED]",
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "tags": "administrator"
    }
  ],
  "vhosts": [
    {
      "name": "development",
      "default_queue_type": "quorum"
    },
    {
      "name": "test",
      "default_queue_type": "quorum"
    }
  ],
  "permissions": [
    {
      "user": "outreach",
      "vhost": "development",
      "configure": ".*",
      "write": ".*",
      "read": ".*"
    },
    {
      "user": "outreach",
      "vhost": "test",
      "configure": ".*",
      "write": ".*",
      "read": ".*"
    }
  ]
}
```