### PR TITLE
Fixing Keycloak Spelling

### DIFF
--- a/blog/2022-07-22-oidc-integration/index.md
+++ b/blog/2022-07-22-oidc-integration/index.md
@@ -66,6 +66,6 @@ However, it is highly recommended that existing clusters configured to use UAA f
 In theory, any OAuth 2.0 server which is OpenID Connect compliant should be supported. RabbitMQ has been tested
 against the following OAuth 2.0 servers:
 
-* KeyCloak
+* Keycloak
 * Auth0
 * Azure Active Directory

--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -33,17 +33,17 @@ and Keycloak as Authorization Server using the following flows:
 * Docker
 * make
 
-## Deploy Key Cloak
+## Deploy Keycloak
 
-1. First, deploy **Key Cloak**. It comes preconfigured with all the required scopes, users and clients.
+1. First, deploy **Keycloak**. It comes preconfigured with all the required scopes, users and clients.
 
-2. Run the following command to start **Key Cloak** server:
+2. Run the following command to start **Keycloak** server:
 
     ```bash
     make start-keycloak
     ```
 
-    **Key Cloak** comes configured with its own signing key. And the [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/keycloak/rabbitmq.config) used by `make start-keycloak` is also configured with the same signing key.
+    **Keycloak** comes configured with its own signing key. And the [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/keycloak/rabbitmq.config) used by `make start-keycloak` is also configured with the same signing key.
 
 3. Access Keycloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
@@ -102,7 +102,7 @@ Note: Ensure you install pika 1.3
 ## Access Management UI
 
 1. Go to http://localhost:15672.
-2. Click on the single button on the page which redirects to **Key Cloak** to authenticate.
+2. Click on the single button on the page which redirects to **Keycloak** to authenticate.
 3. Enter `rabbit_admin` and `rabbit_admin` and you should be redirected back to RabbitMQ Management fully logged in.
 
 

--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -1,5 +1,5 @@
 ---
-title: Use KeyCloak as OAuth 2.0 server
+title: Use Keycloak as OAuth 2.0 server
 displayed_sidebar: docsSidebar
 ---
 <!--
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Use KeyCloak as OAuth 2.0 server
+# Use Keycloak as OAuth 2.0 server
 
 Demonstrate how to authenticate using the OAuth 2.0 protocol
 and Keycloak as Authorization Server using the following flows:
@@ -45,9 +45,9 @@ and Keycloak as Authorization Server using the following flows:
 
     **Key Cloak** comes configured with its own signing key. And the [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/keycloak/rabbitmq.config) used by `make start-keycloak` is also configured with the same signing key.
 
-3. Access KeyCloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+3. Access Keycloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
-There is a dedicated **KeyCloak realm** called `Test` configured as follows:
+There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
 * You configured an [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
 * And a [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
@@ -57,7 +57,7 @@ management api and `producer` to access via AMQP protocol.
 
 ## Start RabbitMQ
 
-Run the command below to start RabbitMQ configured with the **KeyCloak** server we started in the previous section:
+Run the command below to start RabbitMQ configured with the **Keycloak** server we started in the previous section:
 ```bash
 export MODE=keycloak
 make start-rabbitmq
@@ -112,7 +112,7 @@ Note: Ensure you install pika 1.3
 make stop-keycloak
 ```
 
-## Notes about setting up KeyCloak
+## Notes about setting up Keycloak
 
 ### Configure JWT signing Keys
 

--- a/docs/oauth2-examples/index.md
+++ b/docs/oauth2-examples/index.md
@@ -54,7 +54,7 @@ accompanied by [a public GitHub repository](https://github.com/rabbitmq/rabbitmq
     - [Preferred username claims](#preferred-username-claims)
 	- [Use Rich Authorization Requests tokens](#use-rar-tokens)
 * Use different OAuth 2.0 servers
-	- [KeyCloak](./oauth2-examples-keycloak)
+	- [Keycloak](./oauth2-examples-keycloak)
 	- [Auth0](./oauth2-examples-auth0)
 	- [Azure Active Directory](./oauth2-examples-azure)
   - [OAuth2 Proxy](./oauth2-examples-proxy)
@@ -75,7 +75,7 @@ accompanied by [a public GitHub repository](https://github.com/rabbitmq/rabbitmq
 
 To demonstrate OAuth 2.0 you need, at least, an OAuth 2.0 authorization server and RabbitMQ appropriately configured for the chosen authorization server. This guide uses [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) as authorization server to demonstrate basic and advanced configuration to access to the Management UI and various messaging protocols.
 
-This guide also demonstrates how to configure RabbitMQ to use other authorization servers besides [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) such as [KeyCloak](./oauth2-examples-keycloak). The table of content of this guide has the full list of authorization servers.
+This guide also demonstrates how to configure RabbitMQ to use other authorization servers besides [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) such as [Keycloak](./oauth2-examples-keycloak). The table of content of this guide has the full list of authorization servers.
 
 Run the following two commands to start UAA and RabbitMQ configured for UAA:
 

--- a/versioned_docs/version-3.13/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-3.13/oauth2-examples-keycloak.md
@@ -33,17 +33,17 @@ and Keycloak as Authorization Server using the following flows:
 * Docker
 * make
 
-## Deploy Key Cloak
+## Deploy Keycloak
 
-1. First, deploy **Key Cloak**. It comes preconfigured with all the required scopes, users and clients.
+1. First, deploy **Keycloak**. It comes preconfigured with all the required scopes, users and clients.
 
-2. Run the following command to start **Key Cloak** server:
+2. Run the following command to start **Keycloak** server:
 
     ```bash
     make start-keycloak
     ```
 
-    **Key Cloak** comes configured with its own signing key. And the [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/keycloak/rabbitmq.config) used by `make start-keycloak` is also configured with the same signing key.
+    **Keycloak** comes configured with its own signing key. And the [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/keycloak/rabbitmq.config) used by `make start-keycloak` is also configured with the same signing key.
 
 3. Access Keycloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
@@ -102,7 +102,7 @@ Note: Ensure you install pika 1.3
 ## Access Management UI
 
 1. Go to http://localhost:15672.
-2. Click on the single button on the page which redirects to **Key Cloak** to authenticate.
+2. Click on the single button on the page which redirects to **Keycloak** to authenticate.
 3. Enter `rabbit_admin` and `rabbit_admin` and you should be redirected back to RabbitMQ Management fully logged in.
 
 

--- a/versioned_docs/version-3.13/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-3.13/oauth2-examples-keycloak.md
@@ -1,5 +1,5 @@
 ---
-title: Use KeyCloak as OAuth 2.0 server
+title: Use Keycloak as OAuth 2.0 server
 displayed_sidebar: docsSidebar
 ---
 <!--
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Use KeyCloak as OAuth 2.0 server
+# Use Keycloak as OAuth 2.0 server
 
 Demonstrate how to authenticate using the OAuth 2.0 protocol
 and Keycloak as Authorization Server using the following flows:
@@ -45,9 +45,9 @@ and Keycloak as Authorization Server using the following flows:
 
     **Key Cloak** comes configured with its own signing key. And the [rabbitmq.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/keycloak/rabbitmq.config) used by `make start-keycloak` is also configured with the same signing key.
 
-3. Access KeyCloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+3. Access Keycloak management interface go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
-There is a dedicated **KeyCloak realm** called `Test` configured as follows:
+There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
 * You configured an [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
 * And a [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
@@ -57,7 +57,7 @@ management api and `producer` to access via AMQP protocol.
 
 ## Start RabbitMQ
 
-Run the command below to start RabbitMQ configured with the **KeyCloak** server we started in the previous section:
+Run the command below to start RabbitMQ configured with the **Keycloak** server we started in the previous section:
 ```bash
 export MODE=keycloak
 make start-rabbitmq
@@ -112,7 +112,7 @@ Note: Ensure you install pika 1.3
 make stop-keycloak
 ```
 
-## Notes about setting up KeyCloak
+## Notes about setting up Keycloak
 
 ### Configure JWT signing Keys
 

--- a/versioned_docs/version-3.13/oauth2-examples/index.md
+++ b/versioned_docs/version-3.13/oauth2-examples/index.md
@@ -54,7 +54,7 @@ accompanied by [a public GitHub repository](https://github.com/rabbitmq/rabbitmq
     - [Preferred username claims](#preferred-username-claims)
 	- [Use Rich Authorization Requests tokens](#use-rar-tokens)
 * Use different OAuth 2.0 servers
-	- [KeyCloak](./oauth2-examples-keycloak)
+	- [Keycloak](./oauth2-examples-keycloak)
 	- [Auth0](./oauth2-examples-auth0)
 	- [Azure Active Directory](./oauth2-examples-azure)
   - [OAuth2 Proxy](./oauth2-examples-proxy)
@@ -75,7 +75,7 @@ accompanied by [a public GitHub repository](https://github.com/rabbitmq/rabbitmq
 
 To demonstrate OAuth 2.0 you need, at least, an OAuth 2.0 authorization server and RabbitMQ appropriately configured for the chosen authorization server. This guide uses [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) as authorization server to demonstrate basic and advanced configuration to access to the Management UI and various messaging protocols.
 
-This guide also demonstrates how to configure RabbitMQ to use other authorization servers besides [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) such as [KeyCloak](./oauth2-examples-keycloak). The table of content of this guide has the full list of authorization servers.
+This guide also demonstrates how to configure RabbitMQ to use other authorization servers besides [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) such as [Keycloak](./oauth2-examples-keycloak). The table of content of this guide has the full list of authorization servers.
 
 Run the following two commands to start UAA and RabbitMQ configured for UAA:
 


### PR DESCRIPTION
- Replacing "KeyCloak" with "Keycloak"

- Replacing "Key Cloak" with "Keycloak"