### PR TITLE
Document two 'new' features: channel_max_per_node and consumer_max_per_channel

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -248,6 +248,16 @@ Clients that attempt that will run into an error that looks like this in the log
 failed to negotiate connection parameters: negotiated channel_max = 2047 is higher than the maximum allowed value (32)
 ```
 
+### Maximum number of Channels per Node
+
+It is possible to configure the maximum number of channels that are allowed to be open on each node in a cluster using the
+configuration parameter `channel_max_per_node`:
+
+```ini
+# no more than 500 channels can be opened on each node at the same time
+channel_max_per_node = 500
+```
+
 
 ## Monitoring, Metrics and Diagnostics {#monitoring}
 

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -370,6 +370,15 @@ See [Java client guide](/client-libraries/java-api-guide#consuming) for examples
 
 See [.NET client guide](/client-libraries/dotnet-api-guide#consuming) for examples.
 
+## Limiting the number of Consumers per channel
+
+In some scenarios where consumer leaks can happen it is good to limit the number of consumers that can be active on 
+each channel. This can be configured in [rabbitmq.conf](./configure#config-file) using the setting `consumer_max_per_channel`:
+
+```ini
+consumer_max_per_channel = 100
+```
+
 ## Fetching Individual Messages ("Pull API") {#fetching}
 
 With AMQP 0-9-1 it is possible to fetch messages one by one using the `basic.get` protocol

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -372,7 +372,7 @@ See [.NET client guide](/client-libraries/dotnet-api-guide#consuming) for exampl
 
 ## Limiting the number of Consumers per channel
 
-In some scenarios where consumer leaks can happen it is good to limit the number of consumers that can be active on 
+In some scenarios where consumer leaks can happen it is good to limit the number of consumers that can be active on
 each channel. This can be configured in [rabbitmq.conf](./configure#config-file) using the setting `consumer_max_per_channel`:
 
 ```ini

--- a/versioned_docs/version-3.13/channels/index.md
+++ b/versioned_docs/version-3.13/channels/index.md
@@ -248,6 +248,15 @@ Clients that attempt that will run into an error that looks like this in the log
 failed to negotiate connection parameters: negotiated channel_max = 2047 is higher than the maximum allowed value (32)
 ```
 
+### Maximum number of Channels per Node
+
+It is possible to configure the maximum number of channels that are allowed to be open on each node in a cluster using the
+configuration parameter `channel_max_per_node`:
+
+```ini
+# no more than 500 channels can be opened on each node at the same time
+channel_max_per_node = 500
+```
 
 ## Monitoring, Metrics and Diagnostics {#monitoring}
 

--- a/versioned_docs/version-3.13/consumers.md
+++ b/versioned_docs/version-3.13/consumers.md
@@ -140,6 +140,15 @@ See [Java client guide](/client-libraries/java-api-guide#consuming) for examples
 
 See [.NET client guide](/client-libraries/dotnet-api-guide#consuming) for examples.
 
+## Limiting the number of Consumers per channel
+
+In some scenarios where consumer leaks can happen it is good to limit the number of consumers that can be active on
+each channel. This can be configured in [rabbitmq.conf](./configure#config-file) using the setting `consumer_max_per_channel`:
+
+```ini
+consumer_max_per_channel = 100
+```
+
 ### Message Properties and Delivery Metadata {#message-properties}
 
 Every delivery combines message metadata and delivery information. Different client


### PR DESCRIPTION
These were added to the server in https://github.com/rabbitmq/rabbitmq-server/commit/d7374cb244af961331f24e060e77f721edb2b6d1 but never documented. 