### PR TITLE
Remove extra double quotes

### DIFF
--- a/tutorials/tutorial-five-dotnet.md
+++ b/tutorials/tutorial-five-dotnet.md
@@ -57,7 +57,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -78,10 +78,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -89,19 +89,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -109,10 +109,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -120,7 +120,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-dotnet).
@@ -210,14 +210,14 @@ cd ReceiveLogsTopic
 dotnet run "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 cd ReceiveLogsTopic
 dotnet run "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 cd ReceiveLogsTopic
@@ -231,7 +231,7 @@ cd ReceiveLogsTopic
 dotnet run "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 cd EmitLogTopic

--- a/tutorials/tutorial-five-elixir.md
+++ b/tutorials/tutorial-five-elixir.md
@@ -57,7 +57,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -78,10 +78,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe a celerity, second a colour and third a species:
-"`<celerity>.<colour>.<species>`".
+`<celerity>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -89,19 +89,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -109,10 +109,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -120,7 +120,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-elixir).
@@ -189,13 +189,13 @@ To receive all the logs run:
 mix run receive_logs_topic.exs "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 mix run receive_logs_topic.exs "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 mix run receive_logs_topic.exs "*.critical"
@@ -207,7 +207,7 @@ You can create multiple bindings:
 mix run receive_logs_topic.exs "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 mix run emit_log_topic.exs "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-go.md
+++ b/tutorials/tutorial-five-go.md
@@ -57,7 +57,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -78,10 +78,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -89,19 +89,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -109,10 +109,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -120,7 +120,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-go).
@@ -299,13 +299,13 @@ To receive all the logs:
 go run receive_logs_topic.go "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 go run receive_logs_topic.go "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 go run receive_logs_topic.go "*.critical"
@@ -317,7 +317,7 @@ You can create multiple bindings:
 go run receive_logs_topic.go "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 go run emit_log_topic.go "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-java.md
+++ b/tutorials/tutorial-five-java.md
@@ -57,7 +57,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -78,10 +78,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -89,19 +89,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -109,10 +109,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters, "`*`" (star) and "`#`" (hash), aren't used in bindings,
+> When special characters, `*` (star) and `#` (hash), aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -120,7 +120,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-java).
@@ -212,13 +212,13 @@ To receive all the logs:
 java -cp $CP ReceiveLogsTopic "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 java -cp $CP ReceiveLogsTopic "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 java -cp $CP ReceiveLogsTopic "*.critical"
@@ -230,7 +230,7 @@ You can create multiple bindings:
 java -cp $CP ReceiveLogsTopic "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 java -cp $CP EmitLogTopic "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-javascript.md
+++ b/tutorials/tutorial-five-javascript.md
@@ -57,7 +57,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -78,10 +78,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -89,19 +89,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -109,10 +109,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -120,7 +120,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-javascript).
@@ -215,13 +215,13 @@ To receive all the logs:
 ./receive_logs_topic.js "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 ./receive_logs_topic.js "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 ./receive_logs_topic.js "*.critical"
@@ -233,7 +233,7 @@ You can create multiple bindings:
 ./receive_logs_topic.js "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 ./emit_log_topic.js "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-objectivec.md
+++ b/tutorials/tutorial-five-objectivec.md
@@ -41,7 +41,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routingKey` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -62,10 +62,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -73,19 +73,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -93,10 +93,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -104,7 +104,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial][previous].
@@ -155,13 +155,13 @@ To receive all the logs:
 [self receiveLogsTopic:@[@"#"]];
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```objectivec
 [self receiveLogsTopic:@[@"kern.*"]];
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```objectivec
 [self receiveLogsTopic:@[@"*.critical"]];
@@ -173,7 +173,7 @@ You can create multiple bindings:
 [self receiveLogsTopic:@[@"kern.*", @"*.critical"]];
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```objectivec
 [self emitLogTopic:@"A critical kernel error" routingKey:@"kern.critical"];

--- a/tutorials/tutorial-five-php.md
+++ b/tutorials/tutorial-five-php.md
@@ -56,7 +56,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -77,10 +77,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -88,19 +88,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -108,10 +108,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -119,7 +119,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-php).
@@ -203,13 +203,13 @@ To receive all the logs:
 php receive_logs_topic.php "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 php receive_logs_topic.php "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 php receive_logs_topic.php "*.critical"
@@ -221,7 +221,7 @@ You can create multiple bindings:
 php receive_logs_topic.php "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 php emit_log_topic.php "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-python.md
+++ b/tutorials/tutorial-five-python.md
@@ -64,7 +64,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -85,10 +85,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe a celerity, second a colour and third a species:
-"`<celerity>.<colour>.<species>`".
+`<celerity>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -96,19 +96,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -116,10 +116,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -127,7 +127,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-python).
@@ -197,13 +197,13 @@ To receive all the logs run:
 python receive_logs_topic.py "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 python receive_logs_topic.py "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 python receive_logs_topic.py "*.critical"
@@ -215,7 +215,7 @@ You can create multiple bindings:
 python receive_logs_topic.py "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 python emit_log_topic.py "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-ruby.md
+++ b/tutorials/tutorial-five-ruby.md
@@ -57,7 +57,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -78,10 +78,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -89,19 +89,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -109,10 +109,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -120,7 +120,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial](./tutorial-four-ruby).
@@ -185,13 +185,13 @@ To receive all the logs:
 ruby receive_logs_topic.rb "#"
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```bash
 ruby receive_logs_topic.rb "kern.*"
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```bash
 ruby receive_logs_topic.rb "*.critical"
@@ -203,7 +203,7 @@ You can create multiple bindings:
 ruby receive_logs_topic.rb "kern.*" "*.critical"
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```bash
 ruby emit_log_topic.rb "kern.critical" "A critical kernel error"

--- a/tutorials/tutorial-five-spring-amqp.md
+++ b/tutorials/tutorial-five-spring-amqp.md
@@ -59,7 +59,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routing_key` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -80,10 +80,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -91,19 +91,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -111,10 +111,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together

--- a/tutorials/tutorial-five-swift.md
+++ b/tutorials/tutorial-five-swift.md
@@ -41,7 +41,7 @@ Messages sent to a `topic` exchange can't have an arbitrary
 `routingKey` - it must be a list of words, delimited by dots. The
 words can be anything, but usually they specify some features
 connected to the message. A few valid routing key examples:
-"`stock.usd.nyse`", "`nyse.vmw`", "`quick.orange.rabbit`". There can be as
+`stock.usd.nyse`, `nyse.vmw`, `quick.orange.rabbit`. There can be as
 many words in the routing key as you like, up to the limit of 255
 bytes.
 
@@ -62,10 +62,10 @@ In this example, we're going to send messages which all describe
 animals. The messages will be sent with a routing key that consists of
 three words (two dots). The first word in the routing key
 will describe speed, second a colour and third a species:
-"`<speed>.<colour>.<species>`".
+`<speed>.<colour>.<species>`.
 
-We created three bindings: Q1 is bound with binding key "`*.orange.*`"
-and Q2 with "`*.*.rabbit`" and "`lazy.#`".
+We created three bindings: Q1 is bound with binding key `*.orange.*`
+and Q2 with `*.*.rabbit` and `lazy.#`.
 
 These bindings can be summarised as:
 
@@ -73,19 +73,19 @@ These bindings can be summarised as:
   * Q2 wants to hear everything about rabbits, and everything about lazy
     animals.
 
-A message with a routing key set to "`quick.orange.rabbit`"
+A message with a routing key set to `quick.orange.rabbit`
 will be delivered to both queues. Message
-"`lazy.orange.elephant`" also will go to both of them. On the other hand
-"`quick.orange.fox`" will only go to the first queue, and
-"`lazy.brown.fox`" only to the second. "`lazy.pink.rabbit`" will
+`lazy.orange.elephant` also will go to both of them. On the other hand
+`quick.orange.fox` will only go to the first queue, and
+`lazy.brown.fox` only to the second. `lazy.pink.rabbit` will
 be delivered to the second queue only once, even though it matches two bindings.
-"`quick.brown.fox`" doesn't match any binding so it will be discarded.
+`quick.brown.fox` doesn't match any binding so it will be discarded.
 
 What happens if we break our contract and send a message with one or
-four words, like "`orange`" or "`quick.orange.new.rabbit`"? Well,
+four words, like `orange` or `quick.orange.new.rabbit`? Well,
 these messages won't match any bindings and will be lost.
 
-On the other hand "`lazy.orange.new.rabbit`", even though it has four
+On the other hand `lazy.orange.new.rabbit`, even though it has four
 words, will match the last binding and will be delivered to the second
 queue.
 
@@ -93,10 +93,10 @@ queue.
 >
 > Topic exchange is powerful and can behave like other exchanges.
 >
-> When a queue is bound with "`#`" (hash) binding key - it will receive
+> When a queue is bound with `#` (hash) binding key - it will receive
 > all the messages, regardless of the routing key - like in `fanout` exchange.
 >
-> When special characters "`*`" (star) and "`#`" (hash) aren't used in bindings,
+> When special characters `*` (star) and `#` (hash) aren't used in bindings,
 > the topic exchange will behave just like a `direct` one.
 
 Putting it all together
@@ -104,7 +104,7 @@ Putting it all together
 
 We're going to use a `topic` exchange in our logging system. We'll
 start off with a working assumption that the routing keys of logs will
-have two words: "`<facility>.<severity>`".
+have two words: `<facility>.<severity>`.
 
 The code is almost the same as in the
 [previous tutorial][previous].
@@ -149,13 +149,13 @@ To receive all the logs:
 self.receiveLogsTopic(["#"])
 ```
 
-To receive all logs from the facility "`kern`":
+To receive all logs from the facility `kern`:
 
 ```swift
 self.receiveLogsTopic(["kern.*"])
 ```
 
-Or if you want to hear only about "`critical`" logs:
+Or if you want to hear only about `critical` logs:
 
 ```swift
 self.receiveLogsTopic(["*.critical"])
@@ -167,7 +167,7 @@ You can create multiple bindings:
 self.receiveLogsTopic(["kern.*", "*.critical"])
 ```
 
-And to emit a log with a routing key "`kern.critical`" type:
+And to emit a log with a routing key `kern.critical` type:
 
 ```swift
 self.emitLogTopic("A critical kernel error", routingKey: "kern.critical")

--- a/tutorials/tutorial-four-dotnet.md
+++ b/tutorials/tutorial-four-dotnet.md
@@ -139,7 +139,7 @@ channel.BasicPublish(exchange: "direct_logs",
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-elixir.md
+++ b/tutorials/tutorial-four-elixir.md
@@ -131,7 +131,7 @@ AMQP.Basic.publish(channel, "direct_logs", severity, message)
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-go.md
+++ b/tutorials/tutorial-four-go.md
@@ -172,7 +172,7 @@ err = ch.PublishWithContext(ctx,
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-java.md
+++ b/tutorials/tutorial-four-java.md
@@ -131,7 +131,7 @@ channel.basicPublish(EXCHANGE_NAME, severity, null, message.getBytes());
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-javascript.md
+++ b/tutorials/tutorial-four-javascript.md
@@ -139,7 +139,7 @@ channel.publish(exchange, severity, Buffer.from(msg));
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-objectivec.md
+++ b/tutorials/tutorial-four-objectivec.md
@@ -116,7 +116,7 @@ RMQExchange *x = [ch direct:@"logs"];
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-php.md
+++ b/tutorials/tutorial-four-php.md
@@ -133,7 +133,7 @@ $channel->basic_publish($msg, 'direct_logs', $severity);
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 Subscribing
 -----------

--- a/tutorials/tutorial-four-python.md
+++ b/tutorials/tutorial-four-python.md
@@ -144,7 +144,7 @@ channel.basic_publish(exchange='direct_logs',
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-ruby.md
+++ b/tutorials/tutorial-four-ruby.md
@@ -132,7 +132,7 @@ exchange.publish(message, routing_key: severity)
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing

--- a/tutorials/tutorial-four-swift.md
+++ b/tutorials/tutorial-four-swift.md
@@ -116,7 +116,7 @@ x.publish(msg.data(using: .utf8), routingKey: severity)
 ```
 
 To simplify things we will assume that 'severity' can be one of
-'info', 'warning', 'error'.
+`info`, `warning`, or `error`.
 
 
 Subscribing


### PR DESCRIPTION
For some reason, double quotes can be found surrounding many strings that are formatted with backticks.