### PR TITLE
MQTT plugin authenticate using client_id from client certificate

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -596,11 +596,11 @@ global parameter and so takes precedence over it.
 
 #### Use the client_id from client certificate to authenticate 
 
-You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. 
+You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. If the `client_id`(s) did not match, RabbitMQ closes the connection with the reason code `2`, meaning, `the client identifier is not allowed by the server`.
 
 First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
 - `distinguished_name`, this is the DN, or distinguished name, of the certificate
-- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
+- `subject_alternative_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
 If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
 - `dns`

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -594,7 +594,7 @@ to reconnect to switch to a new virtual host.
 is considered more specific than the port-to-vhost mapping with the `mqtt_port_to_vhost_mapping`
 global parameter and so takes precedence over it.
 
-#### Use client_id from client certificate to authenticate 
+#### Use the client_id from client certificate to authenticate 
 
 By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -598,12 +598,12 @@ global parameter and so takes precedence over it.
 
 By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
 
-First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable values are:
+First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
 - `distinguished_name`, this is the DN, or distinguished name, of the certificate
 - `common_name`, this is the CN part of the distinguished name
 - `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable values are:
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
 - `dns`
 - `ip` 
 - `email` 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -596,23 +596,23 @@ global parameter and so takes precedence over it.
 
 #### Use client_id from client certificate to authenticate 
 
-By the default, the plugin passes the `client_id` it received from the MQTT connection to the configured authentication backends as a credential. However, it is possible to extract the `client_id` from the certificate in a very similar way as we extract the username. 
+By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
 
-First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The allowed values are:
-- `distinguished_name`, this is the full DN, or distinguished name, of the certificate
-- `common_name`, this is just the CN part of the distinguished name
-- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension which allows to specify further alternative names which can be of several types.
+First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable values are:
+- `distinguished_name`, this is the DN, or distinguished name, of the certificate
+- `common_name`, this is the CN part of the distinguished name
+- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you should configure `mqtt.ssl_cert_client_id_san_type` which contains the `client_id`, otherwise it defaults to `dns`, its type which can be:
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable values are:
 - `dns`
 - `ip` 
 - `email` 
 - `uri`
 - `other_name`
 
-And if there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+If there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
 
-Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` from the first SAN -subject alternative name- of type uri:
+Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
 
 ```ini
 ssl_cert_login_from = common_name

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -596,14 +596,13 @@ global parameter and so takes precedence over it.
 
 #### Use the client_id from client certificate to authenticate 
 
-By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
+You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. 
 
 First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
 - `distinguished_name`, this is the DN, or distinguished name, of the certificate
-- `common_name`, this is the CN part of the distinguished name
 - `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
 - `dns`
 - `ip` 
 - `email` 
@@ -612,10 +611,10 @@ If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subj
 
 If there can be more than alternative name of the configured type, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
 
-Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
+Here is an example where the username is extracted from the certificate's distinguished name and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
 
 ```ini
-ssl_cert_login_from = common_name
+ssl_cert_login_from = distinguished_name
 mqtt.ssl_cert_client_id_from = subject_alternative_name
 mqtt.ssl_cert_client_id_san_type = uri
 ```

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -610,7 +610,7 @@ If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subj
 - `uri`
 - `other_name`
 
-If there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+If there can be more than alternative name of the configured type, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
 
 Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -266,6 +266,7 @@ rabbitmq_global_messages_dead_lettered_maxlen_total{queue_type="rabbit_mqtt_qos0
 The [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
 
 ## Users and Authentication {#authentication}
+
 MQTT clients will be able to connect provided that they have a set of credentials for an existing user with the appropriate permissions.
 
 For an MQTT connection to succeed, it must successfully authenticate and the user must
@@ -594,24 +595,35 @@ to reconnect to switch to a new virtual host.
 is considered more specific than the port-to-vhost mapping with the `mqtt_port_to_vhost_mapping`
 global parameter and so takes precedence over it.
 
-#### Use the client_id from client certificate to authenticate 
+#### Usage of client_id Extraction from Client Certificates for Authentication
 
-You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. If the `client_id`(s) did not match, RabbitMQ closes the connection with the reason code `2`, meaning, `the client identifier is not allowed by the server`.
+Nodes can be configured to verify that the `client_id` set on the MQTT connection matches the `client_id` found in the client's certificate.
 
-First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
-- `distinguished_name`, this is the DN, or distinguished name, of the certificate
-- `subject_alternative_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
+If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s).
+Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions.
+If the `client_id`(s) did not match, RabbitMQ closes the connection with the reason code `2`, meaning, "the client identifier is not allowed by the server".
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
-- `dns`
-- `ip` 
-- `email` 
-- `uri`
-- `other_name`
+In order to do so, RabbitMQ must first be instructed how to fetch the `client_id` from the certificate. This is done with the `mqtt.ssl_cert_client_id_from` configuration key.
+The acceptable values are:
 
-If there can be more than alternative name of the configured type, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+ * `distinguished_name`: this is the DN, or [distinguished name](https://en.wikipedia.org/wiki/X.509), of the certificate
+ * `subject_alternative_name`: the Subject Alternative Name or SAN, which comes from a certificate's extensions section
+    Because different ypes of Subject Alternative Names exist, the type may need to be specified as well
 
-Here is an example where the username is extracted from the certificate's distinguished name and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
+If `mqtt.ssl_cert_client_id_from` is set to `subject_alternative_name`, the type of alternative name can be configured using `mqtt.ssl_cert_client_id_san_type`. The default type, used if the setting
+is omitted, is `dns`. The acceptable values are:
+
+ * `dns`
+ * `ip`
+ * `email`
+ * `uri`
+ * `other_name`
+
+A certificate can contain multiple SAN fields of the same type, for example, two alternative DNS names. If this is the case, use the `mqtt.ssl_cert_client_id_san_index` configuration key
+to specify the index to be used. By default, RabbitMQ will pick the first value, that is, the default value of `mqtt.ssl_cert_client_id_san_index` is `0`.
+
+Below an example where the username is extracted from the certificate's distinguished name and the `client_id` is extracted from
+the first SAN (Subject Alternative Name) of type `uri`:
 
 ```ini
 ssl_cert_login_from = distinguished_name
@@ -626,7 +638,8 @@ This option is interpreted in the same way as [consumer prefetch](./consumer-pre
 
 An MQTT 5.0 client can define a lower number by setting [Receive Maximum](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901049) in the `CONNECT` packet.
 
-### Custom Exchanges {#custom-exchanges}
+
+## Custom Exchanges {#custom-exchanges}
 
 The `exchange` option determines which exchange messages from MQTT clients are published to.
 The exchange must be created before clients publish any messages. The exchange is expected to be a [topic exchange](/tutorials/amqp-concepts#exchange-topic).

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -594,6 +594,31 @@ to reconnect to switch to a new virtual host.
 is considered more specific than the port-to-vhost mapping with the `mqtt_port_to_vhost_mapping`
 global parameter and so takes precedence over it.
 
+#### Use client_id from client certificate to authenticate 
+
+By the default, the plugin passes the `client_id` it received from the MQTT connection to the configured authentication backends as a credential. However, it is possible to extract the `client_id` from the certificate in a very similar way as we extract the username. 
+
+First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The allowed values are:
+- `distinguished_name`, this is the full DN, or distinguished name, of the certificate
+- `common_name`, this is just the CN part of the distinguished name
+- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension which allows to specify further alternative names which can be of several types.
+
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you should configure `mqtt.ssl_cert_client_id_san_type` which contains the `client_id`, otherwise it defaults to `dns`, its type which can be:
+- `dns`
+- `ip` 
+- `email` 
+- `uri`
+- `other_name`
+
+And if there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+
+Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` from the first SAN -subject alternative name- of type uri:
+
+```ini
+ssl_cert_login_from = common_name
+mqtt.ssl_cert_client_id_from = subject_alternative_name
+mqtt.ssl_cert_client_id_san_type = uri
+```
 
 ### [Flow Control](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901251) {#flow}
 

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -596,11 +596,11 @@ global parameter and so takes precedence over it.
 
 #### Use the client_id from client certificate to authenticate 
 
-You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. 
+You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. If the `client_id`(s) did not match, RabbitMQ closes the connection with the reason code `2`, meaning, `the client identifier is not allowed by the server`.
 
 First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
 - `distinguished_name`, this is the DN, or distinguished name, of the certificate
-- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
+- `subject_alternative_name` here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
 If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
 - `dns`

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -594,16 +594,16 @@ to reconnect to switch to a new virtual host.
 is considered more specific than the port-to-vhost mapping with the `mqtt_port_to_vhost_mapping`
 global parameter and so takes precedence over it.
 
-#### Use client_id from client certificate to authenticate 
+#### Use the client_id from client certificate to authenticate 
 
 By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
 
-First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable values are:
+First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
 - `distinguished_name`, this is the DN, or distinguished name, of the certificate
 - `common_name`, this is the CN part of the distinguished name
 - `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable values are:
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
 - `dns`
 - `ip` 
 - `email` 

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -596,23 +596,23 @@ global parameter and so takes precedence over it.
 
 #### Use client_id from client certificate to authenticate 
 
-By the default, the plugin passes the `client_id` it received from the MQTT connection to the configured authentication backends as a credential. However, it is possible to extract the `client_id` from the certificate in a very similar way as we extract the username. 
+By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
 
-First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The allowed values are:
-- `distinguished_name`, this is the full DN, or distinguished name, of the certificate
-- `common_name`, this is just the CN part of the distinguished name
-- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension which allows to specify further alternative names which can be of several types.
+First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable values are:
+- `distinguished_name`, this is the DN, or distinguished name, of the certificate
+- `common_name`, this is the CN part of the distinguished name
+- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you should configure `mqtt.ssl_cert_client_id_san_type` which contains the `client_id`, otherwise it defaults to `dns`, its type which can be:
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable values are:
 - `dns`
 - `ip` 
 - `email` 
 - `uri`
 - `other_name`
 
-And if there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+If there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
 
-Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` from the first SAN -subject alternative name- of type uri:
+Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
 
 ```ini
 ssl_cert_login_from = common_name

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -596,14 +596,13 @@ global parameter and so takes precedence over it.
 
 #### Use the client_id from client certificate to authenticate 
 
-By the default, the plugin passes the `client_id` as credential to the configured authentication backends. However, it is possible to extract the `client_id` from the certificate. 
+You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. 
 
 First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
 - `distinguished_name`, this is the DN, or distinguished name, of the certificate
-- `common_name`, this is the CN part of the distinguished name
 - `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
 
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
 - `dns`
 - `ip` 
 - `email` 
@@ -612,10 +611,10 @@ If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subj
 
 If there can be more than alternative name of the configured type, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
 
-Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
+Here is an example where the username is extracted from the certificate's distinguished name and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
 
 ```ini
-ssl_cert_login_from = common_name
+ssl_cert_login_from = distinguished_name
 mqtt.ssl_cert_client_id_from = subject_alternative_name
 mqtt.ssl_cert_client_id_san_type = uri
 ```

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -594,30 +594,6 @@ to reconnect to switch to a new virtual host.
 is considered more specific than the port-to-vhost mapping with the `mqtt_port_to_vhost_mapping`
 global parameter and so takes precedence over it.
 
-#### Use the client_id from client certificate to authenticate 
-
-You can configure RabbitMQ to ensure the `client_id` received over the MQTT connection matches the `client_id` found in the client's certificate. If they match, RabbitMQ proceeds with the user's authentication by passing the user's identity along with the `client_id` to the configured authentication backend(s). Some authentication backends, like the `rabbitmq_auth_backend_http`, may use `client_id` credential in addition to `username` to make authentication and/or authorization decisions. If the `client_id`(s) did not match, RabbitMQ closes the connection with the reason code `2`, meaning, `the client identifier is not allowed by the server`.
-
-First, you must configure where RabbitMQ extracts the `client_id` from the certificate by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The acceptable options are:
-- `distinguished_name`, this is the DN, or distinguished name, of the certificate
-- `subject_alternative_name` here the `client_id` is specified in certificate's extension. You can specify further alternative names which can be of several types.
-
-If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name`, you can configure the type of alternative name via the `mqtt.ssl_cert_client_id_san_type` configuration variable. If you do not set it, its default value is `dns`. The acceptable options are:
-- `dns`
-- `ip` 
-- `email` 
-- `uri`
-- `other_name`
-
-If there can be more than alternative name of the configured type, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
-
-Here is an example where the username is extracted from the certificate's distinguished name and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
-
-```ini
-ssl_cert_login_from = distinguished_name
-mqtt.ssl_cert_client_id_from = subject_alternative_name
-mqtt.ssl_cert_client_id_san_type = uri
-```
 
 ### [Flow Control](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901251) {#flow}
 

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -610,7 +610,7 @@ If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subj
 - `uri`
 - `other_name`
 
-If there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+If there can be more than alternative name of the configured type, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
 
 Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` is extracted from the first SAN -subject alternative name- of type uri:
 

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -594,6 +594,31 @@ to reconnect to switch to a new virtual host.
 is considered more specific than the port-to-vhost mapping with the `mqtt_port_to_vhost_mapping`
 global parameter and so takes precedence over it.
 
+#### Use client_id from client certificate to authenticate 
+
+By the default, the plugin passes the `client_id` it received from the MQTT connection to the configured authentication backends as a credential. However, it is possible to extract the `client_id` from the certificate in a very similar way as we extract the username. 
+
+First, you must configure which certificate's attribute has the `client_id` by setting the configuration variable `mqtt.ssl_cert_client_id_from`. The allowed values are:
+- `distinguished_name`, this is the full DN, or distinguished name, of the certificate
+- `common_name`, this is just the CN part of the distinguished name
+- `subject_alternative_name` or `subject_alt_name`, here the `client_id` is specified in certificate's extension which allows to specify further alternative names which can be of several types.
+
+If you set `mqtt.ssl_cert_client_id_from` to `subject_alternative_name` or `subject_alt_name`, you should configure `mqtt.ssl_cert_client_id_san_type` which contains the `client_id`, otherwise it defaults to `dns`, its type which can be:
+- `dns`
+- `ip` 
+- `email` 
+- `uri`
+- `other_name`
+
+And if there can be more than alternative name of the type specified, you can configure which one to choose via the `mqtt.ssl_cert_client_id_san_index` configuration variable. By default, it always pick the first name, i.e. `mqtt.ssl_cert_client_id_san_index = 0`.
+
+Here is an example where the username is extracted from the certificate's `common_name` and the `client_id` from the first SAN -subject alternative name- of type uri:
+
+```ini
+ssl_cert_login_from = common_name
+mqtt.ssl_cert_client_id_from = subject_alternative_name
+mqtt.ssl_cert_client_id_san_type = uri
+```
 
 ### [Flow Control](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901251) {#flow}
 


### PR DESCRIPTION
Implements feature request https://github.com/rabbitmq/rabbitmq-server/issues/9323
