### PR TITLE
Fix indent issue in go tutorial.

### DIFF
--- a/tutorials/tutorial-four-go.md
+++ b/tutorials/tutorial-four-go.md
@@ -261,11 +261,11 @@ func main() {
         defer cancel()
 
         body := bodyFrom(os.Args)
-	    err = ch.PublishWithContext(ctx,
+        err = ch.PublishWithContext(ctx,
                 "logs_direct",         // exchange
                 severityFrom(os.Args), // routing key
-                false, // mandatory
-                false, // immediate
+                false,                 // mandatory
+                false,                 // immediate
                 amqp.Publishing{
                         ContentType: "text/plain",
                         Body:        []byte(body),


### PR DESCRIPTION
Fix an indent issue in go example code.

before:
![image](https://github.com/user-attachments/assets/46e5b858-2e04-41c2-bacb-9f1c8f4fe9cf)

after:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/733e5f6d-7e1c-49b3-bccb-b58a42144069">
