### PR TITLE
Request from product management to remove End of Extended Commercial Support info from the Release Information topic

### DIFF
--- a/release-information/index.md
+++ b/release-information/index.md
@@ -64,7 +64,6 @@ can use community resources for questions but are not entitled to any support fr
 Extended Commercial Support is included in [VMware’s Commercial Open Source RabbitMQ Support](https://tanzu.vmware.com/rabbitmq/oss).
 RabbitMQ patches are produced for security and high severity issues that are reported by users with
 a commercial license. If you already have a license, go to [paid commercial support enquiries](/contact#paid-support).
-Refer to the previous table for end dates for this support.
 
 ## The Next Release
 

--- a/release-information/index.md
+++ b/release-information/index.md
@@ -27,7 +27,7 @@ import {
 Use this information to find out what RabbitMQ releases are currently covered
 by community or extended commercial support and what release is coming next.
 
-If you want to upgrade from one release to another, read the documentation and
+If you want to [upgrade](./docs/upgrade/) from one release to another, read the documentation and
 the release notes of the target release.
 
 ## RabbitMQ Releases {#currently-supported}

--- a/src/components/RabbitMQServerReleaseInfo/index.js
+++ b/src/components/RabbitMQServerReleaseInfo/index.js
@@ -281,12 +281,6 @@ export function RabbitMQServerReleaseInfoTable() {
             "release-eos-community"
           ].join(' ')}>End of Community Support</div>
 
-          <div className={[
-            "release-info-header",
-            "release-eos",
-            "release-eos-commercial"
-          ].join(' ')}>End of Extended Commercial Support</div>
-
           {rows}
         </div>
       </div>

--- a/src/components/RabbitMQServerReleaseInfo/index.js
+++ b/src/components/RabbitMQServerReleaseInfo/index.js
@@ -154,43 +154,40 @@ export function RabbitMQServerReleaseInfoTable() {
         releaseDate = "-";
       }
 
-      var endOfSupportDates = ["-", "-"];
+      var endOfSupportDate = "-";
       var hasOSSSupport = false;
       if (releaseBranch.end_of_support) {
         /* Release branch is supported. */
         if (previousReleaseBranch) {
           const prevReleases = previousReleaseBranch.releases;
           const initialPrevRelease = prevReleases[prevReleases.length - 1];
-          endOfSupportDates[0] = new Date(initialPrevRelease.release_date);
+          endOfSupportDate = new Date(initialPrevRelease.release_date);
         } else {
           hasOSSSupport = true;
-          endOfSupportDates[0] = <abbr title="Supported until the next major or minor release branch is published.">Next release</abbr>;
+          endOfSupportDate = <abbr title="Supported until the next major or minor release branch is published.">Next release</abbr>;
         }
-        endOfSupportDates[1] = new Date(releaseBranch.end_of_support);
       }
 
-      for (const i in endOfSupportDates) {
-        const date = endOfSupportDates[i];
+      const date = endOfSupportDate;
 
-        var className;
-        var content;
-        if (date instanceof Date) {
-          const supported = date > now;
-          className = supported ? "supported-release" : "unsupported-release";
-          content = date.toLocaleDateString("en-GB", dateOptions);
-        } else {
-          className = hasOSSSupport ?
-            "supported-release" : "unsupported-release";
-          content = date;
-        }
-        endOfSupportDates[i] = <div className={[
-          "release-eos",
-          i == 0 ? "release-eos-community" : "release-eos-commercial",
-          className,
-          latestReleaseBranchClassName,
-          isLatestReleaseForBranch ? "" : showClassName
-        ].join(' ')}>{content}</div>;
+      var className;
+      var content;
+      if (date instanceof Date) {
+        const supported = date > now;
+        className = supported ? "supported-release" : "unsupported-release";
+        content = date.toLocaleDateString("en-GB", dateOptions);
+      } else {
+        className = hasOSSSupport ?
+          "supported-release" : "unsupported-release";
+        content = date;
       }
+      endOfSupportDate = <div className={[
+        "release-eos",
+        "release-eos-community",
+        className,
+        latestReleaseBranchClassName,
+        isLatestReleaseForBranch ? "" : showClassName
+      ].join(' ')}>{content}</div>;
 
       if (isLatestReleaseForBranch) {
         var releaseBranchLink;
@@ -244,7 +241,7 @@ export function RabbitMQServerReleaseInfoTable() {
             isLatestReleaseForBranch ? "" : showClassName
           ].join(' ')}>{releaseDate}</div>
 
-          {endOfSupportDates}
+          {endOfSupportDate}
         </>
       );
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -229,7 +229,6 @@ html[data-theme='dark'] .release-information {
     [links] auto
     [reldate] 120px
     [eos-community] 120px
-    [eos-commercial] 120px
     [end];
   grid-template-rows: auto;
 
@@ -325,10 +324,6 @@ html[data-theme='dark'] .release-information {
 
 .release-info-grid .release-eos-community {
   grid-column: 6 / span 1;
-}
-
-.release-info-grid .release-eos-commercial {
-  grid-column: 7 / span 1;
 }
 
 .release-info-grid .release-toggle {


### PR DESCRIPTION
Request from product management to remove "End of Extended Commercial Support info from the Release Information topic. @HowardTwine, can you please provide more information here. 

@michael-k or @dumbbell can one of you please complete further updates to delete the dates (computation) and the display of the column, my commit is only deleting the header, many thanks. 