### PR TITLE
removing note about sales contact form as this form is now redundant

### DIFF
--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -45,10 +45,6 @@ There are two primary ways to obtain RabbitMQ support from the core development 
 
 ### Enquiries
 
-:::important
-On the sales contact form, when asked "What is your solution of interest?", please choose "Cloud Native Application Development and Delivery"
-:::
-
 For enquiries about VMware’s Commercial Open Source RabbitMQ support, go to
 [this page](https://tanzu.vmware.com/rabbitmq/oss) for more information and a
 contact form. For information about VMware Tanzu RabbitMQ, the Enterprise


### PR DESCRIPTION
Removing the note about the sales contact form as this form is now redundant, it is now a link, FYI @HowardTwine 