### PR TITLE
streaming tutorial_2 for python and rust

### DIFF
--- a/sidebarsTutorials.js
+++ b/sidebarsTutorials.js
@@ -477,12 +477,7 @@ const sidebars = {
                     type: 'doc',
                     id: 'tutorial-one-rust-stream',
                     label: 'Hello World',
-                },
-                {
-                    type: 'doc',
-                    id: 'tutorial-two-rust-stream',
-                    label: 'Offset Tracking',
-                },
+                }
 
             ]
         },

--- a/sidebarsTutorials.js
+++ b/sidebarsTutorials.js
@@ -477,7 +477,13 @@ const sidebars = {
                     type: 'doc',
                     id: 'tutorial-one-rust-stream',
                     label: 'Hello World',
-                }
+                },
+                {
+                    type: 'doc',
+                    id: 'tutorial-two-rust-stream',
+                    label: 'Offset Tracking',
+                },
+
             ]
         },
         {
@@ -488,7 +494,13 @@ const sidebars = {
                     type: 'doc',
                     id: 'tutorial-one-python-stream',
                     label: 'Hello World',
+                },
+                {
+                    type: 'doc',
+                    id: 'tutorial-two-python-stream',
+                    label: 'Offset Tracking',
                 }
+
             ]
         },
         {

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -245,7 +245,6 @@ This section covers [RabbitMQ streams](/docs/streams).
     * [C#](tutorials/tutorial-two-dotnet-stream)
     * [Go](tutorials/tutorial-two-go-stream)
     * [Python](tutorials/tutorial-two-python-stream)
-    * [Rust](tutorials/tutorial-two-rust-stream)
   </td>
 
 

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -244,6 +244,8 @@ This section covers [RabbitMQ streams](/docs/streams).
     * [Java](tutorials/tutorial-two-java-stream)
     * [C#](tutorials/tutorial-two-dotnet-stream)
     * [Go](tutorials/tutorial-two-go-stream)
+    * [Python](tutorials/tutorial-two-python-stream)
+    * [Rust](tutorials/tutorial-two-rust-stream)
   </td>
 
 

--- a/tutorials/tutorial-one-python-stream.md
+++ b/tutorials/tutorial-one-python-stream.md
@@ -74,13 +74,11 @@ Now let's create a folder project and install the dependencies:
 # using pip
 mkdir python-rstream
 cd python-rstream
-pip install typing_extensions
 pip install rstream
 
 # using Pipenv
 mkdir python-rstream
 cd python-rstream
-pipenv install typing_extensions
 pipenv install rstream
 pipenv shell
 ```

--- a/tutorials/tutorial-two-python-stream.md
+++ b/tutorials/tutorial-two-python-stream.md
@@ -1,0 +1,447 @@
+---
+title: RabbitMQ tutorial - Offset Tracking
+---
+
+<!--
+Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+import TutorialsHelp from '@site/src/components/Tutorials/TutorialsStreamHelp.md';
+import TutorialsIntro from '@site/src/components/Tutorials/TutorialsStreamIntro.md';
+
+# RabbitMQ Stream tutorial - Offset Tracking
+
+## Introduction
+
+<TutorialsHelp/>
+<TutorialsIntro/>
+
+## Offset Tracking
+
+### Setup
+
+This part of the tutorial consists in writing two programs in Python; a producer that sends a wave of messages with a marker message at the end, and a consumer that receives messages and stops when it gets the marker message.
+It shows how a consumer can navigate through a stream and can even restart where it left off in a previous execution.
+
+This tutorial uses the [rstream Python client](https://github.com/qweeze/rstream).
+Make sure to follow [the setup steps](/tutorials/tutorial-one-python-stream#setup) from the first tutorial.
+
+An executable version of this tutorial can be found in the [RabbitMQ tutorials repository](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/python-stream/).
+
+Please note that the executable version is already implementing the `Server-Side Offset Tracking` feature explained at the end of this tutorial, and this needs to be take in account when testing this scenario.
+
+The sending program is called `offset_tracking_send.py` and the receiving program is called `offset_tracking_receive.py`.
+The tutorial focuses on the usage of the client library, so the final code in the repository should be used to create the scaffolding of the files (e.g. imports, main functions, etc).
+
+### Sending
+
+The sending program creates a `Producer` instance and publishes 100 messages.
+
+The body value of the last message is set to `marker`; this is a marker for the consumer to stop consuming.
+
+The sending is managing messages confirmations so in case of the rstream client we need to define a callback `_on_publish_confirm_client` which is managing the confirmations.
+
+Note the use of a `asyncio.Condition`: The main routine is waiting for it until all the messages get confirmed by the `_on_publish_confirm_client` callback which then notify the main routine.
+This ensures the broker received all the messages before closing the program.
+
+```python
+STREAM = "stream-offset-tracking-python"
+MESSAGES = 100
+# 2GB
+STREAM_RETENTION = 2000000000
+confirmed_messages = 0
+all_confirmed_messages_cond = asyncio.Condition()
+
+async def _on_publish_confirm_client(confirmation: ConfirmationStatus) -> None:
+    global confirmed_messages
+    if confirmation.is_confirmed:
+        confirmed_messages = confirmed_messages + 1
+        if confirmed_messages == 100:
+            async with all_confirmed_messages_cond:
+                all_confirmed_messages_cond.notify()
+
+async def publish():
+    async with Producer("localhost", username="guest", password="guest") as producer:
+        # create a stream if it doesn't already exist
+        await producer.create_stream(
+            STREAM, exists_ok=True, arguments={"max-length-bytes": STREAM_RETENTION}
+        )
+
+        print("Publishing {} messages".format(MESSAGES))
+        # Send 99 hello message
+        for i in range(MESSAGES - 1):
+            amqp_message = AMQPMessage(
+                body=bytes("hello: {}".format(i), "utf-8"),
+            )
+
+            await producer.send(
+                stream=STREAM,
+                message=amqp_message,
+                on_publish_confirm=_on_publish_confirm_client,
+            )
+        # Send a final marker message
+        amqp_message = AMQPMessage(
+            body=bytes("marker: {}".format(i + 1), "utf-8"),
+        )
+
+        await producer.send(
+            stream=STREAM,
+            message=amqp_message,
+            on_publish_confirm=_on_publish_confirm_client,
+        )
+
+        async with all_confirmed_messages_cond:
+            await all_confirmed_messages_cond.wait()
+
+        print("Messages confirmed.")
+
+
+asyncio.run(publish())
+```
+
+Let's now create the receiving program.
+
+### Receiving
+
+The receiving program starts a consumer that attaches at the beginning of the stream `ConsumerOffsetSpecification(OffsetType.FIRST)`.
+It uses two variables: `first_offset` and `last_offset` to output the offsets of the first and last received messages at the end of the program.
+We need to define a callback `on_message` to manage the receving of the messages.
+The consumer stops when it receives the marker message: it assigns the offset to a `last_offset` variable and closes the consumer.
+
+```python
+message_count = -1
+first_offset = -1
+last_offset = -1
+STREAM_NAME = "stream-offset-tracking-python"
+# 2GB
+STREAM_RETENTION = 2000000000
+
+async def on_message(msg: AMQPMessage, message_context: MessageContext):
+    global first_offset
+    global last_offset
+
+    offset = message_context.offset
+    if first_offset == -1:
+        print("First message received")
+        first_offset = offset
+
+    consumer = message_context.consumer
+    stream = message_context.consumer.get_stream(message_context.subscriber_name)
+
+    if "marker" in str(msg):
+        last_offset = offset
+        await consumer.close()
+
+async def consume():
+
+    global first_offset
+    global last_offset
+
+    consumer = Consumer(
+        host="localhost",
+        port=5552,
+        username="guest",
+        password="guest",
+    )
+
+    await consumer.create_stream(
+        STREAM_NAME, exists_ok=True, arguments={"max-length-bytes": STREAM_RETENTION}
+    )
+
+    try:
+        await consumer.start()
+        print("Starting consuming Press control +C to close")
+
+        await consumer.subscribe(
+            stream=STREAM_NAME,
+            callback=on_message,
+            decoder=amqp_decoder,
+            offset_specification=ConsumerOffsetSpecification(
+                OffsetType.FIRST
+            ),
+        )
+        await consumer.run()
+
+    except (KeyboardInterrupt, asyncio.exceptions.CancelledError):
+        await consumer.close()
+
+    # give time to the consumer task to close the consumer
+    await asyncio.sleep(1)
+
+    if first_offset != -1:
+        print(
+            "Done consuming first_offset: {} last_offset {} ".format(
+                first_offset, last_offset
+            )
+        )
+
+
+with asyncio.Runner() as runner:
+    runner.run(consume())
+
+```
+
+### Exploring the Stream
+
+In order to run both examples, open two terminal (shell) tabs.
+
+In the first tab, run the sender to publish a wave of messages:
+
+```shell
+ python3 offset_tracking_send.py
+```
+
+The output is the following:
+
+```shell
+Publishing 100 messages...
+Messages confirmed: true.
+```
+
+Let's run now the receiver.
+Open a new tab.
+Remember it should start from the beginning of the stream because of the `FIRST` offset specification.
+
+```shell
+ python3 offset_tracking_receive.py
+```
+
+Here is the output:
+
+```shell
+Started consuming: Press control +C to close
+First message received.
+Done consuming, first offset 0, last offset 99.
+```
+
+:::note[What is an offset?]
+A stream can be seen as an array where elements are messages.
+The offset is the index of a given message in the array.
+:::
+
+A stream is different from a queue: consumers can read and re-read the same messages and the messages stay in the stream.
+
+Let's try this feature by using the `ConsumerOffsetSpecification(OffsetType.OFFSET, long)` specification to attach at a given offset different from 0.
+Inside the subscribe method of Consumer, set the `ConsumerOffsetSpecification` variable from 
+
+```python
+    offset_specification=ConsumerOffsetSpecification(
+        OffsetType.FIRST
+    ),
+```
+
+to:
+
+```python
+    offset_specification = ConsumerOffsetSpecification(
+        OffsetType.OFFSET, 42
+    )
+```
+
+Offset 42 is arbitrary, it could have been any number between 0 and 99.
+Run the receiver again:
+
+```shell
+ python3 offset_tracking_receive.py
+```
+
+The output is the following:
+
+```shell
+Started consuming: Press control +C to close
+First message received.
+Done consuming, first offset 42, last offset 99.
+```
+
+There is also a way to attach at the very end of stream to see only new messages at the time of the consumer creation.
+This is the `ConsumerOffsetSpecification(OffsetType.NEXT)` offset specification.
+Let's try it:
+
+```python
+    offset_specification = ConsumerOffsetSpecification(
+        OffsetType.NEXT)
+```
+
+Run the receiver:
+
+```shell
+ python3 offset_tracking_receive.py
+```
+
+This time the consumer does not get any messages:
+
+```shell
+Started consuming: Press control +C to close
+```
+
+It is waiting for new messages in the stream.
+Let's publish some by running the sender again.
+Back to the first tab:
+
+```shell
+ python3 offset_tracking_send.py
+```
+
+Wait for the program to exit and switch back to the receiver tab.
+The consumer received the new messages:
+
+```shell
+Started consuming: Press control +C to close
+First message received.
+Done consuming, first offset 100, last offset 199.
+```
+
+The receiver stopped because of the new marker message the sender put at the end of the stream.
+
+This section showed how to "browse" a stream: from the beginning, from any offset, even for new messages.
+The next section covers how to leverage server-side offset tracking to resume where a consumer left off in a previous execution.
+
+### Server-Side Offset Tracking
+
+RabbitMQ Streams provide server-side offset tracking to store the progress of a given consumer in a stream.
+If the consumer were to stop for any reason (crash, upgrade, etc), it would be able to re-attach where it stopped previously to avoid processing the same messages.
+
+RabbitMQ Streams provides an API for offset tracking, but it is possible to use other solutions to store the progress of consuming applications.
+It may depend on the use case, but a relational database can be a good solution as well.
+
+Let's modify the receiver to store the offset of processed messages.
+The updated lines are outlined with comments:
+
+```python
+async def on_message(msg: AMQPMessage, message_context: MessageContext):
+    global message_count
+    global first_offset
+    global last_offset
+
+    offset = message_context.offset
+    if first_offset == -1:
+        print("First message received")
+        first_offset = offset
+
+    consumer = message_context.consumer
+    stream = message_context.consumer.get_stream(message_context.subscriber_name)
+
+    # store the offset after every 10 messages received
+    message_count = message_count + 1
+
+    if message_count % 10 == 0:
+        # store_message needs to take a subscriber_name parameter
+        await consumer.store_offset(
+            stream=stream,
+            offset=offset,
+            subscriber_name=message_context.subscriber_name,
+        )
+
+    # store the offset after receiving the marker message
+    if "marker" in str(msg):
+        await consumer.store_offset(
+            stream=stream,
+            offset=offset,
+            subscriber_name=message_context.subscriber_name,
+        )
+        last_offset = offset
+        await consumer.close()
+
+async def consume():
+    stored_offset = -1
+    global first_offset
+    global last_offset
+
+    # start a consumer and creates the stream is not exist (same as before...)
+
+    try:
+        await consumer.start()
+        print("Started consuming: Press control +C to close")
+        try:
+            # query_offset must take a subscriber_name as parameter
+            stored_offset = await consumer.query_offset(
+                stream=STREAM_NAME, subscriber_name="subscriber_1"
+            )
+        except OffsetNotFound as offset_exception:
+            print(f"Offset not previously stored. {offset_exception}")
+
+        except ServerError as server_error:
+            print(f"Server error: {server_error}")
+            exit(1)
+
+        # if no offset was previously stored start from the first offset
+        stored_offset = stored_offset + 1
+        await consumer.subscribe(
+            stream=STREAM_NAME,
+             # We explicitely need to assign a name to the consumer
+            subscriber_name="subscriber_1",       
+            callback=on_message,
+            decoder=amqp_decoder,
+            offset_specification=ConsumerOffsetSpecification(
+                OffsetType.OFFSET, stored_offset
+            ),
+        )
+        await consumer.run()
+
+    except (KeyboardInterrupt, asyncio.exceptions.CancelledError):
+        await consumer.close()
+
+```
+
+
+Let's run the receiver:
+
+```shell
+ python3 offset_tracking_receive.py
+```
+
+Here is the output:
+
+```shell
+Started consuming: Press control +C to close
+First message received.
+Done consuming, first offset 0, last offset 99.
+```
+
+There is nothing surprising there: the consumer got the messages from the beginning of the stream and stopped when it reached the marker message. 
+
+Let's start it another time:
+
+```shell
+ python3 offset_tracking_receive.py
+```
+
+Here is the output:
+
+```shell
+Started consuming...
+First message received.
+Done consuming, first offset 100, last offset 199.
+```
+
+The most relevant implementations are:
+* The consumer must have a name.
+It is the key to store and retrieve the last stored offset value.
+* The offset is stored every 10 messages.
+This is an unusually low value for offset storage frequency, but this is OK for this tutorial.
+Values in the real world are rather in the hundreds or in the thousands.
+* The offset is stored before closing the consumer, just after getting the marker message.
+
+The consumer restarted exactly where it left off: the last offset in the first run was 99 and the first offset in this second run is 100.
+The consumer stored offset tracking information in the first run, so the client library uses it to resume consuming at the right position in the second run.
+
+This concludes this tutorial on consuming semantics in RabbitMQ Streams.
+It covered how a consumer can attach anywhere in a stream.
+Consuming applications are likely to keep track of the point they reached in a stream.
+They can use the built-in server-side offset tracking feature as demonstrated in this tutorial.
+They are also free to use any other data store solution for this task.
+
+See the [RabbitMQ blog](https://www.rabbitmq.com/blog/2021/09/13/rabbitmq-streams-offset-tracking) and the [stream Java client documentation](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking) for more information on offset tracking.

--- a/tutorials/tutorial-two-rust-stream.md
+++ b/tutorials/tutorial-two-rust-stream.md
@@ -41,7 +41,7 @@ Make sure to follow [the setup steps](/tutorials/tutorial-one-rust-stream#setup)
 
 An executable version of this tutorial can be found in the [RabbitMQ tutorials repository](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/rust-stream/).
 
-Please note that the executable version is already implementing the `Server-Side Offset Tracking` feature explained at the end of this tutorial, and this needs to be take in account when testing ths scenario.
+Please note that the executable version is already implementing the [Server-Side Offset Tracking`](#server-side-offset-tracking) feature explained at the end of this tutorial, and this needs to be take in account when testing ths scenario.
 
 The sending program is called `offset_tracking_send.rs` and the receiving program is called `receive_offset_tracking.rs`.
 The tutorial focuses on the usage of the client library, so the final code in the repository should be used to create the scaffolding of the files (e.g. imports, main functions, etc).
@@ -333,6 +333,7 @@ The line of code that implements it are explained below:
     let notify_on_close_cloned = notify_on_close.clone();
 
     task::spawn(async move {
+        let mut received_messages = -1;
         while let Some(delivery) = consumer.next().await {
             let d = delivery.unwrap();
 
@@ -346,7 +347,9 @@ The line of code that implements it are explained below:
                 );
             }
 
-            if received_messages.fetch_add(1, Ordering::Relaxed) % 10 == 0
+
+            received_messages +=1;
+            if received_messages % 10 == 0
                 || String::from_utf8_lossy(d.message().data().unwrap()).contains("marker")
             {
                 // We can store an offset every 10 messages or after the marker is found

--- a/tutorials/tutorial-two-rust-stream.md
+++ b/tutorials/tutorial-two-rust-stream.md
@@ -1,0 +1,427 @@
+---
+title: RabbitMQ tutorial - Offset Tracking
+---
+
+<!--
+Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+import TutorialsHelp from '@site/src/components/Tutorials/TutorialsStreamHelp.md';
+import TutorialsIntro from '@site/src/components/Tutorials/TutorialsStreamIntro.md';
+
+# RabbitMQ Stream tutorial - Offset Tracking
+
+## Introduction
+
+<TutorialsHelp/>
+<TutorialsIntro/>
+
+## Offset Tracking
+
+### Setup
+
+This part of the tutorial consists in writing two programs in Rust; a producer that sends a wave of messages with a marker message at the end, and a consumer that receives messages and stops when it gets the marker message.
+It shows how a consumer can navigate through a stream and can even restart where it left off in a previous execution.
+
+This tutorial uses [stream Rust client](https://github.com/rabbitmq/rabbitmq-stream-rust-client).
+Make sure to follow [the setup steps](/tutorials/tutorial-one-rust-stream#setup) from the first tutorial.
+
+An executable version of this tutorial can be found in the [RabbitMQ tutorials repository](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/rust-stream/).
+
+Please note that the executable version is already implementing the `Server-Side Offset Tracking` feature explained at the end of this tutorial, and this needs to be take in account when testing ths scenario.
+
+The sending program is called `offset_tracking_send.rs` and the receiving program is called `receive_offset_tracking.rs`.
+The tutorial focuses on the usage of the client library, so the final code in the repository should be used to create the scaffolding of the files (e.g. imports, main functions, etc).
+
+### Sending
+
+The sending program starts by instantiating the `Environment` and creating the stream:
+
+```rust
+    let create_response = environment
+        .stream_creator()
+        .max_length(ByteCapacity::GB(2))
+        .create(stream)
+        .await;
+
+    if let Err(e) = create_response {
+        if let StreamCreateError::Create { stream, status } = e {
+            match status {
+                // we can ignore this error because the stream already exists
+                ResponseCode::StreamAlreadyExists => {}
+                err => {
+                    println!("Error creating stream: {:?} {:?}", stream, err);
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+```
+
+The program then creates a `Producer` instance and publishes 100 messages.
+The body value of the last message is set to `marker`; this is a marker for the consumer to stop consuming.
+
+
+Note the use of a `tokio::sync::Notify`: The main routine is waiting for it until all the messages get confirmed by the confirmation callback.
+This ensures the broker received all the messages before closing the program.
+
+```rust
+    let producer = environment.producer().build(stream).await?;
+
+    for i in 0..message_count {
+        let msg;
+        if i < message_count - 1 {
+            msg = Message::builder().body(format!("hello{}", i)).build();
+        } else {
+            msg = Message::builder().body(format!("marker{}", i)).build();
+        };
+
+        let counter = confirmed_messages.clone();
+        let notifier = notify_on_send.clone();
+        producer
+            .send(msg, move |_| {
+                let inner_counter = counter.clone();
+                let inner_notifier = notifier.clone();
+                async move {
+                    if inner_counter.fetch_add(1, Ordering::Relaxed) == message_count - 1 {
+                        inner_notifier.notify_one();
+                    }
+                }
+            })
+            .await?;
+    }
+
+    notify_on_send.notified().await;
+    println!("Messages confirmed: True");
+    producer.close().await?;
+```
+
+Let's now create the receiving program.
+
+### Receiving
+
+The receiving program creates an `Environment` instance and makes sure the stream is created as well.
+This part of the code is the same as in the sending program, so it is skipped in the next code snippets for brevity's sake.
+The receiving program starts a consumer that attaches at the beginning of the stream `OffsetSpecification::First`.
+It uses two variables: `first_offset` and `last_offset` to output the offsets of the first and last received messages at the end of the program.
+The consumer stops when it receives the marker message: it assigns the offset to the `last_offset` variable and closes the consumer.
+
+```rust
+    let mut consumer = environment
+        .consumer()
+        .offset(OffsetSpecification::First)
+        .build(stream)
+        .await
+        .unwrap();
+
+    let first_cloned_offset = first_offset.clone();
+    let last_cloned_offset = last_offset.clone();
+    let notify_on_close_cloned = notify_on_close.clone();
+
+    task::spawn(async move {
+        while let Some(delivery) = consumer.next().await {
+            let d = delivery.unwrap();
+
+            if first_offset.load(Ordering::Relaxed) == -1 {
+                println!("consuming first message");
+                _ = first_offset.compare_exchange(
+                    first_offset.load(Ordering::Relaxed),
+                    d.offset() as i64,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                );
+            }
+
+            if  String::from_utf8_lossy(d.message().data().unwrap()).contains("marker")
+            {
+                last_offset.store(d.offset() as i64, Ordering::Relaxed);
+                let handle = consumer.handle();
+                _ = handle.close().await;
+                notify_on_close_cloned.notify_one();
+            }
+        }
+    });
+
+    notify_on_close.notified().await;
+
+    if first_cloned_offset.load(Ordering::Relaxed) != -1 {
+        println!(
+            "Done consuming first_offset: {:?} last_offset: {:?}  ",
+            first_cloned_offset, last_cloned_offset
+        );
+    }
+```
+
+### Exploring the Stream
+
+In order to run both examples, open two terminal (shell) tabs.
+
+In the first tab, run the sender to publish a wave of messages:
+
+```shell
+ cargo run --bin send_offset_tracking
+```
+
+The output is the following:
+
+```shell
+Publishing 100 messages
+Messages confirmed: True
+```
+
+Let's run now the receiver.
+Open a new tab.
+Remember it should start from the beginning of the stream because of the `OffsetSpecification::First` offset specification.
+
+```shell
+  cargo run --bin receive_offset_tracking
+```
+
+Here is the output:
+
+```shell
+Started consuming
+consuming first message
+Done consuming first_offset: 0 last_offset: 99
+```
+
+:::note[What is an offset?]
+A stream can be seen as an array where elements are messages.
+The offset is the index of a given message in the array.
+:::
+
+A stream is different from a queue: consumers can read and re-read the same messages and the messages stay in the stream.
+
+Let's try this feature by using the `OffsetSpecification::Offset` specification to attach at a given offset different from 0.
+When creating the environment for the Consumer, set the `OffsetSpecification` variable from 
+
+```rust
+    consumer = environment
+        .consumer()
+        .offset(OffsetSpecification::First)
+        .build(stream)
+        .await
+        .unwrap();
+```
+
+to:
+
+```rust
+    consumer = environment
+        .consumer()
+        .offset(OffsetSpecification::Offset(42))
+        .build(stream)
+        .await
+        .unwrap();
+```
+
+Offset 42 is arbitrary, it could have been any number between 0 and 99.
+Run the receiver again:
+
+```shell
+ cargo run --bin receive_offset_tracking
+```
+
+Here is the output:
+
+```shell
+Started consuming:
+First message received.
+Done consuming first_offset: 42 last_offset: 99
+```
+
+There is also a way to attach at the very end of stream to see only new messages at the time of the consumer creation.
+This is the `OffsetSpecification::Next` offset specification.
+Let's try it:
+
+```rust
+    consumer = environment
+        .consumer()
+        .offset(OffsetSpecification::Next)
+        .build(stream)
+        .await
+        .unwrap();
+```
+
+Run the receiver:
+
+```shell
+ cargo run --bin receive_offset_tracking
+```
+
+This time the consumer does not get any messages:
+
+```shell
+Started consuming
+```
+
+It is waiting for new messages in the stream.
+Let's publish some by running the sender again.
+Back to the first tab:
+
+```shell
+ cargo run --bin send_offset_tracking
+```
+
+Wait for the program to exit and switch back to the receiver tab.
+The consumer received the new messages:
+
+```shell
+Started consuming
+First message received.
+Done consuming first_offset: 100 last_offset: 199
+```
+
+The receiver stopped because of the new marker message the sender put at the end of the stream.
+
+This section showed how to "browse" a stream: from the beginning, from any offset, even for new messages.
+The next section covers how to leverage server-side offset tracking to resume where a consumer left off in a previous execution.
+
+### Server-Side Offset Tracking
+
+RabbitMQ Streams provide server-side offset tracking to store the progress of a given consumer in a stream.
+If the consumer were to stop for any reason (crash, upgrade, etc), it would be able to re-attach where it stopped previously to avoid processing the same messages.
+
+RabbitMQ Streams provides an API for offset tracking, but it is possible to use other solutions to store the progress of consuming applications.
+It may depend on the use case, but a relational database can be a good solution as well.
+
+Let's modify the receiver to store the offset of processed messages.
+The line of code that implements it are explained below:
+
+```rust
+    let mut consumer = environment
+        .consumer()
+        // The consumer needs a name to use Server-Side Offset Tracking
+        .name("consumer-1")
+        .offset(OffsetSpecification::First)
+        .build(stream)
+        .await
+        .unwrap();
+
+    println!("Started consuming");
+
+    // We can query if a stored offset exists
+    let mut stored_offset: u64 = consumer.query_offset().await.unwrap_or_else(|_| 0);
+
+    if stored_offset >  0 {
+        stored_offset += 1;
+    }
+    consumer = environment
+        .consumer()
+        // The consumer needs a name to use Server-Side Offset Tracking
+        .name("consumer-1")
+        .offset(OffsetSpecification::Offset(stored_offset))
+        .build(stream)
+        .await
+        .unwrap();
+
+    let first_cloned_offset = first_offset.clone();
+    let last_cloned_offset = last_offset.clone();
+    let notify_on_close_cloned = notify_on_close.clone();
+
+    task::spawn(async move {
+        while let Some(delivery) = consumer.next().await {
+            let d = delivery.unwrap();
+
+            if first_offset.load(Ordering::Relaxed) == -1 {
+                println!("First message received");
+                _ = first_offset.compare_exchange(
+                    first_offset.load(Ordering::Relaxed),
+                    d.offset() as i64,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                );
+            }
+
+            if received_messages.fetch_add(1, Ordering::Relaxed) % 10 == 0
+                || String::from_utf8_lossy(d.message().data().unwrap()).contains("marker")
+            {
+                // We can store an offset every 10 messages or after the marker is found
+                let _ = consumer
+                    .store_offset(d.offset())
+                    .await
+                    .unwrap_or_else(|e| println!("Err: {}", e));
+                if String::from_utf8_lossy(d.message().data().unwrap()).contains("marker") {
+                    last_offset.store(d.offset() as i64, Ordering::Relaxed);
+                    let handle = consumer.handle();
+                    _ = handle.close().await;
+                    notify_on_close_cloned.notify_one();
+
+                }
+            }
+        }
+    });
+
+    notify_on_close.notified().await;
+
+    if first_cloned_offset.load(Ordering::Relaxed) != -1 {
+        println!(
+            "Done consuming first_offset: {:?} last_offset: {:?}  ",
+            first_cloned_offset, last_cloned_offset
+        );
+    }
+```
+
+
+Let's run the receiver:
+
+```shell
+ cargo run --bin receive_offset_tracking
+```
+
+Here is the output:
+
+```shell
+Started consuming: Press control +C to close
+First message received.
+Done consuming, first offset 0, last offset 99.
+```
+
+There is nothing surprising there: the consumer got the messages from the beginning of the stream and stopped when it reached the marker message. 
+
+Let's start it another time:
+
+```shell
+cargo run --bin receive_offset_tracking
+```
+
+Here is the output:
+
+```shell
+Started consuming
+First message received.
+Done consuming first_offset: 100 last_offset: 199
+```
+
+The most relevant implementations are:
+* The consumer must have a name.
+It is the key to store and retrieve the last stored offset value.
+* The offset is stored every 10 messages.
+This is an unusually low value for offset storage frequency, but this is OK for this tutorial.
+Values in the real world are rather in the hundreds or in the thousands.
+* The offset is stored before closing the consumer, just after getting the marker message.
+
+The consumer restarted exactly where it left off: the last offset in the first run was 99 and the first offset in this second run is 100.
+Note the `OffsetSpecification::First` offset specification is ignored: a stored offset takes precedence over the offset specification parameter.
+The consumer stored offset tracking information in the first run, so the client library uses it to resume consuming at the right position in the second run.
+
+This concludes this tutorial on consuming semantics in RabbitMQ Streams.
+It covered how a consumer can attach anywhere in a stream.
+Consuming applications are likely to keep track of the point they reached in a stream.
+They can use the built-in server-side offset tracking feature as demonstrated in this tutorial.
+They are also free to use any other data store solution for this task.
+
+See the [RabbitMQ blog](https://www.rabbitmq.com/blog/2021/09/13/rabbitmq-streams-offset-tracking) and the [stream Java client documentation](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking) for more information on offset tracking.


### PR DESCRIPTION
Tutorial two for RabbitMQ streams for Python and Rust clients.

It fixes a small thing on the Python tutorial1 as we don't need to install the type_extension dependency.