### PR TITLE
Change continuous membership reconciliation default to be false.

### DIFF
--- a/docs/quorum-queues/index.md
+++ b/docs/quorum-queues/index.md
@@ -638,7 +638,7 @@ are expected to come back and only a minority (often just one) node is stopped f
       <p>
         <ul>
           <li>Data type: boolean</li>
-          <li>Default: `true`</li>
+          <li>Default: `false`</li>
         </ul>
       </p>
     </td>

--- a/versioned_docs/version-3.13/quorum-queues/index.md
+++ b/versioned_docs/version-3.13/quorum-queues/index.md
@@ -595,7 +595,7 @@ The following configuration parameters control the behavior of continuous member
       <p>
         <ul>
           <li>Data type: boolean</li>
-          <li>Default: `true`</li>
+          <li>Default: `false`</li>
         </ul>
       </p>
     </td>


### PR DESCRIPTION
It seems `quorum_queue.continuous_membership_reconciliation.enabled` default value is `false` in `main` and `v3.13.x`, hence this correction.

From `rabbitmq-server` `main`: https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl#L64

From `rabbitmq-server` `v3.13.x`:  https://github.com/rabbitmq/rabbitmq-server/blob/v3.13.x/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl#L64