### PR TITLE
Add row about server-named queues in QQ feature matrix

### DIFF
--- a/docs/quorum-queues/index.md
+++ b/docs/quorum-queues/index.md
@@ -124,6 +124,7 @@ Some features are not currently supported by quorum queues.
 | Adheres to [policies](./parameters#policies) | yes | yes (see [Policy support](#policy-support)) |
 | Poison message handling | no | yes |
 | Global [QoS Prefetch](#global-qos) | yes | no |
+| [Server-named queues](./queues#server-named-queues) | yes | no |
 
 Modern quorum queues also offer [higher throughput and less latency variability](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
 for many workloads.

--- a/versioned_docs/version-3.13/quorum-queues/index.md
+++ b/versioned_docs/version-3.13/quorum-queues/index.md
@@ -141,6 +141,7 @@ Some features are not currently supported by quorum queues.
 | Adheres to [policies](./parameters#policies) | yes | yes (see [Policy support](#policy-support)) |
 | Poison message handling | no | yes |
 | Global [QoS Prefetch](#global-qos) | yes | no |
+| [Server-named queues](./queues#server-named-queues) | yes | no |
 
 Modern quorum queues also offer [higher throughput and less latency variability](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
 for many workloads.


### PR DESCRIPTION
Add row about server-named queues in QQ feature matrix, since it's not implemented for quorum queues.