### PR TITLE
Correct description of OAuth2 preferred username claims config

### DIFF
--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -134,7 +134,7 @@ In chronological order, here is the sequence of events that occur when a client 
 | `auth_oauth2.resource_server_type`         | The Resource Server Type required when using [Rich Authorization Request](#rich-authorization-request) token format
 | `auth_oauth2.additional_scopes_key`        | Configure the plugin to look for scopes in other fields (maps to `additional_rabbitmq_scopes` in the old format). |
 | `auth_oauth2.scope_prefix`                 | [Configure the prefix for all scopes](#scope-prefix). The default value is `auth_oauth2.resource_server_id` followed by the dot `.` character. |
-| `auth_oauth2.preferred_username_claims`    | [List of the JWT claims](#preferred-username-claims) to look for the username associated with the token separated by commas.
+| `auth_oauth2.preferred_username_claims`    | [List of the JWT claims](#preferred-username-claims) to look for the username associated with the token.
 | `auth_oauth2.default_key`                  | ID of the default signing key.
 | `auth_oauth2.signing_keys`                 | Paths to the [signing key files](#signing-key-files).
 | `auth_oauth2.issuer`                       | The [issuer URL](#configure-issuer) of the authorization server that is used to discover endpoints such as `jwk_uri` and others (https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).


### PR DESCRIPTION
Since 3.10/[rabbitmq/rabbitmq-server#7458](https://github.com/rabbitmq/rabbitmq-server/pull/7458), preferred_username_claims has accepted a list of claim names rather than a comma-separated string.