### PR TITLE
Replace preferred_username_claims advanced.config example with modern…

### DIFF
--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -561,14 +561,13 @@ By default, RabbitMQ searches for the `sub` claim first, and if it is not found,
 
 Most authorization servers return the user's GUID in the `sub` claim instead of the user's username or email address, anything the user can relate to. When the `sub` claim does not carry a *user-friendly username*, you can configure one or several claims to extract the username from the token.
 
-Example `advanced.config` configuration:
-
+Example `rabbitmq.conf` configuration:
 ```
-  ...
-  {rabbitmq_auth_backend_oauth2, [
-    {resource_server_id, <<"rabbitmq">>},
-    {preferred_username_claims, [<<"user_name">>,<<"email">>]},
-  ...
+# ...
+auth_oauth2.resource_server_id = rabbitmq
+auth_oauth2.preferred_username_claims.1 = user_name
+auth_oauth2.preferred_username_claims.2 = email
+# ...
 ```
 
 In the example configuration, RabbitMQ searches for the `user_name` claim first and if it is not found, RabbitMQ searches for the `email`. If these are not found, RabbitMQ uses its default lookup mechanism which first looks for `sub` and then `client_id`.


### PR DESCRIPTION
… config example

Since the project recommends using the modern config example, we should use the modern config in the docs wherever possible.