### PR TITLE
Client options can't be set globally in rabbitmq.conf

### DIFF
--- a/versioned_docs/version-3.13/uri-query-parameters.md
+++ b/versioned_docs/version-3.13/uri-query-parameters.md
@@ -135,7 +135,6 @@ against the hostname `myhost`.
 </table>
 
 [TLS options](./ssl) can also be specified globally using the
-`amqp_client.ssl_options` configuration key in the `rabbitmq.config` or
 `advanced.config` file in this manner:
 
 ```erlang


### PR DESCRIPTION
amqp_client.ssl_options are not available to be set in the rabbitmq.conf file - only available in the advance.conf file.