### PR TITLE
docs/install-debian: add ERL_MAX_PORTS check

### DIFF
--- a/docs/install-debian.md
+++ b/docs/install-debian.md
@@ -615,6 +615,13 @@ cat /proc/$RABBITMQ_BEAM_PROCESS_PID/limits
 can be used to display effective limits of a running process. `$RABBITMQ_BEAM_PROCESS_PID`
 is the OS PID of the Erlang VM running RabbitMQ, as returned by `rabbitmq-diagnostics status`.
 
+`ERL_MAX_PORTS` defaults to 65536, if you set LimitNOFILE to higher than this,
+you will want to update `ERL_MAX_PORTS`. To see the maximum ports of the
+rabbitmq process, the following command can be ran.
+
+```bash
+rabbitmqctl eval 'erlang:system_info(port_limit).'
+```
 
 ## Managing the Service {#managing-service}
 


### PR DESCRIPTION
It would be nice to have docs on how to check on how many ports rabbitmq can open, if ERL_MAX_PORTS differs from LimitNOFILE. You can find this command from[0].

[0] - https://www.erlang.org/docs/26/man/erl#+Q