### PR TITLE
In 4.0, the default memory watermark increased to 0.6

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -760,7 +760,7 @@ ssl_handshake_timeout = 5000
       to the OS:
 
 ```ini
-vm_memory_high_watermark.relative = 0.6
+vm_memory_high_watermark.relative = 0.7
 ```
 ```ini
 vm_memory_high_watermark.absolute = 2GB
@@ -773,7 +773,7 @@ vm_memory_high_watermark.absolute = 2GB
         Default:
 
 ```ini
-vm_memory_high_watermark.relative = 0.4
+vm_memory_high_watermark.relative = 0.6
 ```
       </p>
     </td>

--- a/docs/memory-use/index.md
+++ b/docs/memory-use/index.md
@@ -639,7 +639,7 @@ If message payloads are large, they will not be reflected in the queue process m
 
 ### Why does the queue memory grow and shrink when publishing/consuming? {#queue-memory-usage-dynamics}
 
-Erlang uses [generational garbage collection](https://www.erlang-solutions.com/blog/erlang-19-0-garbage-collector.html) for each Erlang process.
+Erlang uses [generational garbage collection](https://www.erlang-solutions.com/blog/erlang-garbage-collector/) for each Erlang process.
 Garbage collection is done per queue, independently of all other Erlang processes.
 
 When garbage collection runs, it will copy used process memory before deallocating unused memory.
@@ -654,12 +654,12 @@ This can lead to the queue process using up to twice as much memory during garba
 If Erlang VM tries to allocate more memory than is available, the VM itself will either crash or be killed by the OOM killer.
 When the Erlang VM crashes, RabbitMQ will lose all non-persistent data.
 
-High memory watermark blocks publishers and prevents new messages from being enqueued.
-Since garbage collection can double the memory used by a queue, it is unsafe to set the high memory watermark above `0.5`.
-The default high memory watermark is set to `0.4` since this is safer as not all memory is used by queues.
-This is entirely workload specific, which differs across RabbitMQ deployments.
+Garbage collection can briefly double the memory used by a queue. However, given that:
+* the garbage collection process is performed on different queues at different times
+* and given that in modern RabbitMQ versions, all types of queues (classic, quorum, streams)
+  either don't store messages in memory at all or store only a limited amount of messages in memory
 
-We recommend many queues so that memory allocation / garbage collection is spread across many Erlang processes.
+a significant spike in overall RabbitMQ node memory usage caused by the garbage collection process is very unlikely.
 
 ## Total Memory Use Calculation Strategies {#strategies}
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -46,7 +46,7 @@ to detect the total amount of RAM available to it on startup and when
 <code>rabbitmqctl set_vm_memory_high_watermark <em>value</em></code> is
 executed.
 
-By default, including if the limit hint is not configured, a RabbitMQ node will use about 40%
+By default, including if the limit hint is not configured, a RabbitMQ node will use about 60%
 of the available RAM, it raises a memory [alarm](./alarms) and will block all
 connections that are publishing messages. Once the [memory alarm](./alarms) has cleared (e.g. due
 to delivering some messages to clients that consume and [acknowledge the deliveries](./confirms)) normal
@@ -57,13 +57,6 @@ The limit does not prevent RabbitMQ nodes
 from using more than the computed limit, it is merely the point at which
 publishers are throttled
 :::
-
-Note that this does not prevent the RabbitMQ server
-from using more than the computed limit, it is merely the point at which
-publishers are throttled. Erlang's garbage collector can, in
-the worst case, cause double the amount of memory to be used
-(by default, 80% of RAM). It is strongly recommended that OS
-swap or page files are enabled.
 
 ## Configuring the Memory Limit (or Threshold) {#configuring-threshold}
 
@@ -140,13 +133,13 @@ such as Kubernetes. Prefer the [absolute threshold](#absolute-limit) instead.
 The memory threshold at which the flow control is triggered
 can be adjusted by editing the [configuration file](./configure#configuration-files).
 
-The example below sets the threshold to the default value of 0.4:
+The example below sets the threshold to the default value of 0.6:
 ```ini
 # new style config format, recommended
-vm_memory_high_watermark.relative = 0.4
+vm_memory_high_watermark.relative = 0.6
 ```
 
-The default value of 0.4 stands for 40% of available (detected) RAM.
+The default value of 0.6 stands for 60% of available (detected) RAM.
 
 ### Updating Memory Threshold on a Running Node
 
@@ -166,7 +159,7 @@ rabbitmqctl set_vm_memory_high_watermark absolute <em><memory_limit></em>
 For example:
 
 ```bash
-rabbitmqctl set_vm_memory_high_watermark 0.6
+rabbitmqctl set_vm_memory_high_watermark 0.7
 ```
 
 and
@@ -239,16 +232,9 @@ it will append a warning to the [log file](./logging). It then assumes than
 2018-11-22 10:44:33.654 [warning] Unknown total memory size for your OS {unix,magic_homegrown_os}. Assuming memory size is 1024MB.
 ```
 
-In this case, the `vm_memory_high_watermark`
-configuration value is used to scale the assumed 1GB
-RAM. With the default value of
-`vm_memory_high_watermark` set to 0.4,
-RabbitMQ's memory threshold is set to 410MB, thus it will
-throttle producers whenever RabbitMQ is using more than
-410MB memory. Thus when RabbitMQ can't recognize your
-platform, if you actually have 8GB RAM installed and you
-want RabbitMQ to throttle producers when the server is using
-above 3GB, set `vm_memory_high_watermark` to 3.
+In this case, set `total_memory_available_override_value` to the amount of memory
+actually available on your system. The `vm_memory_high_watermark.relative`
+will then be calculated relative to the value set in `total_memory_available_override_value`.
 
 For guidelines on recommended RAM watermark settings,
 see [Deployment Guidelines](./production-checklist#resource-limits-ram).

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -225,8 +225,10 @@ as the high memory watermark. For example, on a node configured to have its memo
 <code>disk_free_limit.absolute = 4G</code> would be a recommended minimum.
 
 :::warning
-Running out of disk space is a very serious problem, commonly leading to outages
-and data loss. When in doubt, overprovision the disk space and/or use a high `disk_free_limit`.
+Nodes running out of disk space should be considered a very serious operational problem,
+commonly leading to outages and possibly data loss for the affected node.
+
+When in doubt, overprovision the disk space and/or use a high `disk_free_limit`.
 :::
 
 ### Open File Handles Limit {#resource-limits-file-handle-limit}
@@ -235,7 +237,7 @@ Operating systems limit maximum number of concurrently open file handles, which
 includes network sockets. Make sure that you have limits set high enough to allow
 for expected number of concurrent connections and queues.
 
-Make sure your environment allows for at least 50K open file descriptors for effective RabbitMQ
+Make sure production environments allow for at least 50K open file descriptors for effective RabbitMQ
 user, including in development environments.
 
 As a guideline, multiply the 95th percentile number of concurrent connections

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -178,8 +178,8 @@ RabbitMQ uses [Resource-driven alarms](./alarms)
 to throttle publishers when consumers do not keep up.
 
 By default, RabbitMQ will not accept any new messages when it detects
-that it's using more than 40% of the available memory (as reported by the OS):
-`vm_memory_high_watermark.relative = 0.4`. This is a safe default
+that it's using more than 60% of the available memory (as reported by the OS):
+`vm_memory_high_watermark.relative = 0.6`. This is a safe default
 and care should be taken when modifying this value, even when the
 host is a dedicated RabbitMQ node.
 
@@ -192,7 +192,8 @@ A few recommendations when adjusting the default
 `vm_memory_high_watermark`:
 
  * Nodes hosting RabbitMQ should have at least <strong>256 MiB</strong> of
-   memory available at all times. Deployments that use [quorum queues](./quorum-queues), [Shovel](./shovel) and [Federation](./federation) may need more.
+   memory available at all times. Deployments that use [quorum queues](./quorum-queues) require more,
+   see [how quorum queue use resources](./quorum-queues#resource-us) for more informatio.
  * The recommended `vm_memory_high_watermark.relative` range is `0.4 to 0.7`
  * Values above `0.7` should be used with care and with solid [memory usage](./memory-use) and infrastructure-level [monitoring](./monitoring) in place.
    The OS and file system must be left with at least 30% of the memory, otherwise performance may degrade severely due to paging.
@@ -219,48 +220,14 @@ default ensures that RabbitMQ works out of the box for
 everyone. As for production deployments, we recommend the
 following:
 
-<ul class="plain">
-  <li>
-    <p>
-      The minimum recommended free disk space low watermark value is about the same
-      as the high memory watermark. For example, on a node configured to have its memory watermark of 4GB,
-      <code>disk_free_limit.absolute = 4G</code> would be a recommended minimum.
-    </p>
+The minimum recommended free disk space low watermark value is about the same
+as the high memory watermark. For example, on a node configured to have its memory watermark of 4GB,
+<code>disk_free_limit.absolute = 4G</code> would be a recommended minimum.
 
-    <p>
-      In the example above, if available disk space drops
-      below 4GB, all publishers will be blocked and no new messages
-      will be accepted. Queues will need to be drained by
-      consumers before publishing will be allowed to resume.
-    </p>
-  </li>
-  <li>
-    <p>
-      Continuing with the example above, <code>disk_free_limit.absolute = 6G</code>
-      is a safer value.
-    </p>
-
-    <p>
-      If RabbitMQ needs to
-      flush to disk up to its high memory watermark worth of data, as can sometimes be the case during
-      shutdown, there will be sufficient disk space available for RabbitMQ
-      to start again in all but the most pessimistic scenarios.
-      6GB
-    </p>
-  </li>
-  <li>
-    <p>
-      Continuing with the example above, <code>disk_free_limit.absolute = 8G</code>
-      is the safest value to use.
-    </p>
-
-    <p>
-      It should be enough disk space for the most pessimistic scenario where a node first has to move
-      up its high memory watermark worth of data (so, about 4 GiB) to disk, and then perform an on disk
-      data operation that could temporarily nearly double the amount of disk space used.
-    </p>
-  </li>
-</ul>
+:::warning
+Running out of disk space is a very serious problem, commonly leading to outages
+and data loss. When in doubt, overprovision the disk space and/or use a high `disk_free_limit`.
+:::
 
 ### Open File Handles Limit {#resource-limits-file-handle-limit}
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -769,24 +769,6 @@ The upgrade process can require additional resources.
 Make sure there are enough resources available to proceed, in particular free
 memory and free disk space.
 
-It's recommended to have at least half of the system memory free
-before the upgrade. Default memory watermark is 0.4 so it should be
-ok, but you should still double-check. Starting with RabbitMQ `3.6.11`
-the way nodes [calculate their total RAM consumption](./memory-use) has changed.
-
-When upgrading from an earlier version,
-it is required that the node has enough free disk space to fit at
-least a full copy of the node data directory. Nodes create backups
-before proceeding to upgrade their database. If disk space is
-depleted, the node will abort upgrading and may fail to start
-until the data directory is restored from the backup.
-
-For example, if you have 10 GiB of free system memory and the Erlang
-process (i.e. `beam.smp`) memory footprint is around 6 GiB, then it
-can be unsafe to proceed. Likewise w.r.t. disk if you have 10 GiB of
-free space and the data directory (e.g. `/var/lib/rabbitmq`) takes
-10 GiB.
-
 When upgrading a cluster using the rolling upgrade strategy,
 be aware that queues and connections can migrate to other nodes
 during the upgrade.
@@ -794,6 +776,8 @@ during the upgrade.
 If clients support connections recovery and can connect to different nodes, they will reconnect
 to the nodes that are still running. If clients are configured to create exclusive queues,
 these queues might be recreated on different nodes after client reconnection.
+This will lead to additional memory usage on the running nodes, while
+one of the nodes is being upgraded.
 
 To handle such migrations, make sure you have enough
 spare resources on the remaining nodes so they can handle the extra load.


### PR DESCRIPTION
Additionaly, some edits around memory usage docs.