### PR TITLE
Better PowerShell/cmd.exe examples

### DIFF
--- a/client-libraries/build-dotnet-client.md
+++ b/client-libraries/build-dotnet-client.md
@@ -45,7 +45,7 @@ To build the .NET/C# client libraries on Windows, you will need
 
 To build the client with Visual Studio, first run
 
-```powershell
+```PowerShell
 build.bat
 ```
 
@@ -61,7 +61,7 @@ Then
 
 To build the client without Visual Studio, run
 
-```powershell
+```PowerShell
 build.bat
 ```
 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -195,38 +195,39 @@ depending on the programming language used.
 
 To add a user, use `rabbitmqctl add_user`. It has multiple ways of specifying a [password](./passwords):
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # will prompt for password, only use this option interactively
 rabbitmqctl add_user "username"
-```
 
-```bash
 # Password is provided via standard input.
 # Note that certain characters such as !, &, $, #, and so on must be escaped to avoid
 # special interpretation by the shell.
 echo '2a55f70a841f18b97c3a7db939b7adc9e34a0f1b' | rabbitmqctl add_user 'username'
-```
 
-```bash
 # Password is provided as a command line argument.
 # Note that certain characters such as !, &, $, #, and so on must be escaped to avoid
 # special interpretation by the shell.
 rabbitmqctl add_user 'username' '2a55f70a841f18b97c3a7db939b7adc9e34a0f1b'
 ```
-
-On Windows, `rabbitmqctl` becomes `rabbitmqctl.bat` and shell escaping is different based on your shell:
-
-<Tabs>
-<TabItem value="powershell" label="PowerShell" default>
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # password is provided as a command line argument
 rabbitmqctl.bat add_user 'username' '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
+
+# passwords with special characters must be quoted correctly
+rabbitmqctl.bat add_user 'username' '"w63pnZ&LnYMO(t"'
 ```
 </TabItem>
 <TabItem value="cmd" label="cmd">
 ```batch
 rem password is provided as a command line argument
 rabbitmqctl.bat add_user "username" "9a55f70a841f18b97c3a7db939b7adc9e34a0f1d"
+
+rem passwords with special characters must be quoted correctly
+rabbitmqctl.bat add_user "username" "w63pnZ&LnYMO(t"
 ```
 </TabItem>
 </Tabs>
@@ -235,79 +236,112 @@ rabbitmqctl.bat add_user "username" "9a55f70a841f18b97c3a7db939b7adc9e34a0f1d"
 
 To list users in a cluster, use `rabbitmqctl list_users`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl list_users
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 rabbitmqctl.bat list_users
 ```
+</TabItem>
+</Tabs>
 
 The output can be changed to be JSON:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl list_users --formatter=json
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 rabbitmqctl.bat list_users --formatter=json
 ```
+</TabItem>
+</Tabs>
 
 ### Deleting a User
 
 To delete a user, use `rabbitmqctl delete_user`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl delete_user 'username'
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 rabbitmqctl.bat delete_user 'username'
 ```
+</TabItem>
+</Tabs>
 
 ### Granting Permissions to a User
 
 To grant [permissions](#authorisation) to a user in a [virtual host](./vhosts), use `rabbitmqctl set_permissions`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # First ".*" for configure permission on every entity
 # Second ".*" for write permission on every entity
 # Third ".*" for read permission on every entity
 rabbitmqctl set_permissions -p "custom-vhost" "username" ".*" ".*" ".*"
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # First ".*" for configure permission on every entity
 # Second ".*" for write permission on every entity
 # Third ".*" for read permission on every entity
 rabbitmqctl.bat set_permissions -p 'custom-vhost' 'username' '.*' '.*' '.*'
 ```
+</TabItem>
+</Tabs>
 
 ### Clearing Permissions of a User in a Virtual Host
 
 To revoke [permissions](#authorisation) from a user in a [virtual host](./vhosts), use `rabbitmqctl clear_permissions`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # Revokes permissions in a virtual host
 rabbitmqctl clear_permissions -p "custom-vhost" "username"
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # Revokes permissions in a virtual host
 rabbitmqctl.bat clear_permissions -p 'custom-vhost' 'username'
 ```
+</TabItem>
+</Tabs>
 
 ### Operations on Multiple Virtual Hosts
 
 Every `rabbitmqctl` permission management operation is scoped to a single virtual host.
 Bulk operations have to be scripted, with the list of virtual hosts coming from `rabbitmqctl list_vhosts --silent`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # Assumes a Linux shell.
 # Grants a user permissions to all virtual hosts.
 for v in $(rabbitmqctl list_vhosts --silent); do rabbitmqctl set_permissions -p $v "a-user" ".*" ".*" ".*"; done
 ```
-
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+rabbitmqctl.bat list_vhosts --silent | %{ rabbitmqctl.bat set_permissions -p $_ 'a-user' '.*' '.*' '.*' }
+```
+</TabItem>
+</Tabs>
 
 ## Seeding (Pre-creating) Users and Permissions {#seeding}
 
@@ -861,9 +895,19 @@ will be logged differently. See [TLS Troubleshooting guide](./troubleshooting-ss
 [rabbitmqctl authenticate_user](./cli) can be used to test authentication
 for a username and password pair:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl authenticate_user "a-username" "a/password"
 ```
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+# note that double quotes are required due to the & character
+rabbitmqctl.bat authenticate_user 'a-username' '"a/p&assword"'
+```
+</TabItem>
+</Tabs>
 
 If authentication succeeds, it will exit with
 the code of zero. In case of a failure, a non-zero exit code will be used and a failure error message will be printed.
@@ -887,6 +931,8 @@ a problem used in a particular programming language or environment.
 [rabbitmqctl list_permissions](./cli) can be used to inspect a user's
 permission in a given virtual host:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl list_permissions --vhost /
 # => Listing permissions for vhost "/" ...
@@ -901,6 +947,14 @@ rabbitmqctl list_permissions --vhost gw1
 # => guest	.*	.*	.*
 # => user2	^user2	^user2	^user2
 ```
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+rabbitmqctl.bat list_permissions --vhost /
+rabbitmqctl.bat list_permissions --vhost gw1
+```
+</TabItem>
+</Tabs>
 
 [Server logs](./logging) will contain entries about operation authorisation
 failures. For example, if a user does not have any permissions configured for a virtual host:

--- a/docs/ae.md
+++ b/docs/ae.md
@@ -1,6 +1,7 @@
 ---
 title: Alternate Exchanges
 ---
+
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
@@ -17,6 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Alternate Exchanges
 
@@ -55,15 +59,23 @@ To specify an AE using policy, add the key 'alternate-exchange'
 to a policy definition and make sure that the policy matches the exchange(s)
 that need the AE defined. For example:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl set_policy AE "^my-direct$" '{"alternate-exchange":"my-ae"}' --apply-to exchanges
 ```
-
-Or, on Windows:
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+rabbitmqctl.bat set_policy AE '^my-direct$' '"{""alternate-exchange"":""my-ae""}"' --apply-to exchanges
+```
+</TabItem>
+<TabItem value="cmd" label="cmd">
+```batch
 rabbitmqctl.bat set_policy AE "^my-direct$" "{""alternate-exchange"":""my-ae""}" --apply-to exchanges
 ```
+</TabItem>
+</Tabs>
 
 This will apply an AE of "my-ae" to the exchange called
 "my-direct". Policies can also be defined using the management

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,7 @@
 ---
 title: Command Line Tools
 ---
+
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
@@ -17,6 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Command Line Tools
 
@@ -89,13 +93,22 @@ any missing arguments when executed.
 
 To find out what commands are available, use the `help` command:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl help
-```
 
-```bash
 rabbitmq-diagnostics help
 ```
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+rabbitmqctl.bat help
+
+rabbitmq-diagnostics.bat help
+```
+</TabItem>
+</Tabs>
 
 The command can display usage information for a particular command:
 
@@ -550,21 +563,22 @@ and so on.
 To retrieve node status, use `rabbitmq-diagnostics status` or `rabbitmq-diagnostics.bat status`
 with an optional `--node` target:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmq-diagnostics  status
-```
 
-```bash
 rabbitmq-diagnostics  status --node rabbit@target-hostname.local
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 rabbitmq-diagnostics .bat status
-```
 
-```powershell
 rabbitmq-diagnostics .bat status --node rabbit@target-hostname.local
 ```
+</TabItem>
+</Tabs>
 
 ### Starting a node
 
@@ -583,21 +597,20 @@ the node, which depends on the package typed used when RabbitMQ was installed.
 To stop a node using RabbitMQ CLI tools, use
 `rabbitmqctl shutdown` or `rabbitmqctl.bat shutdown` with an optional `--node` target:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 rabbitmqctl shutdown
-```
-
-```bash
 rabbitmqctl shutdown --node rabbit@target-hostname.local
 ```
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 rabbitmqctl.bat shutdown
-```
-
-```powershell
 rabbitmqctl.bat shutdown --node rabbit@target-hostname.local
 ```
+</TabItem>
+</Tabs>
 
 ## rabbitmqadmin {#http-api-cli}
 

--- a/docs/clustering-ssl.md
+++ b/docs/clustering-ssl.md
@@ -290,7 +290,7 @@ user that installed RabbitMQ.
 Here is a complete `rabbitmq-env-conf.bat` file using the `-ssl_dist_opfile` setting ([strategy two](#linux-strategy-two) covered above).
 Note the use of forward-slash directory delimiters.
 
-```powershell
+```PowerShell
 @echo off
 rem NOTE: If spaces are present in any of these paths,
 rem double quotes must be used.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1552,7 +1552,7 @@ rabbitmqctl encode '"amqp://fred:secret@host1.domain/my_vhost"' mypassphrase
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 # <<"guest">> here is a value to encode, as an Erlang binary,
 # as it would have appeared in advanced.config
 rabbitmqctl encode "<<""guest"">>" mypassphrase
@@ -1576,7 +1576,7 @@ rabbitmqctl decode '{encrypted, <<"...">>}' mypassphrase
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl decode "{encrypted, <<""..."">>}" mypassphrase
 # => <<"guest">>
 rabbitmqctl decode "{encrypted, <<""..."">>}" mypassphrase
@@ -1619,7 +1619,7 @@ rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 \
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 \
                      "<<""guest"">>" mypassphrase
 ```
@@ -1696,7 +1696,7 @@ with administrator permissions:
  * Run `rabbitmq-service.bat stop` to stop the service
  * Run `rabbitmq-service.bat remove` to remove the Windows service (this will *not* remove RabbitMQ or its data directory)
  * Set environment variables via command line, i.e. run commands like the following:
-   ```powershell
+   ```PowerShell
    set RABBITMQ_BASE=C:\Data\RabbitMQ
    ```
  * Run `rabbitmq-service.bat install`

--- a/docs/dlx.md
+++ b/docs/dlx.md
@@ -61,7 +61,7 @@ rabbitmqctl set_policy DLX ".*" '{"dead-letter-exchange":"my-dlx"}' --apply-to q
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl set_policy DLX ".*" "{""dead-letter-exchange"":""my-dlx""}" --apply-to queues
 ```
     </td>

--- a/docs/federated-exchanges/index.md
+++ b/docs/federated-exchanges/index.md
@@ -1,6 +1,7 @@
 ---
 title: Federated Exchanges
 ---
+
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
@@ -17,6 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Federated Exchanges
 
@@ -112,42 +116,48 @@ To add an upstream, use the `rabbitmqctl set_parameter` command. It accepts thre
 
 The following example configures an upstream named "origin" which can be contacted at <code>remote-host.local:5672</code>:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # Adds a federation upstream named "origin"
 rabbitmqctl set_parameter federation-upstream origin '{"uri":"amqp://remote-host.local:5672"}'
 ```
-
-On Windows, use `rabbitmqctl.bat` and suitable PowerShell quoting:
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # Adds a federation upstream named "origin"
-rabbitmqctl.bat set_parameter federation-upstream origin "{""uri"":""amqp://remote-host.local:5672""}"
+rabbitmqctl.bat set_parameter federation-upstream origin '"{""uri"":""amqp://remote-host.local:5672""}"'
 ```
+</TabItem>
+</Tabs>
 
 More upstream definition parameters are covered in the [Federation Reference guide](./federation-reference).
 
 Once an upstream has been specified, a policy that controls federation can be added. It is added just like
 any other [policy](./parameters#policies), using:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # Adds a policy named "exchange-federation"
 rabbitmqctl set_policy exchange-federation \
-"^federated\." \
-'{"federation-upstream-set":"all"}' \
---priority 10 \
---apply-to exchanges
+    "^federated\." \
+    '{"federation-upstream-set":"all"}' \
+    --priority 10 \
+    --apply-to exchanges
 ```
-
-Here's a Windows version of the above example:
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # Adds a policy named "exchange-federation"
-rabbitmqctl.bat set_policy exchange-federation ^
-"^federated\." ^
-"{""federation-upstream-set"":""all""}" ^
---priority 10 ^
---apply-to exchanges
+rabbitmqctl.bat set_policy exchange-federation `
+    "^federated\." `
+    '"{""federation-upstream-set"":""all""}"' `
+    --priority 10 `
+    --apply-to exchanges
 ```
+</TabItem>
+</Tabs>
 
 In the example above, the policy will match exchanges whose name begins with a `federated.` prefix
 in the default virtual host. Those exchanges will set up federation links for all declared upstreams.

--- a/docs/federated-queues/index.md
+++ b/docs/federated-queues/index.md
@@ -1,6 +1,7 @@
 ---
 title: Federated Queues
 ---
+
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
@@ -17,6 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Federated Queues
 
@@ -123,36 +127,44 @@ To add an upstream, use the `rabbitmqctl set_parameter` command. It accepts thre
 
 The following example configures an upstream named "origin" which can be contacted at `remote-host.local:5672`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # Adds a federation upstream named "origin"
 rabbitmqctl set_parameter federation-upstream origin '{"uri":"amqp://remote-host.local:5672"}'
 ```
-
-On Windows, use <code>rabbitmqctl.bat</code> and suitable PowerShell quoting:
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # Adds a federation upstream named "origin"
-rabbitmqctl.bat set_parameter federation-upstream origin "{""uri"":""amqp://remote-host.local:5672""}"
+rabbitmqctl.bat set_parameter federation-upstream origin '"{""uri"":""amqp://remote-host.local:5672""}"'
 ```
+</TabItem>
+</Tabs>
 
 Once an upstream has been specified, a policy that controls federation can be added.
 It is added just like any other [policy](./parameters#policies), using `rabbitmqctl set_policy`:
 
+<Tabs>
+<TabItem value="bash" label="bash" default>
 ```bash
 # Adds a policy named "queue-federation"
-rabbitmqctl set_policy queue-federation "^federated\." '{"federation-upstream-set":"all"}' \
+rabbitmqctl set_policy queue-federation "^federated\." \
+    '{"federation-upstream-set":"all"}' \
     --priority 10 \
     --apply-to queues
 ```
-
-Here's a Windows version of the above example:
-
-```powershell
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
 # Adds a policy named "queue-federation"
-rabbitmqctl.bat set_policy queue-federation "^federated\." "{""federation-upstream-set"":""all""}" ^
-    --priority 10 ^
+rabbitmqctl.bat set_policy queue-federation '^federated\.' `
+    '"{""federation-upstream-set"":""all""}"' `
+    --priority 10 `
     --apply-to queues
 ```
+</TabItem>
+</Tabs>
 
 In the example above, the policy will match queues whose name begins with a `federated.` prefix
 in the default virtual host. Those queues will set up federation links for all declared upstreams.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -137,15 +137,17 @@ First let's define an upstream:
     <th>rabbitmqctl</th>
     <td>
 ```bash
-rabbitmqctl set_parameter federation-upstream my-upstream \<br/>'{"uri":"amqp://target.hostname","expires":3600000}'
+rabbitmqctl set_parameter federation-upstream my-upstream \
+    '{"uri":"amqp://target.hostname","expires":3600000}'
 ```
     </td>
   </tr>
   <tr>
     <th>rabbitmqctl.bat (Windows)</th>
     <td>
-```powershell
-rabbitmqctl.bat set_parameter federation-upstream my-upstream ^<br/>"{""uri"":""amqp://target.hostname"",""expires"":3600000}"
+```PowerShell
+rabbitmqctl.bat set_parameter federation-upstream my-upstream `
+    '"{""uri"":""amqp://target.hostname"",""expires"":3600000}"'
 ```
     </td>
   </tr>
@@ -176,15 +178,17 @@ Then define a policy that will match built-in exchanges and use this upstream:
     <th>rabbitmqctl</th>
     <td>
 ```bash
-rabbitmqctl set_policy --apply-to exchanges federate-me "^amq\." '{"federation-upstream-set":"all"}'
+rabbitmqctl set_policy --apply-to exchanges federate-me "^amq\." \
+    '{"federation-upstream-set":"all"}'
 ```
     </td>
   </tr>
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
-rabbitmqctl.bat set_policy --apply-to exchanges federate-me "^amq\." ^<br/>"{""federation-upstream-set"":""all""}"
+```PowerShell
+rabbitmqctl.bat set_policy --apply-to exchanges federate-me "^amq\." `
+    '"{""federation-upstream-set"":""all""}"'
 ```
     </td>
   </tr>
@@ -193,7 +197,7 @@ rabbitmqctl.bat set_policy --apply-to exchanges federate-me "^amq\." ^<br/>"{""f
     <td>
 ```ini
 PUT /api/policies/%2f/federate-me
-{"pattern":"^amq\.", "definition":{"federation-upstream-set":"all"}, \<br/> "apply-to":"exchanges"}
+{"pattern":"^amq\.", "definition":{"federation-upstream-set":"all"}, "apply-to":"exchanges"}
 ```
     </td>
   </tr>

--- a/docs/install-windows-manual.md
+++ b/docs/install-windows-manual.md
@@ -155,7 +155,7 @@ or edit [configuration](./configure#configuration-files).
 
 Run the command
 
-```powershell
+```PowerShell
 rabbitmq-server.bat -detached
 ```
 
@@ -197,7 +197,7 @@ or edit [configuration](./configure#configuration-files).
 
 Install the service by running
 
-```powershell
+```PowerShell
 rabbitmq-service.bat install
 ```
 
@@ -218,7 +218,7 @@ same functions as the service script.
 
 To start the broker, execute
 
-```powershell
+```PowerShell
 rabbitmq-service.bat start
 ```
 
@@ -256,7 +256,7 @@ which has to be placed into the correct location for the user.
 To stop the broker or check its status, use
 `rabbitmqctl.bat` in `sbin` (as an administrator).
 
-```powershell
+```PowerShell
 rabbitmqctl.bat stop
 ```
 
@@ -266,7 +266,7 @@ rabbitmqctl.bat stop
 The following command performs the most basic node health check and displays some information about
 the node if it is running:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat status
 ```
 

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -60,7 +60,7 @@ It does, however, manage the required dependencies.
 
 To install RabbitMQ using Chocolatey, run the following command from the command line or from PowerShell:
 
-```powershell
+```PowerShell
 choco install rabbitmq
 ```
 
@@ -115,7 +115,7 @@ can be managed from the Start menu.
 ## CLI Tools {#cli}
 
 RabbitMQ nodes are often managed, inspected and operated using [CLI Tools](./cli)
-in [PowerShell](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/powershell).
+in [PowerShell](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/PowerShell).
 
 On Windows, CLI tools have a `.bat` suffix compared to other platforms. For example,
 `rabbitmqctl` on Windows is invoked as `rabbitmqctl.bat`.
@@ -127,7 +127,7 @@ The main [CLI tools guide](./cli) covers most topics related to command line too
 
 In order to explore what commands various RabbitMQ CLI tools provide, use the `help` command:
 
-```powershell
+```PowerShell
 # lists commands provided by rabbitmqctl.bat
 rabbitmqctl.bat help
 
@@ -140,7 +140,7 @@ rabbitmq-plugins.bat help
 
 To learn about a specific command, pass its name as an argument to `help`:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat help add_user
 ```
 
@@ -195,7 +195,7 @@ Note that CLI tools will have to [authenticate to the target RabbitMQ node](#cli
 To stop the broker or check its status, use
 `rabbitmqctl.bat` in `sbin` (as an administrator).
 
-```powershell
+```PowerShell
 rabbitmqctl.bat stop
 ```
 
@@ -204,7 +204,7 @@ rabbitmqctl.bat stop
 The following [CLI command](#cli) runs a basic [health check](./monitoring#health-checks)
 and displays some information about the node if it is running.
 
-```powershell
+```PowerShell
 # A basic health check of both the node and CLI tool connectivity/authentication
 rabbitmqctl.bat status
 ```

--- a/docs/lazy-queues.md
+++ b/docs/lazy-queues.md
@@ -104,7 +104,7 @@ To specify a queue mode using a policy, add the key `queue-mode` to a policy def
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-      ```powershell
+      ```PowerShell
       rabbitmqctl set_policy Lazy "^lazy-queue$" "{""queue-mode"":""lazy""}" --apply-to queues
       ```
     </td>
@@ -134,7 +134,7 @@ to specify a different `queue-mode`:
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-      ```powershell
+      ```PowerShell
       rabbitmqctl set_policy Lazy "^lazy-queue$" "{""queue-mode"":""default""}" --apply-to queues
       ```
     </td>

--- a/docs/maxlength/index.md
+++ b/docs/maxlength/index.md
@@ -84,7 +84,7 @@ rabbitmqctl set_policy my-pol "^one-meg$" \
   <tr>
     <th>rabbitmqctl on Windows</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy my-pol "^one-meg$" ^
   "{""max-length-bytes"":1048576}" ^
   --apply-to queues
@@ -116,7 +116,7 @@ rabbitmqctl set_policy my-pol "^two-messages$" \
   <tr>
     <th>rabbitmqctl on Windows</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy my-pol "^two-messages$" ^
   "{""max-length"":2,""overflow"":""reject-publish""}" ^
   --apply-to queues

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -469,7 +469,7 @@ rabbitmqctl set_global_parameter mqtt_port_to_vhost_mapping \
 
 with `rabbitmqctl.bat` on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_global_parameter mqtt_port_to_vhost_mapping ^
     "{""1883"":""vhost1"", ""8883"":""vhost1"", ""1884"":""vhost2"", ""8884"":""vhost2""}"
 ```
@@ -557,7 +557,7 @@ rabbitmqctl set_global_parameter mqtt_default_vhosts \
 
 With `rabbitmqctl`, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl set_global_parameter mqtt_default_vhosts ^
     "{""O=client,CN=guest"": ""vhost1"", ""O=client,CN=rabbit"": ""vhost2""}'
 ```

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -228,7 +228,7 @@ rabbitmqctl set_policy federate-me \
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy federate-me ^
     "^federated\." "{""federation-upstream-set"":""all""}" ^
     --priority 1 ^
@@ -345,7 +345,7 @@ rabbitmqctl set_policy ttl-fed \
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl set_policy ttl-fed ^
     "^tf\." "{""federation-upstream-set"":""all"", ""message-ttl"":60000}" ^
     --priority 1 ^
@@ -356,7 +356,7 @@ rabbitmqctl set_policy ttl-fed ^
   <tr>
     <th>HTTP API</th>
     <td>
-```powershell
+```PowerShell
 PUT /api/policies/%2f/ttl-fed
     {"pattern": "^tf\.",
     "definition": {"federation-upstream-set":"all", "message-ttl":60000},
@@ -679,7 +679,7 @@ rabbitmqctl set_operator_policy transient-queue-ttl \
     <tr>
         <th>rabbitmqctl (Windows)</th>
         <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_operator_policy transient-queue-ttl ^
     "^amq\." "{""expires"": 1800000}" ^
     --priority 1 ^

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -143,7 +143,7 @@ PLUGINS_DIR="/usr/lib/rabbitmq/plugins:/usr/lib/rabbitmq/lib/rabbitmq_server-3.1
 
 On Windows, a semicolon is used as path separator:
 
-```powershell
+```PowerShell
 # Example rabbitmq-env-conf.bat file that features a colon-separated list of plugin directories
 PLUGINS_DIR="C:\Example\RabbitMQ\plugins;C:\Example\RabbitMQ\rabbitmq_server-3.11.6\plugins"
 ```

--- a/docs/shovel-dynamic.md
+++ b/docs/shovel-dynamic.md
@@ -72,7 +72,7 @@ rabbitmqctl set_parameter shovel my-shovel \
 On Windows `rabbitmqctl` is named `rabbitmqctl.bat` and command line value escaping will be
 different:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_parameter shovel my-shovel ^
   "{""src-protocol"": ""amqp091"", ""src-uri"":""amqp://localhost"", ""src-queue"": ""source-queue"", ^
    ""dest-protocol"": ""amqp091"", ""dest-uri"": ""amqp://remote.rabbitmq.local"", ^

--- a/docs/ssl/index.md
+++ b/docs/ssl/index.md
@@ -926,7 +926,7 @@ system-wide. Only administrative users can have write access to the system-wide 
 
 The following example adds a certificate to the store of user `Root` (also known as `Trust` in some .NET implementation)
 
-```powershell
+```PowerShell
 # Windows
 certmgr -add -all \path\to\cacert.cer -s Root
 ```
@@ -938,7 +938,7 @@ certmgr -add -c Trust /path/to/cacert.cer
 
 To add a certificate to the system-wide (machine) certificate store instead, run
 
-```powershell
+```PowerShell
 # Windows
 certmgr -add -all \path\to\cacert.cer -s -r localMachine Root
 ```

--- a/docs/stomp.md
+++ b/docs/stomp.md
@@ -516,7 +516,7 @@ rabbitmqctl set_policy stomp-queues "^stomp-" '{"max-length":1000}' --apply-to q
 
 with `rabbitmqctl.bat` on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy stomp-queues "^stomp-" "{""max-length"":1000}" --apply-to queues
 ```
 

--- a/docs/troubleshooting-ssl.md
+++ b/docs/troubleshooting-ssl.md
@@ -155,7 +155,7 @@ rabbitmqctl eval 'ssl:versions().'
 
 Or, on Windows
 
-```powershell
+```PowerShell
 rabbitmqctl.bat eval 'ssl:versions().'
 ```
 
@@ -179,7 +179,7 @@ rabbitmq-diagnostics cipher_suites --format openssl --silent
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmq-diagnostics.bat cipher_suites --format openssl --silent
 ```
 

--- a/docs/ttl.md
+++ b/docs/ttl.md
@@ -93,7 +93,7 @@ policy definition:
     <tr>
         <th>rabbitmqctl (Windows)</th>
         <td>
-            ```powershell
+            ```PowerShell
             rabbitmqctl set_policy TTL ".*" "{""message-ttl"":60000}" --apply-to queues
             ```
         </td>
@@ -275,7 +275,7 @@ The following policy makes all queues expire after 30 minutes since last use:
     <tr>
         <th>rabbitmqctl (Windows)</th>
         <td>
-            ```powershell
+            ```PowerShell
             rabbitmqctl.bat set_policy expiry ".*" "{""expires"":1800000}" --apply-to queues
             ```
         </td>

--- a/docs/windows-configuration.md
+++ b/docs/windows-configuration.md
@@ -47,7 +47,7 @@ To specify a non-standard port to be used for Erlang distribution, do the follow
  * Remove the RabbitMQ Windows service using `.\rabbitmq-service.bat remove`
  * Create the `%AppData%\RabbitMQ\rabbitmq-env-conf.bat` file with the following contents (use your own port number):
 
-```powershell
+```PowerShell
 set DIST_PORT=44556
 ```
 
@@ -70,7 +70,7 @@ the version you wish RabbitMQ to use. If you must upgrade Erlang, use this proce
  * Install the new version of Erlang
  * Open the "RabbitMQ Command Prompt (sbin dir)" start menu item and run the commands below to reinstall the Windows service
 
-```powershell
+```PowerShell
 .\rabbitmq-service.bat remove
 .\rabbitmq-service.bat install
 .\rabbitmq-service.bat start
@@ -115,7 +115,7 @@ One of these options can be used to mitigate:
 
  * Avoid using non-ASCII characters in RabbitMQ installation and [node directory](./relocate) paths
  * On recent versions of Windows, issue the command
-   ```powershell
+   ```PowerShell
    chcp 65001
    ```
    before using CLI tools to force
@@ -149,7 +149,7 @@ Two possible mitigations are:
 	a.  in PowerShell: `Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1`
 	b. open a new console window for changes to take effect
 
-For further information, including caveats, see [Colored text output in PowerShell console using ANSI / VT100 codes](https://stackoverflow.com/questions/51680709/colored-text-output-in-powershell-console-using-ansi-vt100-codes)
+For further information, including caveats, see [Colored text output in PowerShell console using ANSI / VT100 codes](https://stackoverflow.com/questions/51680709/colored-text-output-in-PowerShell-console-using-ansi-vt100-codes)
 
 
 ## Installing as a non-administrator User Leaves `.erlang.cookie` in the Wrong Place {#cookie-location}
@@ -196,7 +196,7 @@ First, log in using the administrative account you used, or will use, to
 install RabbitMQ and create the `%AppData%\RabbitMQ\rabbitmq-env-conf.bat` file
 with the following contents:
 
-```powershell
+```PowerShell
 @echo off
 set SERVER_ADDITIONAL_ERL_ARGS=-kernel net_ticktime 120
 ```
@@ -208,7 +208,7 @@ If you have not yet installed RabbitMQ, the setting will be picked up during ins
 If you have already installed RabbitMQ, open the "RabbitMQ Command Prompt (sbin dir)"
 start menu item and run these commands:
 
-```powershell
+```PowerShell
 .\rabbitmq-service.bat stop
 .\rabbitmq-service.bat remove
 .\rabbitmq-service.bat install

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -368,7 +368,7 @@ const config = {
           'java',
           'json',
           'php',
-          'powershell',
+          'PowerShell',
           'python',
           'shell-session',
           'yaml',

--- a/tutorials/tutorial-one-dotnet.md
+++ b/tutorials/tutorial-one-dotnet.md
@@ -64,14 +64,14 @@ on behalf of the consumer.
 >
 > RabbitMQ .NET client 5.0 and later versions are distributed via [nuget](https://www.nuget.org/packages/RabbitMQ.Client).
 >
-> This tutorial assumes you are using powershell on Windows. On MacOS and Linux nearly
+> This tutorial assumes you are using PowerShell on Windows. On MacOS and Linux nearly
 > any shell will work.
 
 ### Setup
 
 First let's verify that you have .NET Core toolchain in `PATH`:
 
-```powershell
+```PowerShell
 dotnet --help
 ```
 
@@ -79,7 +79,7 @@ should produce a help message.
 
 Now let's generate two projects, one for the publisher and one for the consumer:
 
-```powershell
+```PowerShell
 dotnet new console --name Send
 mv Send/Program.cs Send/Send.cs
 dotnet new console --name Receive
@@ -90,7 +90,7 @@ This will create two new directories named `Send` and `Receive`.
 
 Then we add the client dependency.
 
-```powershell
+```PowerShell
 cd Send
 dotnet add package RabbitMQ.Client
 cd ../Receive
@@ -269,14 +269,14 @@ Open two terminals.
 
 You can run the clients in any order, as both declares the queue. We will run the consumer first so you can see it waiting for and then receiving the message:
 
-```powershell
+```PowerShell
 cd Receive
 dotnet run
 ```
 
 Then run the producer:
 
-```powershell
+```PowerShell
 cd Send
 dotnet run
 ```

--- a/tutorials/tutorial-one-elixir.md
+++ b/tutorials/tutorial-one-elixir.md
@@ -208,7 +208,7 @@ created a queue above &#8210; using `AMQP.Queue.declare`.
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/tutorials/tutorial-one-java.md
+++ b/tutorials/tutorial-one-java.md
@@ -254,7 +254,7 @@ the publisher from another terminal.
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 
@@ -270,7 +270,7 @@ Time to move on to [part 2](./tutorial-two-java) and build a simple _work queue_
 > ```
 >
 > or on Windows:
-> ```powershell
+> ```PowerShell
 > set CP=.;amqp-client-5.16.0.jar;slf4j-api-1.7.36.jar;slf4j-simple-1.7.36.jar
 > java -cp %CP% Send
 > ```

--- a/tutorials/tutorial-one-javascript.md
+++ b/tutorials/tutorial-one-javascript.md
@@ -236,7 +236,7 @@ the publisher from another terminal.
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/tutorials/tutorial-one-php.md
+++ b/tutorials/tutorial-one-php.md
@@ -238,7 +238,7 @@ Ctrl-C to stop it), so try running the sender from another terminal.
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/tutorials/tutorial-one-python.md
+++ b/tutorials/tutorial-one-python.md
@@ -172,7 +172,7 @@ declaring the queue in both programs.
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/tutorials/tutorial-one-ruby.md
+++ b/tutorials/tutorial-one-ruby.md
@@ -223,7 +223,7 @@ the producer from another terminal.
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/tutorials/tutorial-one-spring-amqp.md
+++ b/tutorials/tutorial-one-spring-amqp.md
@@ -318,7 +318,7 @@ java -jar target/rabbitmq-tutorials.jar --spring.profiles.active=hello-world,sen
 > ```
 >
 > On Windows, omit the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/tutorials/tutorial-two-dotnet.md
+++ b/tutorials/tutorial-two-dotnet.md
@@ -69,7 +69,7 @@ program will schedule tasks to our work queue, so let's name it
 
 Like [tutorial one](./tutorial-one-dotnet) we need to generate two projects.
 
-```powershell
+```PowerShell
 dotnet new console --name NewTask
 mv NewTask/Program.cs NewTask/NewTask.cs
 dotnet new console --name Worker

--- a/tutorials/tutorial-two-javascript.md
+++ b/tutorials/tutorial-two-javascript.md
@@ -253,7 +253,7 @@ to learn more.
 > ```
 >
 > On Windows, drop the sudo:
-> ```powershell
+> ```PowerShell
 > rabbitmqctl.bat list_queues name messages_ready messages_unacknowledged
 > ```
 

--- a/versioned_docs/version-3.13/access-control.md
+++ b/versioned_docs/version-3.13/access-control.md
@@ -217,8 +217,8 @@ rabbitmqctl add_user 'username' '2a55f70a841f18b97c3a7db939b7adc9e34a0f1b'
 On Windows, `rabbitmqctl` becomes `rabbitmqctl.bat` and shell escaping is different based on your shell:
 
 <Tabs>
-<TabItem value="powershell" label="PowerShell" default>
-```powershell
+<TabItem value="PowerShell" label="PowerShell" default>
+```PowerShell
 # password is provided as a command line argument
 rabbitmqctl.bat add_user 'username' '9a55f70a841f18b97c3a7db939b7adc9e34a0f1d'
 ```
@@ -239,7 +239,7 @@ To list users in a cluster, use `rabbitmqctl list_users`:
 rabbitmqctl list_users
 ```
 
-```powershell
+```PowerShell
 rabbitmqctl.bat list_users
 ```
 
@@ -249,7 +249,7 @@ The output can be changed to be JSON:
 rabbitmqctl list_users --formatter=json
 ```
 
-```powershell
+```PowerShell
 rabbitmqctl.bat list_users --formatter=json
 ```
 
@@ -261,7 +261,7 @@ To delete a user, use `rabbitmqctl delete_user`:
 rabbitmqctl delete_user 'username'
 ```
 
-```powershell
+```PowerShell
 rabbitmqctl.bat delete_user 'username'
 ```
 
@@ -276,7 +276,7 @@ To grant [permissions](#authorisation) to a user in a [virtual host](./vhosts), 
 rabbitmqctl set_permissions -p "custom-vhost" "username" ".*" ".*" ".*"
 ```
 
-```powershell
+```PowerShell
 # First ".*" for configure permission on every entity
 # Second ".*" for write permission on every entity
 # Third ".*" for read permission on every entity
@@ -292,7 +292,7 @@ To revoke [permissions](#authorisation) from a user in a [virtual host](./vhosts
 rabbitmqctl clear_permissions -p "custom-vhost" "username"
 ```
 
-```powershell
+```PowerShell
 # Revokes permissions in a virtual host
 rabbitmqctl.bat clear_permissions -p 'custom-vhost' 'username'
 ```

--- a/versioned_docs/version-3.13/ae.md
+++ b/versioned_docs/version-3.13/ae.md
@@ -61,7 +61,7 @@ rabbitmqctl set_policy AE "^my-direct$" '{"alternate-exchange":"my-ae"}' --apply
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy AE "^my-direct$" "{""alternate-exchange"":""my-ae""}" --apply-to exchanges
 ```
 

--- a/versioned_docs/version-3.13/cli.md
+++ b/versioned_docs/version-3.13/cli.md
@@ -558,11 +558,11 @@ rabbitmq-diagnostics  status
 rabbitmq-diagnostics  status --node rabbit@target-hostname.local
 ```
 
-```powershell
+```PowerShell
 rabbitmq-diagnostics .bat status
 ```
 
-```powershell
+```PowerShell
 rabbitmq-diagnostics .bat status --node rabbit@target-hostname.local
 ```
 
@@ -591,11 +591,11 @@ rabbitmqctl shutdown
 rabbitmqctl shutdown --node rabbit@target-hostname.local
 ```
 
-```powershell
+```PowerShell
 rabbitmqctl.bat shutdown
 ```
 
-```powershell
+```PowerShell
 rabbitmqctl.bat shutdown --node rabbit@target-hostname.local
 ```
 

--- a/versioned_docs/version-3.13/clustering-ssl.md
+++ b/versioned_docs/version-3.13/clustering-ssl.md
@@ -290,7 +290,7 @@ user that installed RabbitMQ.
 Here is a complete `rabbitmq-env-conf.bat` file using the `-ssl_dist_opfile` setting ([strategy two](#linux-strategy-two) covered above).
 Note the use of forward-slash directory delimiters.
 
-```powershell
+```PowerShell
 @echo off
 rem NOTE: If spaces are present in any of these paths,
 rem double quotes must be used.

--- a/versioned_docs/version-3.13/configure.md
+++ b/versioned_docs/version-3.13/configure.md
@@ -1568,7 +1568,7 @@ rabbitmqctl encode '"amqp://fred:secret@host1.domain/my_vhost"' mypassphrase
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 # <<"guest">> here is a value to encode, as an Erlang binary,
 # as it would have appeared in advanced.config
 rabbitmqctl encode "<<""guest"">>" mypassphrase
@@ -1592,7 +1592,7 @@ rabbitmqctl decode '{encrypted, <<"...">>}' mypassphrase
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl decode "{encrypted, <<""..."">>}" mypassphrase
 # => <<"guest">>
 rabbitmqctl decode "{encrypted, <<""..."">>}" mypassphrase
@@ -1635,7 +1635,7 @@ rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 \
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 \
                      "<<""guest"">>" mypassphrase
 ```
@@ -1712,7 +1712,7 @@ with administrator permissions:
  * Run `rabbitmq-service.bat stop` to stop the service
  * Run `rabbitmq-service.bat remove` to remove the Windows service (this will *not* remove RabbitMQ or its data directory)
  * Set environment variables via command line, i.e. run commands like the following:
-   ```powershell
+   ```PowerShell
    set RABBITMQ_BASE=C:\Data\RabbitMQ
    ```
  * Run `rabbitmq-service.bat install`

--- a/versioned_docs/version-3.13/dlx.md
+++ b/versioned_docs/version-3.13/dlx.md
@@ -60,7 +60,7 @@ rabbitmqctl set_policy DLX ".*" '{"dead-letter-exchange":"my-dlx"}' --apply-to q
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl set_policy DLX ".*" "{""dead-letter-exchange"":""my-dlx""}" --apply-to queues
 ```
     </td>

--- a/versioned_docs/version-3.13/federated-exchanges/index.md
+++ b/versioned_docs/version-3.13/federated-exchanges/index.md
@@ -119,7 +119,7 @@ rabbitmqctl set_parameter federation-upstream origin '{"uri":"amqp://remote-host
 
 On Windows, use `rabbitmqctl.bat` and suitable PowerShell quoting:
 
-```powershell
+```PowerShell
 # Adds a federation upstream named "origin"
 rabbitmqctl.bat set_parameter federation-upstream origin "{""uri"":""amqp://remote-host.local:5672""}"
 ```
@@ -140,7 +140,7 @@ rabbitmqctl set_policy exchange-federation \
 
 Here's a Windows version of the above example:
 
-```powershell
+```PowerShell
 # Adds a policy named "exchange-federation"
 rabbitmqctl.bat set_policy exchange-federation ^
 "^federated\." ^

--- a/versioned_docs/version-3.13/federated-queues/index.md
+++ b/versioned_docs/version-3.13/federated-queues/index.md
@@ -130,7 +130,7 @@ rabbitmqctl set_parameter federation-upstream origin '{"uri":"amqp://remote-host
 
 On Windows, use <code>rabbitmqctl.bat</code> and suitable PowerShell quoting:
 
-```powershell
+```PowerShell
 # Adds a federation upstream named "origin"
 rabbitmqctl.bat set_parameter federation-upstream origin "{""uri"":""amqp://remote-host.local:5672""}"
 ```
@@ -147,7 +147,7 @@ rabbitmqctl set_policy queue-federation "^federated\." '{"federation-upstream-se
 
 Here's a Windows version of the above example:
 
-```powershell
+```PowerShell
 # Adds a policy named "queue-federation"
 rabbitmqctl.bat set_policy queue-federation "^federated\." "{""federation-upstream-set"":""all""}" ^
     --priority 10 ^

--- a/versioned_docs/version-3.13/federation.md
+++ b/versioned_docs/version-3.13/federation.md
@@ -144,7 +144,7 @@ rabbitmqctl set_parameter federation-upstream my-upstream \<br/>'{"uri":"amqp://
   <tr>
     <th>rabbitmqctl.bat (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_parameter federation-upstream my-upstream ^<br/>"{""uri"":""amqp://target.hostname"",""expires"":3600000}"
 ```
     </td>
@@ -183,7 +183,7 @@ rabbitmqctl set_policy --apply-to exchanges federate-me "^amq\." '{"federation-u
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy --apply-to exchanges federate-me "^amq\." ^<br/>"{""federation-upstream-set"":""all""}"
 ```
     </td>

--- a/versioned_docs/version-3.13/ha/index.md
+++ b/versioned_docs/version-3.13/ha/index.md
@@ -445,7 +445,7 @@ Consider mirroring to the majority (N/2+1) nodes with "ha-mode":"exactly" instea
 See [Replication Factor](#replication-factor) above.
 :::
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy ha-all "^ha\." "{""ha-mode"":""all""}"
 ```
     </td>
@@ -511,7 +511,7 @@ cluster:
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-      ```powershell
+      ```PowerShell
       rabbitmqctl set_policy ha-nodes "^nodes\." ^
 "{""ha-mode"":""nodes"",""ha-params"":[""rabbit@nodeA"", ""rabbit@nodeB""]}"
       ```

--- a/versioned_docs/version-3.13/install-windows-manual.md
+++ b/versioned_docs/version-3.13/install-windows-manual.md
@@ -155,7 +155,7 @@ or edit [configuration](./configure#configuration-files).
 
 Run the command
 
-```powershell
+```PowerShell
 rabbitmq-server.bat -detached
 ```
 
@@ -197,7 +197,7 @@ or edit [configuration](./configure#configuration-files).
 
 Install the service by running
 
-```powershell
+```PowerShell
 rabbitmq-service.bat install
 ```
 
@@ -218,7 +218,7 @@ same functions as the service script.
 
 To start the broker, execute
 
-```powershell
+```PowerShell
 rabbitmq-service.bat start
 ```
 
@@ -256,7 +256,7 @@ which has to be placed into the correct location for the user.
 To stop the broker or check its status, use
 `rabbitmqctl.bat` in `sbin` (as an administrator).
 
-```powershell
+```PowerShell
 rabbitmqctl.bat stop
 ```
 
@@ -266,7 +266,7 @@ rabbitmqctl.bat stop
 The following command performs the most basic node health check and displays some information about
 the node if it is running:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat status
 ```
 

--- a/versioned_docs/version-3.13/install-windows.md
+++ b/versioned_docs/version-3.13/install-windows.md
@@ -60,7 +60,7 @@ It does, however, manage the required dependencies.
 
 To install RabbitMQ using Chocolatey, run the following command from the command line or from PowerShell:
 
-```powershell
+```PowerShell
 choco install rabbitmq
 ```
 
@@ -115,7 +115,7 @@ can be managed from the Start menu.
 ## CLI Tools {#cli}
 
 RabbitMQ nodes are often managed, inspected and operated using [CLI Tools](./cli)
-in [PowerShell](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/powershell).
+in [PowerShell](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/PowerShell).
 
 On Windows, CLI tools have a `.bat` suffix compared to other platforms. For example,
 `rabbitmqctl` on Windows is invoked as `rabbitmqctl.bat`.
@@ -127,7 +127,7 @@ The main [CLI tools guide](./cli) covers most topics related to command line too
 
 In order to explore what commands various RabbitMQ CLI tools provide, use the `help` command:
 
-```powershell
+```PowerShell
 # lists commands provided by rabbitmqctl.bat
 rabbitmqctl.bat help
 
@@ -140,7 +140,7 @@ rabbitmq-plugins.bat help
 
 To learn about a specific command, pass its name as an argument to `help`:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat help add_user
 ```
 
@@ -195,7 +195,7 @@ Note that CLI tools will have to [authenticate to the target RabbitMQ node](#cli
 To stop the broker or check its status, use
 `rabbitmqctl.bat` in `sbin` (as an administrator).
 
-```powershell
+```PowerShell
 rabbitmqctl.bat stop
 ```
 
@@ -204,7 +204,7 @@ rabbitmqctl.bat stop
 The following [CLI command](#cli) runs a basic [health check](./monitoring#health-checks)
 and displays some information about the node if it is running.
 
-```powershell
+```PowerShell
 # A basic health check of both the node and CLI tool connectivity/authentication
 rabbitmqctl.bat status
 ```

--- a/versioned_docs/version-3.13/lazy-queues.md
+++ b/versioned_docs/version-3.13/lazy-queues.md
@@ -113,7 +113,7 @@ To specify a queue mode using a policy, add the key `queue-mode` to a policy def
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-      ```powershell
+      ```PowerShell
       rabbitmqctl set_policy Lazy "^lazy-queue$" "{""queue-mode"":""lazy""}" --apply-to queues
       ```
     </td>
@@ -143,7 +143,7 @@ to specify a different `queue-mode`:
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-      ```powershell
+      ```PowerShell
       rabbitmqctl set_policy Lazy "^lazy-queue$" "{""queue-mode"":""default""}" --apply-to queues
       ```
     </td>

--- a/versioned_docs/version-3.13/maxlength/index.md
+++ b/versioned_docs/version-3.13/maxlength/index.md
@@ -84,7 +84,7 @@ rabbitmqctl set_policy my-pol "^one-meg$" \
   <tr>
     <th>rabbitmqctl on Windows</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy my-pol "^one-meg$" ^
   "{""max-length-bytes"":1048576}" ^
   --apply-to queues
@@ -116,7 +116,7 @@ rabbitmqctl set_policy my-pol "^two-messages$" \
   <tr>
     <th>rabbitmqctl on Windows</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy my-pol "^two-messages$" ^
   "{""max-length"":2,""overflow"":""reject-publish""}" ^
   --apply-to queues

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -469,7 +469,7 @@ rabbitmqctl set_global_parameter mqtt_port_to_vhost_mapping \
 
 with `rabbitmqctl.bat` on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_global_parameter mqtt_port_to_vhost_mapping ^
     "{""1883"":""vhost1"", ""8883"":""vhost1"", ""1884"":""vhost2"", ""8884"":""vhost2""}"
 ```
@@ -557,7 +557,7 @@ rabbitmqctl set_global_parameter mqtt_default_vhosts \
 
 With `rabbitmqctl`, on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl set_global_parameter mqtt_default_vhosts ^
     "{""O=client,CN=guest"": ""vhost1"", ""O=client,CN=rabbit"": ""vhost2""}'
 ```

--- a/versioned_docs/version-3.13/parameters.md
+++ b/versioned_docs/version-3.13/parameters.md
@@ -228,7 +228,7 @@ rabbitmqctl set_policy federate-me \
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy federate-me ^
     "^federated\." "{""federation-upstream-set"":""all""}" ^
     --priority 1 ^
@@ -345,7 +345,7 @@ rabbitmqctl set_policy ttl-fed \
   <tr>
     <th>rabbitmqctl (Windows)</th>
     <td>
-```powershell
+```PowerShell
 rabbitmqctl set_policy ttl-fed ^
     "^tf\." "{""federation-upstream-set"":""all"", ""message-ttl"":60000}" ^
     --priority 1 ^
@@ -356,7 +356,7 @@ rabbitmqctl set_policy ttl-fed ^
   <tr>
     <th>HTTP API</th>
     <td>
-```powershell
+```PowerShell
 PUT /api/policies/%2f/ttl-fed
     {"pattern": "^tf\.",
     "definition": {"federation-upstream-set":"all", "message-ttl":60000},
@@ -679,7 +679,7 @@ rabbitmqctl set_operator_policy transient-queue-ttl \
     <tr>
         <th>rabbitmqctl (Windows)</th>
         <td>
-```powershell
+```PowerShell
 rabbitmqctl.bat set_operator_policy transient-queue-ttl ^
     "^amq\." "{""expires"": 1800000}" ^
     --priority 1 ^

--- a/versioned_docs/version-3.13/plugins.md
+++ b/versioned_docs/version-3.13/plugins.md
@@ -143,7 +143,7 @@ PLUGINS_DIR="/usr/lib/rabbitmq/plugins:/usr/lib/rabbitmq/lib/rabbitmq_server-3.1
 
 On Windows, a semicolon is used as path separator:
 
-```powershell
+```PowerShell
 # Example rabbitmq-env-conf.bat file that features a colon-separated list of plugin directories
 PLUGINS_DIR="C:\Example\RabbitMQ\plugins;C:\Example\RabbitMQ\rabbitmq_server-3.11.6\plugins"
 ```

--- a/versioned_docs/version-3.13/shovel-dynamic.md
+++ b/versioned_docs/version-3.13/shovel-dynamic.md
@@ -72,7 +72,7 @@ rabbitmqctl set_parameter shovel my-shovel \
 On Windows `rabbitmqctl` is named `rabbitmqctl.bat` and command line value escaping will be
 different:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_parameter shovel my-shovel ^
   "{""src-protocol"": ""amqp091"", ""src-uri"":""amqp://localhost"", ""src-queue"": ""source-queue"", ^
    ""dest-protocol"": ""amqp091"", ""dest-uri"": ""amqp://remote.rabbitmq.local"", ^

--- a/versioned_docs/version-3.13/ssl/index.md
+++ b/versioned_docs/version-3.13/ssl/index.md
@@ -926,7 +926,7 @@ system-wide. Only administrative users can have write access to the system-wide 
 
 The following example adds a certificate to the store of user `Root` (also known as `Trust` in some .NET implementation)
 
-```powershell
+```PowerShell
 # Windows
 certmgr -add -all \path\to\cacert.cer -s Root
 ```
@@ -938,7 +938,7 @@ certmgr -add -c Trust /path/to/cacert.cer
 
 To add a certificate to the system-wide (machine) certificate store instead, run
 
-```powershell
+```PowerShell
 # Windows
 certmgr -add -all \path\to\cacert.cer -s -r localMachine Root
 ```

--- a/versioned_docs/version-3.13/stomp.md
+++ b/versioned_docs/version-3.13/stomp.md
@@ -516,7 +516,7 @@ rabbitmqctl set_policy stomp-queues "^stomp-" '{"max-length":1000}' --apply-to q
 
 with `rabbitmqctl.bat` on Windows:
 
-```powershell
+```PowerShell
 rabbitmqctl.bat set_policy stomp-queues "^stomp-" "{""max-length"":1000}" --apply-to queues
 ```
 

--- a/versioned_docs/version-3.13/troubleshooting-ssl.md
+++ b/versioned_docs/version-3.13/troubleshooting-ssl.md
@@ -155,7 +155,7 @@ rabbitmqctl eval 'ssl:versions().'
 
 Or, on Windows
 
-```powershell
+```PowerShell
 rabbitmqctl.bat eval 'ssl:versions().'
 ```
 
@@ -179,7 +179,7 @@ rabbitmq-diagnostics cipher_suites --format openssl --silent
 
 Or, on Windows:
 
-```powershell
+```PowerShell
 rabbitmq-diagnostics.bat cipher_suites --format openssl --silent
 ```
 

--- a/versioned_docs/version-3.13/ttl.md
+++ b/versioned_docs/version-3.13/ttl.md
@@ -93,7 +93,7 @@ policy definition:
     <tr>
         <th>rabbitmqctl (Windows)</th>
         <td>
-            ```powershell
+            ```PowerShell
             rabbitmqctl set_policy TTL ".*" "{""message-ttl"":60000}" --apply-to queues
             ```
         </td>
@@ -275,7 +275,7 @@ The following policy makes all queues expire after 30 minutes since last use:
     <tr>
         <th>rabbitmqctl (Windows)</th>
         <td>
-            ```powershell
+            ```PowerShell
             rabbitmqctl.bat set_policy expiry ".*" "{""expires"":1800000}" --apply-to queues
             ```
         </td>

--- a/versioned_docs/version-3.13/windows-configuration.md
+++ b/versioned_docs/version-3.13/windows-configuration.md
@@ -47,7 +47,7 @@ To specify a non-standard port to be used for Erlang distribution, do the follow
  * Remove the RabbitMQ Windows service using `.\rabbitmq-service.bat remove`
  * Create the `%AppData%\RabbitMQ\rabbitmq-env-conf.bat` file with the following contents (use your own port number):
 
-```powershell
+```PowerShell
 set DIST_PORT=44556
 ```
 
@@ -70,7 +70,7 @@ the version you wish RabbitMQ to use. If you must upgrade Erlang, use this proce
  * Install the new version of Erlang
  * Open the "RabbitMQ Command Prompt (sbin dir)" start menu item and run the commands below to reinstall the Windows service
 
-```powershell
+```PowerShell
 .\rabbitmq-service.bat remove
 .\rabbitmq-service.bat install
 .\rabbitmq-service.bat start
@@ -115,7 +115,7 @@ One of these options can be used to mitigate:
 
  * Avoid using non-ASCII characters in RabbitMQ installation and [node directory](./relocate) paths
  * On recent versions of Windows, issue the command
-   ```powershell
+   ```PowerShell
    chcp 65001
    ```
    before using CLI tools to force
@@ -149,7 +149,7 @@ Two possible mitigations are:
 	a.  in PowerShell: `Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1`
 	b. open a new console window for changes to take effect
 
-For further information, including caveats, see [Colored text output in PowerShell console using ANSI / VT100 codes](https://stackoverflow.com/questions/51680709/colored-text-output-in-powershell-console-using-ansi-vt100-codes)
+For further information, including caveats, see [Colored text output in PowerShell console using ANSI / VT100 codes](https://stackoverflow.com/questions/51680709/colored-text-output-in-PowerShell-console-using-ansi-vt100-codes)
 
 
 ## Installing as a non-administrator User Leaves `.erlang.cookie` in the Wrong Place {#cookie-location}
@@ -196,7 +196,7 @@ First, log in using the administrative account you used, or will use, to
 install RabbitMQ and create the `%AppData%\RabbitMQ\rabbitmq-env-conf.bat` file
 with the following contents:
 
-```powershell
+```PowerShell
 @echo off
 set SERVER_ADDITIONAL_ERL_ARGS=-kernel net_ticktime 120
 ```
@@ -208,7 +208,7 @@ If you have not yet installed RabbitMQ, the setting will be picked up during ins
 If you have already installed RabbitMQ, open the "RabbitMQ Command Prompt (sbin dir)"
 start menu item and run these commands:
 
-```powershell
+```PowerShell
 .\rabbitmq-service.bat stop
 .\rabbitmq-service.bat remove
 .\rabbitmq-service.bat install


### PR DESCRIPTION
Fixes #1903
Related to rabbitmq/rabbitmq-server#11432

* Rename `powershell` to `PowerShell`
* Add Windows-specific `add_user` examples with special characters