### PR TITLE
Refresh upgrade-related documentation

### DIFF
--- a/docs/blue-green-upgrade.md
+++ b/docs/blue-green-upgrade.md
@@ -19,10 +19,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-Blue-green deployment is an [upgrade strategy](./upgrade) that is based on the idea of setting up
-a second RabbitMQ cluster (the "green" one) next to the current production
-cluster (the "blue" one). Applications are then switched to the "green"
-cluster. When that migration is done, the "blue" cluster is decommissioned (shut down).
+Blue-green deployment is a migrtion technique that can also be used as an [upgrade strategy](./upgrade).
+The main idea is to set up a new environment (the "green" one) and switch to it
+when it is ready. Technically nothing is upgraded - the application just switch
+to a different environment, which might be using a different version, but can
+also differ in other aspects. For example, the same approach can be used
+to migrate to new hardware, while keeping the same version of RabbitMQ.
+
+When that migration is done, the old ("blue") cluster is decommissioned (shut down, deleted).
 To simplify the switch, [federated queues](./federated-queues)
 can be used to transfer enqueued messages from the "blue" to the "green" cluster.
 
@@ -71,7 +75,7 @@ Please read the guides linked above and the
 
 You can now switch your consumers to use the new "green" cluster. To achieve
 that, reconfigure your load balancer or your consumer applications, depending
-on your setup. The Upgrade guide covers [some client features which enable
+on your setup. The upgrade guide covers [some client features which enable
 them to switch between nodes](./upgrade#rabbitmq-restart-handling).
 
 At that point, your producers are still publishing to "blue", but thanks to

--- a/docs/blue-green-upgrade.md
+++ b/docs/blue-green-upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrading RabbitMQ Using Blue-Green Deployment Strategy
+title: Blue-Green Deployment
 displayed_sidebar: docsSidebar
 ---
 <!--
@@ -18,10 +18,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-# Upgrading RabbitMQ Using Blue-Green Deployment Strategy
-
-## Overview {#overview}
 
 Blue-green deployment is an [upgrade strategy](./upgrade) that is based on the idea of setting up
 a second RabbitMQ cluster (the "green" one) next to the current production
@@ -108,14 +104,14 @@ federation or shovel plugins finish to drain the queues on "blue".
 When they are empty, reconfigure your producers like you did for the consumers
 and start them again. At this point, everything is moved to the "green" cluster.
 
-## Decomission the "blue" Cluster {#decomission-blue}
+## Decommission the "blue" Cluster {#decommission-blue}
 
 You are now free to shutdown the nodes in the "blue" cluster.
 
 ## Real-world Example {#example}
 
 Dan Baskette, Gareth Smith and Claude Devarenne of Pivotal
-[published an article](https://content.pivotal.io/blog/blue-green-application-deployments-with-rabbitmq)
+[published an article](https://tanzu.vmware.com/content/blog/blue-green-application-deployments-with-rabbitmq)
 about this method where producers and consumers are CloudFoundry applications.
 The article is very detailed  and uses diagrams to describe the procedure.
 They also made a [video to show it in action](https://www.youtube.com/watch?v=S2oO-t-E38c).

--- a/docs/blue-green-upgrade.md
+++ b/docs/blue-green-upgrade.md
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-Blue-green deployment is a migrtion technique that can also be used as an [upgrade strategy](./upgrade).
+Blue-green deployment is a migration technique that can also be used as an [upgrade strategy](./upgrade).
 The main idea is to set up a new environment (the "green" one) and switch to it
 when it is ready. Technically nothing is upgraded - the application just switch
 to a different environment, which might be using a different version, but can

--- a/docs/blue-green-upgrade.md
+++ b/docs/blue-green-upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: Blue-Green Deployment
-displayed_sidebar: docsSidebar
 ---
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.

--- a/docs/feature-flags/index.md
+++ b/docs/feature-flags/index.md
@@ -65,17 +65,6 @@ and so on.
 For example, RabbitMQ 3.13.x and 3.12.x nodes are compatible as long as no
 3.13.x-specific feature flags are enabled.
 
-<p class="box-warning">
-This subsystem does not guarantee that all future changes in
-RabbitMQ can be implemented as feature flags and entirely backwards
-compatible with older release series. Therefore, <strong>a future
-version of RabbitMQ might still require a cluster-wide shutdown for
-upgrading</strong>.
-
-Please always read <a href="/release-information">release notes</a> to see if a
-rolling upgrade to the next minor or major RabbitMQ version is possible.
-</p>
-
 ### Key CLI Tool Commands
 
  *  To list feature flags:

--- a/docs/grow-then-shrink-upgrade.md
+++ b/docs/grow-then-shrink-upgrade.md
@@ -1,0 +1,131 @@
+---
+title: Grow-then-Shrink Upgrade
+displayed_sidebar: docsSidebar
+---
+<!--
+Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::note
+This strategy involves node identity changes and replica transfers to the newly added nodes.
+
+With quorum queues and streams that have large data sets, this means that the cluster will
+experience substantial network traffic volume and disk I/O spikes that a rolling in-place upgrade would not.
+
+Consider using [in-place upgrades](#in-place) or [Blue/Green deployment upgrades](./blue-green-upgrade) instead.
+:::
+
+:::danger
+In order to safely perform a grow-then-shrink upgrade, several precautions must be taken
+:::
+
+A Grow-then-Shrink upgrade usually involves the following steps. Consider a three node cluster with nodes
+A, B, and C:
+
+ * Add a new node, node D, to the cluster
+ * Place a new replica of every quorum queue and every stream to the new node using commands such as `rabbitmq-queues grow`
+ * Check that the cluster is in a good state: no [alarms](./alarms) are in effect, no ongoing queue or stream replica sync operations
+   and the system is otherwise under a reasonable load
+ * Remove node A from the cluster using `rabbitmqctl forget_cluster_node`
+ * Add a new node, node E, to the cluster
+ * Place a new replica of every quorum queue and every stream to the new node using commands such as `rabbitmq-queues grow`
+ * Check that the cluster is in a good state
+ * Remove node B from the cluster using `rabbitmqctl forget_cluster_node`
+ * and so on
+
+This approach may seem like one that strikes a good balance between the relative simplicity of
+in-place upgrades and the safety of Blue-Green deployment upgrades. However, in practice this
+strategy has comparable characteristics to the in-place upgrade option:
+
+ * Newly added nodes may affect the existing cluster state
+ * Replicas will migrate between nodes during the upgrade process
+
+In addition, this approach has its own unique potential risks:
+
+ * Node identities change during the upgrade process, which can affect [historical monitoring data](./monitoring/)
+ * Nodes must transfer their data sets to the newly added members, which can result in a **very substantial increase
+   in network traffic and disk I/O**
+ * Premature removal of nodes (see below) can lead to a quorum loss for a subset of quorum queues and streams
+
+:::danger
+In order to safely perform a grow-then-shrink upgrade, several precautions must be taken
+:::
+
+In order to safely perform a grow-then-shrink upgrade, several precautions must be taken:
+
+ * After a new node is added and a replica extension process is initiated, the process must
+   be given enough time to complete
+ * Before a node is removed, a health check must be run to ensure that it is not quorum critical for any queues (or streams):
+   that is, that the removal of the node will not leave any quorum queues or streams without an online majority
+ * Nodes must be removed from the cluster explicitly using `rabbitmqctl forget_cluster_node`
+
+[Streams](./streams/) specifically were not designed for environments where replica (node) identity change is frequent,
+and all replicas can be transferred away and replaced over duration of a single cluster upgrade.
+
+### Key Precautions
+
+To determine if a node is quorum critical, use the following [health check](./monitoring#health-checks):
+
+<Tabs groupId="shell-specific">
+<TabItem value="bash" label="bash" default>
+```bash
+# exits with a non-zero code if any of the internal components, quorum queues or stream queues
+# will lose online quorum should the target node be shut down;
+# additionally, it will print which components and/or queues are affected
+rabbitmq-diagnostics check_if_node_is_quorum_critical
+```
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+# exits with a non-zero code if any of the internal components, quorum queues or stream queues
+# will lose online quorum should the target node be shut down;
+# additionally, it will print which components and/or queues are affected
+rabbitmq-diagnostics.bat check_if_node_is_quorum_critical
+```
+</TabItem>
+</Tabs>
+
+The following [health check](./monitoring#health-checks) must be used to determine if there may be
+any remaining initial quorum queue replica log transfers:
+
+<Tabs groupId="shell-specific">
+<TabItem value="bash" label="bash" default>
+```bash
+# exits with a non-zero status if there are any ongoing initial quorum queue
+# replica sync operations
+rabbitmq-diagnostics check_if_new_quorum_queue_replicas_have_finished_initial_sync
+```
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+# exits with a non-zero status if there are any ongoing initial quorum queue
+# replica sync operations
+rabbitmq-diagnostics.bat check_if_new_quorum_queue_replicas_have_finished_initial_sync
+```
+</TabItem>
+</Tabs>
+
+:::tip
+Consider adding and removing a single node at a time
+:::
+
+If multiple nodes are added and removed at a time, the health checks must be performed on all of them.
+Removing multiple nodes at a time is more likely to leave certain quorum queues or streams without
+an online majority, therefore it is highly recommended to add and remove a single node at a time.
+

--- a/docs/grow-then-shrink-upgrade.md
+++ b/docs/grow-then-shrink-upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: Grow-then-Shrink Upgrade
-displayed_sidebar: docsSidebar
 ---
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.

--- a/docs/grow-then-shrink-upgrade.md
+++ b/docs/grow-then-shrink-upgrade.md
@@ -58,7 +58,7 @@ strategy has comparable characteristics to the in-place upgrade option:
 
 In addition, this approach has its own unique potential risks:
 
- * Node identities change during the upgrade process, which can affect [historical monitoring data](./monitoring/)
+ * Node identities change during the upgrade process, which can affect [historical monitoring data](./monitoring)
  * Nodes must transfer their data sets to the newly added members, which can result in a **very substantial increase
    in network traffic and disk I/O**
  * Premature removal of nodes (see below) can lead to a quorum loss for a subset of quorum queues and streams
@@ -75,7 +75,7 @@ In order to safely perform a grow-then-shrink upgrade, several precautions must 
    that is, that the removal of the node will not leave any quorum queues or streams without an online majority
  * Nodes must be removed from the cluster explicitly using `rabbitmqctl forget_cluster_node`
 
-[Streams](./streams/) specifically were not designed for environments where replica (node) identity change is frequent,
+[Streams](./streams) specifically were not designed for environments where replica (node) identity change is frequent,
 and all replicas can be transferred away and replaced over duration of a single cluster upgrade.
 
 ### Key Precautions

--- a/docs/rolling-upgrade.md
+++ b/docs/rolling-upgrade.md
@@ -1,0 +1,206 @@
+---
+title: Rolling (in-place) Upgrade
+displayed_sidebar: docsSidebar
+---
+<!--
+Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Rolling upgrade is a popular upgrade strategy, in which nodes are upgraded
+one by one: each node is stopped, upgraded and then started. Upgraded nodes rejoin the cluster,
+which temporarily works in a mixed-version mode: some nodes run the old version, some run the new one.
+
+While all nodes have to be restarted during the upgrade, the
+cluster as a whole remains available throughout the process
+(unless it only has one node, of course).
+
+:::important
+Rolling upgrades don't support skipping versions, except patch releases (for example you **can** upgrade directly
+from 3.13.0 to 3.13.7 but you **cannot** upgrade directly from 3.12.x to 4.0). Moreover, for specific upgrades,
+additional constraints may apply. Please refer to the [version upgradability](./upgrade#rabbitmq-version-upgradability) table for more information.
+:::
+
+## Before the Upgrade {#before}
+
+### Investigate if the current and target versions have a rolling upgrade path
+
+Please refer to the [version upgradability](./upgrade#rabbitmq-version-upgradability) table for information
+about the supported upgrade paths.
+
+#### Check Erlang Version Requirements
+
+Refer to [Erlang Version Requirements](./upgrade#rabbitmq-erlang-version-requirement).
+
+If the same Erlang version is supported by both the current and target RabbitMQ versions,
+you can leave Erlang as is. However, you can consider upgrading Erlang to the latest
+supported version at the same time. Both Erlang and RabbitMQ upgrades require a restart,
+so it may be more convenient to do both at the same time.
+
+If the target RabbitMQ version requires a newer Erlang version,
+you need to prepare to upgrade Erlang together with RabbitMQ.
+
+### Carefully Read the Release Notes Up to the Selected RabbitMQ Version
+
+The [release notes](https://github.com/rabbitmq/rabbitmq-server/releases)
+may indicate specific additional upgrade steps. Always consult the release notes
+of all versions between the one currently deployed and the target one.
+
+### Verify All Stable Feature Flags Are Enabled
+
+[All stable feature flags should be enabled](./feature-flags#how-to-enable-feature-flags) after each upgrade.
+Otherwise, the upgrade process is not really complete, since some of the changes are not effective.
+If you follow this advice, there should be nothing to do with regards to the feature flags before the upgrade,
+since they were all enabled after the previous upgrade.
+
+However, since attempting an upgrade with disabled feature flags may lead to serious issues, it's a good
+practice to check if all stable feature flags are enabled before starting the upgrade. You can safely
+run `rabbitmqctl enable_feature_flag all` - it will do nothing if all flags are already enabled.
+
+### Make Sure All Package Dependencies (including Erlang) are Available
+
+If you are using Debian or RPM packages, you must ensure
+that all dependencies are available. In particular, the
+correct version of Erlang. You may have to setup additional
+third-party package repositories to achieve that.
+
+Please read recommendations for
+[Debian-based](./which-erlang#debian) and
+[RPM-based](./which-erlang#redhat) distributions to find the
+appropriate repositories for Erlang.
+
+### Assess Cluster Health
+
+Make sure nodes are healthy and there are no [network partition](./partitions)
+or [disk or memory alarms](./alarms) in effect.
+
+RabbitMQ management UI, CLI tools or HTTP API can be used for
+assessing the health of the system.
+
+The overview page in the management UI displays effective RabbitMQ
+and Erlang versions, multiple cluster-wide metrics and rates. From
+this page ensure that all nodes are running and they are all "green"
+(w.r.t. file descriptors, memory, disk space, and so on).
+
+We recommend recording the number of durable queues, the number
+of messages they hold and other pieces of information about the
+topology that are relevant. This data will help verify that the
+system operates within reasonable parameters after the upgrade.
+
+Use [node health checks](./monitoring#health-checks) to
+vet individual nodes.
+
+Queues in flow state or blocked/blocking connections might not be a problem,
+depending on your workload. It's up to you to determine if this is
+a normal situation or if the cluster is under unexpected load and
+thus, decide if it's safe to continue with the upgrade.
+
+However, if there are queues in an undefined state (a.k.a. `NaN` or
+"ghost" queues), you should first start by understanding what is
+wrong before starting an upgrade.
+
+### Ensure Cluster Has the Capacity for Upgrading
+
+Please refer to [changes in system resource usage](./upgrade#system-resource-usage)
+for information about how the upgrade process can affect resource usage.
+
+## Perform the Upgrade
+
+The main part of the upgrade process is performed by stopping, upgrading and starting each node one by one.
+The following steps should be performed for all nodes.
+
+### Stop the Node
+
+The exact way to stop a node depends on how it was started.
+
+### Take a Backup
+
+Optionally, when the node is stopped, you can [backup](./backup) its data folder.
+
+### Upgrade the Node
+
+Install the new version of RabbitMQ and other packages if necessary.
+
+Make sure you have an Erlang version compatible with the new RabbitMQ version.
+
+### Start the Node
+
+Start the node and verify that it joins the cluster.
+
+You can perform the following checks to ensure that the node started and rejoined
+the cluster successfully:
+
+* run `rabbitmqctl cluster_status` and verify the output
+  * the upgraded node should be listed as running
+  * there should be no network partitions nor active alarms
+* check the management UI
+  * all nodes should be listed on the main page
+  * resource usage should be within acceptable limits
+* check the logs
+  * there should be no errors
+
+## After the Upgrade {#after}
+
+### Verify that the Upgrade Has Succeeded
+
+Like you did before the upgrade, verify the health and [monitoring data](./monitoring/) to
+make sure all cluster nodes are in good shape and the service is running again.
+
+### Enable New Feature Flags {#enable-ff-after-upgrade}
+
+Once all the nodes are upgraded and the cluster is healthy,
+[enable all stable feature flags](./feature-flags#how-to-enable-feature-flags).
+If the new version doesn't provide any new feature flags, you can still run
+`rabbitmqctl enable_feature_flag all` - it will simply do nothing.
+
+## Real-world Example {#example}
+
+Rolling upgrade strategy is not specific to any particular deployment tooling
+or infrastructure. Many orchestration tools have a built-in concept of rolling upgrades
+with hooks allowing to perform custom actions before and after each node is upgraded.
+
+One such orchestration tool is Kubernetes. It can perform a [rolling update](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update)
+of a `StatefulSet`. Let's walk through what happens when you want to upgrade RabbitMQ
+deployed to Kubernetes using the [Cluster Operator](/kubernetes/operator/operator-overview).
+Let's assume the cluster has three nodes, which means the nodes are called `server-0`, `server-1`, and `server-2`
+(there would be a prefix with the name of your cluster, but that's irrelevant for this example).
+
+1. Make sure the existing cluster is running RabbitMQ 3.13 and has all stable feature flags enabled
+1. Update the `RabbitmqCluster` object with the new image (eg. change from `rabbitmq:3.13.7-management` to `rabbitmq:4.0.0-management`)
+1. The Cluster Operator will update the `StatefulSet` object with the new image, triggering the rolling upgrade mechanism built-in to Kubernetes
+1. Kubernetes will stop `server-2` (it always goes from the highest index to the lowest)
+   - The pod will check if it can safely stop, by calling `rabbitmq-upgrade await_online_quorum_plus_one`
+   - When that command exits with a zero status, the pod will stop
+1. Kubernetes will download and start the new OCI image. Effectively, it upgraded the packages of RabbitMQ, Erlang and other system dependencies
+1. `server-2` starts and [attempts to rejoin the cluster](./feature-flags#version-compatibility)
+   - it has the same feature flags enabled as it had before it stopped (the state of feature flags is stored in a file)
+   - feature flags that were introduced in RabbitMQ 4.0 or **not** enabled at this point
+   - therefore, the upgraded node can join the cluster1
+1. Once the node starts, it synchronizes its metadata (eg. becomes aware of queues declared while it was down), and starts quorum
+   queue and stream members, which should quickly catch up with the rest of the cluster (any messages published while the node was down
+   are replicated to it, etc)
+1. Once `server-2` is running, Kubernetes stops `server-1` and the process repeats
+1. Once `server-0` is upgraded and running, all nodes are running on the new version
+1. You can now enable new feature flags and [rebalance the cluster](./upgrade#rebalance)
+
+While the process has many steps (and we skipped some details), you only had to change the `image` value,
+wait a few minutes and then ran two commands to enable new feature flags and rebalance the cluster.
+
+When performing a rolling upgrade without Kubernetes, you need to go through the same steps - you just have
+to do them manually or using some other automation. Using OCI images further simplifies the process since the image
+contains the new RabbitMQ version already with a compatible Erlang version and other dependencies.

--- a/docs/rolling-upgrade.md
+++ b/docs/rolling-upgrade.md
@@ -43,7 +43,7 @@ additional constraints may apply. Please refer to the [version upgradability](./
 Please refer to the [version upgradability](./upgrade#rabbitmq-version-upgradability) table for information
 about the supported upgrade paths.
 
-#### Check Erlang Version Requirements
+### Check Erlang Version Requirements
 
 Refer to [Erlang Version Requirements](./upgrade#rabbitmq-erlang-version-requirement).
 

--- a/docs/rolling-upgrade.md
+++ b/docs/rolling-upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: Rolling (in-place) Upgrade
-displayed_sidebar: docsSidebar
 ---
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.

--- a/docs/rolling-upgrade.md
+++ b/docs/rolling-upgrade.md
@@ -158,7 +158,7 @@ the cluster successfully:
 
 ### Verify that the Upgrade Has Succeeded
 
-Like you did before the upgrade, verify the health and [monitoring data](./monitoring/) to
+Like you did before the upgrade, verify the health and [monitoring data](./monitoring) to
 make sure all cluster nodes are in good shape and the service is running again.
 
 ### Enable New Feature Flags {#enable-ff-after-upgrade}

--- a/docs/rolling-upgrade.md
+++ b/docs/rolling-upgrade.md
@@ -190,7 +190,7 @@ Let's assume the cluster has three nodes, which means the nodes are called `serv
 1. `server-2` starts and [attempts to rejoin the cluster](./feature-flags#version-compatibility)
    - it has the same feature flags enabled as it had before it stopped (the state of feature flags is stored in a file)
    - feature flags that were introduced in RabbitMQ 4.0 or **not** enabled at this point
-   - therefore, the upgraded node can join the cluster1
+   - therefore, the upgraded node can join the cluster
 1. Once the node starts, it synchronizes its metadata (eg. becomes aware of queues declared while it was down), and starts quorum
    queue and stream members, which should quickly catch up with the rest of the cluster (any messages published while the node was down
    are replicated to it, etc)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -58,7 +58,7 @@ Refer to the [rolling upgrade guide](./rolling-upgrade) page for more details, b
   * upgrade RabbitMQ and, if applicable, Erlang
   * start the node
   * watch [monitoring and health check](./monitoring) data to assess the health and recovery of the upgraded node and cluster
-* Once all nodes are upgraded, [enable feature flags](.//feature-flags#how-to-enable-feature-flags) introduced in the new version
+* Once all nodes are upgraded, [enable feature flags](./feature-flags#how-to-enable-feature-flags) introduced in the new version
 
 ### Blue-Green Deployment
 
@@ -116,7 +116,7 @@ A, B, and C:
   * the system is otherwise under a reasonable load
  * Remove node A from the cluster using `rabbitmqctl forget_cluster_node`
 * Repeat the steps above for the other nodes; in a 3-node cluster example, the cluster should now consist of nodes D, E and F
-* [Enable feature flags](.//feature-flags#how-to-enable-feature-flags) introduced in the new version
+* [Enable feature flags](./feature-flags#how-to-enable-feature-flags) introduced in the new version
 
 Multiple nodes can be added and removed at a time.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -76,7 +76,7 @@ A blue-green upgrade usually involves the following steps performed by a deploym
 by an operator. Refer to the [blue-green deployment guide](./blue-green-upgrade) for more details about these steps:
 
 * Deploy a new cluster with the desired version
-* Synchronie metadata between the old and the new cluster (unless applications can declare their own metadata)
+* Synchronize metadata between the old and the new cluster (unless applications can declare their own metadata)
 * Set up federation
 * Switch consumers to the new cluster
 * Drain messages
@@ -87,7 +87,7 @@ There's also a simplfied version of the blue-green strategy, if some downtime is
 
 * Deploy a new cluster with the target version
 * Stop the applications
-* Synchronie metadata between the old and new clusters
+* Synchronize metadata between the old and new clusters
 * Move all messages from the old cluster to the new one (e.g. using [Shovel](./shovel))
 * Reconfigure applications to use the new cluster
 * Start publishers and consumers
@@ -266,7 +266,7 @@ using the [Cluster Operator](/kubernetes/operator/operator-overview), this is al
 ### Rebalancing Queue Leaders {#rebalance}
 
 If either the rolling or grown-then-shrink upgrade strategy is used, queue leaders will not be evenly distributed
-between the nodes. Rebalancing of queue and stream leaders helps spread the load across all cluster nodes.
+between the nodes after the upgrade. Rebalancing of queue and stream leaders helps spread the load across all cluster nodes.
 
 To rebalance all queue and stream leader replicas, run:
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrading RabbitMQ
-displayed_sidebar: docsSidebar
 ---
 <!--
 Copyright (c) 2005-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -137,10 +137,10 @@ The following shows the supported upgrade paths.
 
 | From     | To     | Notes                                                         |
 |----------|--------|---------------------------------------------------------------|
-| 3.13.x   | 4.0.x  | Some feature flags **must** be enabled **before** the upgrade |
+| 3.13.x   | 4.0.x  | All feature flags **must** be enabled **before** the upgrade  |
 | 3.12.x   | 3.13.x |                                                               |
 | 3.11.18  | 3.12.x | All feature flags **must** be enabled **before** the upgrade  |
-| 3.10.x   | 3.11.x | Some feature flags **must** be enabled **before** the upgrade |
+| 3.10.x   | 3.11.x | All feature flags **must** be enabled **before** the upgrade  |
 | 3.9.x    | 3.10.x |                                                               |
 | 3.8.x    | 3.9.x  |                                                               |
 | 3.7.18   | 3.8.x  |                                                               |

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -24,80 +24,75 @@ import TabItem from '@theme/TabItem';
 
 # Upgrading RabbitMQ
 
-## Overview {#overview}
-
-This guide covers topics related to RabbitMQ installation upgrades.
-
-1. [An overview](#basics) of several common approaches to upgrading RabbitMQ
-1. [RabbitMQ version upgradability](#rabbitmq-version-upgradability): explains what versions or series can be upgraded to what later series
-1. [Erlang version requirement](#rabbitmq-erlang-version-requirement)
-1. [Plugin compatibility between versions](#rabbitmq-plugins-compatibility)
-1. Features [that do not support in-place upgrade](#unsupported-inplace-upgrade)
-1. [Changes in system resource usage and reporting](#system-resource-usage) in the new version
-1. How upgrades of [multi-node clusters](#clusters) is different from those with only a single node
-1. Marking [nodes for maintenance](#maintenance-mode)
-1. [Recommended upgrade steps](#recommended-upgrade-steps)
-1. [Caveats](#caveats)
-1. [Handling node restarts](#rabbitmq-restart-handling) in applications
-
-See [Release Information](/release-information) to find out what RabbitMQ release series are supported.
-Release notes of individual releases are [published on GitHub](https://github.com/rabbitmq/rabbitmq-server/releases).
-
-## Important Note on Upgrading to 3.12 and 3.13
-
 :::important
-RabbitMQ 3.12 requires all previously existing feature flags to be [enabled](./feature-flags#how-to-enable-feature-flags) before the upgrade.
+You can only upgrade to RabbitMQ 4.0 from RabbitMQ 3.13.
 
-The upgrade will fail if you miss this step.
+Moreover, [feature flags have to be enabled](./feature-flags#how-to-enable-feature-flags) **before** the upgrade. The upgrade will fail if you miss this step.
 :::
 
-## Basics {#basics}
+## Upgrade Strategies {#strategies}
 
-There are two major upgrade scenarios that are covered in this guide: a [single node](#single-node-upgrade) and a [cluster](#multiple-nodes-upgrade),
-as well as several most commonly used strategies:
+There are three major upgrade strategies that can be used with RabbitMQ. Below you'll find a brief overview
+of all of them. Each strategy has a dedicated page with more detailed information.
 
- * In-place upgrade where each node is upgraded with its existing on disk data
- * [Blue-green deployment](./blue-green-upgrade) where a new cluster is created and existing data is migrated to it
- * A grow-then-shrink approach where one or more new nodes are added to the cluster, then the old nodes are eventually removed
-
-Below is a brief overview of the common strategies. The rest of the guide covers each strategy in more detail.
-
-The [RabbitMQ version upgradability](#rabbitmq-version-upgradability) section explains what versions or series can be upgraded to what later series.
-
-### In-place Upgrades {#in-place}
+### Rolling (in-place) Upgrade {#rolling-upgrade}
 
 :::tip
 This upgrade strategy is recommended
 :::
 
-An in-place upgrade usually involves the following steps performed by a deployment tool or manually
-by an operator. Each step is covered in more detail later in this guide. An intentionally oversimplified
-list of steps would include:
+A rolling upgrade (also referred to as in-place upgrade) is an upgrade process where nodes are upgraded one by one.
+Refer to the [rolling upgrade guide](./rolling-upgrade) page for more details, but here are the main steps:
 
- * Investigate if the current and target versions have an in-place upgrade path: check [version upgradability](#rabbitmq-version-upgradability), [Erlang version requirements](#rabbitmq-erlang-version-requirement), release notes, [features that do not support in-place upgrades](#unsupported-inplace-upgrade), and [known caveats](#caveats)
- * Check that the node or cluster is in a good state in order to be upgraded: no [alarms](./alarms) are in effect, no ongoing queue or stream replica sync operations
-   and the system is otherwise under a reasonable load
- * Stop the node
- * Upgrade RabbitMQ and, if applicable, Erlang
- * Start the node
- * Watch [monitoring and health check](./monitoring) data to assess the health and recovery of the upgraded node or cluster
+* Investigate if the current and target versions have a rolling upgrade path
+  * check [version upgradability](#rabbitmq-version-upgradability)
+  * check [Erlang version requirements](#rabbitmq-erlang-version-requirement)
+  * check [the release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.0)
+  * verify that all stable [feature flags are enabled](.//feature-flags#how-to-enable-feature-flags)
+* Check that the node or cluster is in a good state in order to be upgraded
+  * no [alarms](./alarms) are in effect
+  * no ongoing queue or stream replica sync operations
+  * the system is otherwise under a reasonable load
+* For each node
+  * stop the node
+  * upgrade RabbitMQ and, if applicable, Erlang
+  * start the node
+  * watch [monitoring and health check](./monitoring) data to assess the health and recovery of the upgraded node and cluster
+* Once all nodes are upgraded, [enable feature flags](.//feature-flags#how-to-enable-feature-flags) introduced in the new version
 
-[Rolling upgrades](#rolling-upgrades) between certain versions are not supported. [Full Stop Upgrades](#full-stop-upgrades)
-and the [Blue/Green deployment](./blue-green-upgrade) upgrade strategy cover the two options available for those cases.
-
-### Blue-Green Deployment Upgrades
+### Blue-Green Deployment
 
 :::tip
 This upgrade strategy is the safest option. It is recommended
-for environments where a rolling in-place upgrade is not an option
+for environments where a rolling upgrade is not an option
 for any reason, or extra safety is particularly important
 :::
 
 [The Blue/Green deployment](./blue-green-upgrade) strategy offers the benefit of making the upgrade process safer at the cost of
 temporary increasing infrastructure footprint. The safety aspect comes from the fact that the operator
-can abort an upgrade by switching applications back to the existing cluster.
+can abort an upgrade by switching applications back to the old cluster.
 
-### Grow-then-Shrink Upgrades
+A blue-green upgrade usually involves the following steps performed by a deployment tool or manually
+by an operator. Refer to the [blue-green upgrade guide](./blue-green-upgrade) for more details about these steps:
+
+* Deploy a new cluster with the desired version
+* Synchronie metadata between the old and the new cluster (unless applications can declare their own metadata)
+* Set up federation
+* Switch consumers to the new cluster
+* Drain messages
+* Switch publishers to the new cluster
+* Decommission the old cluster
+
+There's also a simplfied version of the blue-green strategy, if some downtime is acceptable:
+
+* Deploy a new cluster with the target version
+* Stop the applications
+* Synchronie metadata between the old and new clusters
+* Move all messages from the old cluster to the new one (e.g. using [Shovel](./shovel))
+* Reconfigure applications to use the new cluster
+* Start publishers and consumers
+
+### Grow-then-Shrink Upgrade
 
 :::danger
 This upgrade strategy changes replica identities, can result in massive unnecessary data transfers between
@@ -107,122 +102,72 @@ nodes, and is only safe with important precautions. Therefore, it is [highly rec
 A [grow-and-shrink upgrade](#grow-then-shrink) usually involves the following steps. Consider a three node cluster with nodes
 A, B, and C:
 
- * Add a new node, node D, to the cluster
- * Place a new replica of every quorum queue and every stream to the new node using commands such as `rabbitmq-queues grow`
- * Check that the cluster is in a good state: no [alarms](./alarms) are in effect, no ongoing queue or stream replica sync operations
-   and the system is otherwise under a reasonable load
+* Investigate if the current and target versions can be clustered together
+  * check [version upgradability](#rabbitmq-version-upgradability); if a rolling upgrade between the old and new version is not supported,
+    that also means that these two versions cannot coexist in a single cluster
+  * check [Erlang version requirements](#rabbitmq-erlang-version-requirement)
+  * check [the release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.0)
+ * Add a new node, node D, to the cluster (note, you may need to [disable new feature flags](feature-flags#how-to-start-new-node-disabled-feature-flags)
+   for node D to be able to join the cluster)
+ * Place a new replica of every quorum queue and every stream on the new node
+* Check that the node or cluster is in a good state
+  * no [alarms](./alarms) are in effect
+  * no ongoing queue or stream replica sync operations
+  * the system is otherwise under a reasonable load
  * Remove node A from the cluster using `rabbitmqctl forget_cluster_node`
- * Add a new node, node E, to the cluster
- * Place a new replica of every quorum queue and every stream to the new node using commands such as `rabbitmq-queues grow`
- * Check that the cluster is in a good state
- * Remove node B from the cluster using `rabbitmqctl forget_cluster_node`
- * and so on
+* Repeat the steps above for the other nodes; in a 3-node cluster example, the cluster should now consist of nodes D, E and F
+* [Enable feature flags](.//feature-flags#how-to-enable-feature-flags) introduced in the new version
 
 Multiple nodes can be added and removed at a time.
-
-Similarly to [rolling upgrades](#rolling-upgrades), grow-and-shrink upgrades between certain versions are not supported.
-[Full Stop Upgrades](#full-stop-upgrades) and the [Blue/Green deployment](./blue-green-upgrade) upgrade strategy cover the two options available for those cases.
 
 
 ## RabbitMQ Version Upgradability {#rabbitmq-version-upgradability}
 
-All versions starting with `3.7.27` support [rolling upgrades](#rolling-upgrades) to compatible
-later versions using [feature flags](./feature-flags).
+You can only upgrade to RabbitMQ 4.0 from RabbitMQ 3.13.x.
 
-A [full cluster stop](#full-stop-upgrades) may be required for feature version upgrades
-but such cases are rare in modern release series thanks to feature flags.
+Don't forget to [enable all stable feature flags](./feature-flags#how-to-enable-feature-flags) while still on 3.13,
+**before** attempting an upgrade to RabbitMQ 4.0, or the upgrade will fail.
 
-:::important
-As a rule of thumb, upgrade to the latest patch release in the target series,
-and then [enable all stable feature flags](./feature-flags#how-to-enable-feature-flags)
-after all cluster nodes have been upgraded.
-:::
+If you are not on RabbitMQ 3.13 yet, refer to the table below to understand your upgrade path.
 
-:::important
-When an upgrade jumps multiple release series (e.g. goes from `3.9.x` to `3.13.x`), it may be necessary to perform
-one or more intermediate upgrades first.
+<details>
+  <summary>Release Series Upgradeability</summary>
 
-For each intermediary upgrade, upgrade to the latest patch release in the target series,
-and then [enable all stable feature flags](./feature-flags#how-to-enable-feature-flags)
-after all cluster nodes have been upgraded.
-:::
-
-When an upgrade jumps multiple release series (e.g. goes from `3.9.x` to `3.13.x`), it may be necessary to perform
-one or more intermediate upgrades first. For each intermediary upgrade, upgrade to the latest patch release in the target series,
-and then [enable all stable feature flags](./feature-flags#how-to-enable-feature-flags)
-after all cluster nodes have been upgraded.
-
-For example, when upgrading from `3.9.x` to `3.13.x`, it would be necessary to
-
-1. First upgrade to the latest 3.10.x patch release
-2. Then to the latest patch release of 3.11.x
-3. Then to the latest patch release of 3.12.x
-4. Finally, upgrade to the latest release in the 3.13.x
-
-Don't forget to [enable all stable feature flags](./feature-flags#how-to-enable-feature-flags) every step of
-the process or the follow step may fail because some feature flags have [graduated](./feature-flags#graduation) (became mandatory).
-
-Or consider a [The Blue/Green deployment](./blue-green-upgrade) upgrade in one go.
-
-### Release Series Upgradeability with Rolling Upgrades
-
-Current release series upgrade compatibility with **rolling** upgrade:
+The following shows the supported upgrade paths.
 
 | From     | To     | Notes                                                         |
 |----------|--------|---------------------------------------------------------------|
+| 3.13.x   | 4.0.x  | Some feature flags **must** be enabled **before** the upgrade |
 | 3.12.x   | 3.13.x |                                                               |
 | 3.11.18  | 3.12.x | All feature flags **must** be enabled **before** the upgrade  |
 | 3.10.x   | 3.11.x | Some feature flags **must** be enabled **before** the upgrade |
 | 3.9.x    | 3.10.x |                                                               |
 | 3.8.x    | 3.9.x  |                                                               |
 | 3.7.18   | 3.8.x  |                                                               |
+</details>
 
-### Release Series Upgradeability with Full Stop Upgrades
-
-Current release series upgrade compatibility with **full stop** upgrade:
-
-| From     | To     | Notes                                                        |
-|----------|--------|--------------------------------------------------------------|
-| 3.12.x   | 3.13.x |                                                               |
-| 3.11.18  | 3.12.x | All feature flags should be enabled **before** this upgrade  |
-| 3.10.x   | 3.11.x | Some feature flags should be enabled **before** this upgrade |
-| 3.9.x    | 3.10.x |                                                              |
-| 3.8.x    | 3.9.x  |                                                              |
-| 3.7.27   | 3.9.x  |                                                              |
-| 3.6.x    | 3.8.x  |                                                              |
-| 3.6.x    | 3.7.x  |                                                              |
-| 3.5.x    | 3.7.x  |                                                              |
-| =< 3.4.x | 3.6.16 |                                                              |
-
+:::note
+RabbitMQ 3.13 included experimental support for Khepri. However, major changes
+had to be introduced since then, leading to incompatibilities between Khepri support
+in 3.13 and 4.0. Therefore, RabbitMQ 3.13 with Khepri enabled **cannot** be upgraded
+to 4.0. [Blue-Green Upgrade](./blue-green-upgrade) can still be used in this situation,
+since technically it is not an upgrade, but rather a migration to a fresh cluster.
+:::
 
 ## Erlang Version Requirements {#rabbitmq-erlang-version-requirement}
 
+Please refer to the [Erlang Version Requirements](./which-erlang) guide
+to learn the minimum required and maximum supported version of Erlang for a given RabbitMQ version.
+
+It's generally recommended to use the latest Erlang version supported by the target RabbitMQ version.
+
 We recommend that you upgrade Erlang together with RabbitMQ.
-Please refer to the [Erlang Version Requirements](./which-erlang) guide.
-
-
-## Features that Do Not Support In-place Upgrades {#unsupported-inplace-upgrade}
-
-[Priority queue](./priority) on disk data currently cannot be migrated in place between 3.6 and any later series.
-If an upgrade is performed in place, such queues would start empty (without any messages) after node restart.
-
-To migrate an environment with priority queues and preserve their content (messages),
-a [blue-green upgrade](./blue-green-upgrade) strategy should be used.
-
 
 ## Plugin Compatibility Between Versions {#rabbitmq-plugins-compatibility}
 
-Unless otherwise specified in release notes, RabbitMQ plugin API
-introduces no breaking changes within a release series (e.g. between
-`3.12.5` and `3.12.13`). If upgrading to a new minor or major version
-(e.g. `3.13.2`), plugin must be upgraded to their versions that support
-the new RabbitMQ version series.
-
-In rare cases patch versions of RabbitMQ can break some plugin APIs.
-Such cases will be documented in the breaking changes section of the release notes document.
-
-[Community plugins page](/community-plugins) contains information on RabbitMQ
-version support for plugins not included into the RabbitMQ distribution.
+Plugins included in the RabbitMQ distribution are guaranteed to be compatible with the
+version they are distributed with. If [community plugins](/community-plugins) are used,
+they need to be verified separately.
 
 ### Management Plugin Upgrades {#management-ui}
 
@@ -230,281 +175,122 @@ RabbitMQ management plugin comes with a Web application that runs in the browser
 
 After upgrading a cluster, it is highly recommended to clear browser cache,
 local storage, session storage and cookies for the domain(s) used to access the management UI.
-
-### Discontinued Plugins
-
-Sometimes a new feature release drops a plugin or multiple plugins from the distribution.
-For example, `rabbitmq_management_visualiser` no longer ships with RabbitMQ as of
-3.7.0. Such plugins **must be disabled** before the upgrade.
-A node that has a missing plugin enabled will fail to start.
+Otherwise, you may experience JavaScript errors.
 
 
-## Changes in System Resource Usage and Reporting {#system-resource-usage}
+## Upgrade Considerations
 
-Different versions of RabbitMQ can have different resource usage. That
+### Changes in System Resource Usage {#system-resource-usage}
+
+During and after the upgrade, connections and queues will be balanced
+differently between the nodes: as nodes go down, connections
+will be reestablished on the remaining nodes and queue leaders will be reelected.
+It is important to make sure your cluster can sustain the workload while some,
+usually one, node is down for the upgrade. Performing the upgrade during low
+traffic hours is recommended.
+
+Additionally, different versions of RabbitMQ can have different resource usage. That
 should be taken into account before upgrading: make sure there's enough
 capacity to run the workload with the new version. Always consult with
 the release notes of all versions between the one currently deployed and the
 target one in order to find out about changes which could impact
 your workload and resource usage.
 
-
-## Single Node and Cluster Upgrades {#clusters}
-
 ### Upgrading a Single Node Installation {#single-node-upgrade}
 
-Upgrading single node installation is similar to upgrading clusters. [Feature flags](./feature-flags) should be enabled after each
-upgrade (it's always a good idea to double-check by enabling them before the next upgrade as well - if they are already
-enabled, it will just do nothing). You should also follow the [upgrade compatibility matrix](#rabbitmq-version-upgradability).
+There are no fundamental differences between upgrading a single node installation compared
+to upgrading a multi-node cluster.
 
-Client (application) connections will be dropped when the node stops. Applications need to be
-prepared to handle this and reconnect.
-
-With some distributions (e.g. the generic binary UNIX) you can install a newer version of
-RabbitMQ without removing or replacing the old one, which can make upgrade faster.
-You should make sure the new version [uses the same data directory](./relocate).
-
-RabbitMQ does not support downgrades; it's strongly advised to back node's data directory up before
-upgrading.
+#### Upgrading Development Environments {#upgrading-dev-environments}
 
 Single node deployments are often local development or test environments. In such cases, if
-the upgrade involves jumping multiple release series (eg. from `3.8.15` to `3.13.2`),
-it's easier to simply delete everything in the data directory and go directly
-to the desired version. Effectively, it's no longer an upgrade but a fresh installation of the new version.
+the messages stored in RabbitMQ are not important, it may be easier to simply
+delete everything in the data directory and start a fresh node of the new version. Effectively,
+it's no longer an upgrade but a fresh installation of the new version.
+
 Please note that this process will **delete all data** in your RabbitMQ (definitions and messages), but this is usually
-not a problem in a developement/test environment. The definitions can be preserved using [export/import](./definitions).
+not a problem in a development/test environment. The definitions can be preserved using [export/import](./definitions).
+The benefit of this approach is that you can easily jump from any version to any other version without worrying
+about compatibility and feature flags.
 
-### Upgrading Multiple Nodes {#multiple-nodes-upgrade}
+### Downgrades
 
-Depending on what versions are involved in an upgrade, RabbitMQ cluster
-*may* provide an opportunity to perform upgrades without cluster
-downtime using a procedure known as rolling upgrade. A rolling upgrade
-is when nodes are stopped, upgraded and restarted one-by-one, with the
-rest of the cluster still running while each node is being upgraded.
+RabbitMQ does not officially support downgrades - they are not tested and should not be relied upon.
+Users who want extra safety can use [blue-green deployment](./blue-green-upgrade) approach,
+which allows switching back to the old environment.
 
-If rolling upgrades are not possible, the entire cluster should be
-stopped, then restarted. This is referred to as a full stop upgrade.
+Having said that, downgrades technically work between some versions, especially if they only differ by a patch release.
+It is not guaranteed however: there have been patch releases that could not be downgraded even to the immediately
+preceding patch release.
 
-Client (application) connections will be dropped when each node stops. Applications need to be
-prepared to handle this and reconnect.
+### Backup
 
-### Rolling Upgrades {#rolling-upgrades}
+It's strongly advised to back node's data directory up before upgrading.
 
-Rolling upgrades are possible only between compatible RabbitMQ and Erlang versions.
+### When to Restart Nodes {#maintaining-quorum}
 
-#### With RabbitMQ 3.8 or Later Versions {#rolling-upgrade-starting-with-3.8}
+Multiple components and features depend on the availability of a quorum of nodes. In the most common
+case of a 3-node cluster, this means that 2 nodes should always be available during the upgrade.
 
-RabbitMQ provides a [feature flag](./feature-flags) subsystem which is
-responsible for determining if two RabbitMQ nodes of different versions are compatible with respect
-to a certain feature, important internal implementation detail or behavior.
-
-If they are, then two nodes with different versions can run side-by-side in the
-same cluster: this allows a rolling upgrade of cluster members without
-shutting down the cluster entirely.
-
-To learn more, please read the [feature flags documentation](./feature-flags).
-
-
-### When to Restart Nodes {#rolling-upgrades-restarting-nodes}
-
-It is important to let the node being upgraded to fully start and sync
-all data from its peers before proceeding to upgrade the next one. You
-can check for that via the management UI. Confirm that:
-
-* the `rabbitmqctl await_startup` (or `rabbitmqctl wait <pidfile>`) command returns
-* the node starts and rejoins its cluster according to the management overview page or `rabbitmq-diagnostics cluster_status`
-* the node is not quorum-critical for any [quorum queues](#quorum-queues) and streams it hosts
-
-During a rolling upgrade, client connection recovery will make sure that connections
-are rebalanced. Primary queue replicas will migrate to other nodes.
-In practice this will put more load on the remaining cluster nodes.
-This can impact performance and stability of the cluster.
-It's not recommended to perform rolling upgrades under high load.
-
-Nodes can be put into maintenance mode to prepare them for
-shutdown during rolling upgrades. This is covered below.
-
-### After Restarting All Nodes {#after-restarting}
-
-After performing a rolling upgrade and putting the last node out of [maintenance mode](#maintenance-mode),
-perform the following steps:
-
- * Enable all [feature flags](./feature-flags) in the cluster using `rabbitmqctl enable_feature_flag all`
- * Rebalance all queue and stream leader replicas with `rabbitmq-queues rebalance all`
-
-Enabling all feature flags is **very important** for future upgrade, which may require all
-feature flags from certain earlier versions to be enabled.
-
-Rebalancing of queue and stream leader replicas helps spread the load across
-all cluster nodes.
-
-
-## Grow-then-Shrink Upgrades {#grow-then-shrink}
-
-:::note
-This strategy involves node identity changes and replica transfers to the newly added nodes.
-
-With quorum queues and streams that have large data sets, this means that the cluster will
-experience substantial network traffic volume and disk I/O spikes that a rolling in-place upgrade would not.
-
-Consider using [in-place upgrades](#in-place) or [Blue/Green deployment upgrades](./blue-green-upgrade) instead.
-:::
-
-:::danger
-In order to safely perform a grow-then-shrink upgrade, several precautions must be taken
-:::
-
-A Grow-then-Shrink upgrade usually involves the following steps. Consider a three node cluster with nodes
-A, B, and C:
-
- * Add a new node, node D, to the cluster
- * Place a new replica of every quorum queue and every stream to the new node using commands such as `rabbitmq-queues grow`
- * Check that the cluster is in a good state: no [alarms](./alarms) are in effect, no ongoing queue or stream replica sync operations
-   and the system is otherwise under a reasonable load
- * Remove node A from the cluster using `rabbitmqctl forget_cluster_node`
- * Add a new node, node E, to the cluster
- * Place a new replica of every quorum queue and every stream to the new node using commands such as `rabbitmq-queues grow`
- * Check that the cluster is in a good state
- * Remove node B from the cluster using `rabbitmqctl forget_cluster_node`
- * and so on
-
-This approach may seem like one that strikes a good balance between the relative simplicity of
-in-place upgrades and the safety of Blue-Green deployment upgrades. However, in practice this
-strategy has comparable characteristics to the in-place upgrade option:
-
- * Newly added nodes may affect the existing cluster state
- * Replicas will migrate between nodes during the upgrade process
-
-In addition, this approach has its own unique potential risks:
-
- * Node identities change during the upgrade process, which can affect [historical monitoring data](./monitoring/)
- * Nodes must transfer their data sets to the newly added members, which can result in a **very substantial increase
-   in network traffic and disk I/O**
- * Premature removal of nodes (see below) can lead to a quorum loss for a subset of quorum queues and streams
-
-:::danger
-In order to safely perform a grow-then-shrink upgrade, several precautions must be taken
-:::
-
-In order to safely perform a grow-then-shrink upgrade, several precautions must be taken:
-
- * After a new node is added and a replica extension process is initiated, the process must
-   be given enough time to complete
- * Before a node is removed, a health check must be run to ensure that it is not quorum critical for any queues (or streams):
-   that is, that the removal of the node will not leave any quorum queues or streams without an online majority
- * Nodes must be removed from the cluster explicitly using `rabbitmqctl forget_cluster_node`
-
-[Streams](./streams/) specifically were not designed for environments where replica (node) identity change is frequent,
-and all replicas can be transferred away and replaced over duration of a single cluster upgrade.
-
-### Key Precautions
-
-To determine if a node is quorum critical, use the following [health check](./monitoring#health-checks):
+RabbitMQ provides a [health check](./monitoring#health-checks) command that would fail
+should any quorum queues, stream queues or other internal components on the target node lose their quorum, if that node was to be shut down:
 
 <Tabs groupId="shell-specific">
 <TabItem value="bash" label="bash" default>
 ```bash
-# exits with a non-zero status if shutting down target node would leave some quorum queues
-# or streams without an online majority
+# exits with a non-zero code if any of the internal components, quorum queues or stream queues
+# will lose online quorum should the target node be shut down;
+# additionally, it will print which components and/or queues are affected
 rabbitmq-diagnostics check_if_node_is_quorum_critical
 ```
 </TabItem>
 <TabItem value="PowerShell" label="PowerShell">
 ```PowerShell
-# exits with a non-zero status if shutting down target node would leave some quorum queues
-# or streams without an online majority
+# exits with a non-zero code if any of the internal components, quorum queues or stream queues
+# will lose online quorum should the target node be shut down;
+# additionally, it will print which components and/or queues are affected
 rabbitmq-diagnostics.bat check_if_node_is_quorum_critical
 ```
 </TabItem>
 </Tabs>
 
-The following [health check](./monitoring#health-checks) must be used to determine if there may be
-any remaining initial quorum queue replica log transfers:
+For example, consider a three node cluster with nodes A, B, and C and some quorum queues. If node B is currently down,
+this check will fail if executed against node A or C, because if A or C went down, there would only be one node running
+(and therefore, there would be no quorum). When node B comes back online, the same check would succeed.
+
+When automating the upgrade process, you can use `rabbitmq-upgrade await_online_quorum_plus_one` command
+to block the node shutdown process until there is enough nodes running to maintain quorum. Note that
+some deployment options already incorporate this check - for example, when running RabbitMQ on Kubernetes
+using the [Cluster Operator](./kubernetes/operator/operator-overview), this is already a part of the `preStop` hook.
+
+### Rebalancing Queue Leaders {#rebalance}
+
+If either the rolling or grown-then-shrink upgrade strategy is used, queue leaders will not be evenly distributed
+between the nodes. Rebalancing of queue and stream leaders helps spread the load across all cluster nodes.
+
+To rebalance all queue and stream leader replicas, run:
 
 <Tabs groupId="shell-specific">
 <TabItem value="bash" label="bash" default>
 ```bash
-# exits with a non-zero status if there are any ongoing initial quorum queue
-# replica sync operations
-rabbitmq-diagnostics check_if_new_quorum_queue_replicas_have_finished_initial_sync
+rabbitmq-queues rebalance all
 ```
 </TabItem>
 <TabItem value="PowerShell" label="PowerShell">
 ```PowerShell
-# exits with a non-zero status if there are any ongoing initial quorum queue
-# replica sync operations
-rabbitmq-diagnostics.bat check_if_new_quorum_queue_replicas_have_finished_initial_sync
+rabbitmq-queues.bat rebalance all
 ```
 </TabItem>
 </Tabs>
 
-:::tip
-Consider adding and removing a single node at a time
-:::
+### Full-Stop Upgrades {#full-stop-upgrades}
 
-If multiple nodes are added and removed at a time, the health checks must be performed on all of them.
-Removing multiple nodes at a time is more likely to leave certain quorum queues or streams without
-an online majority, therefore it is highly recommended to add and remove a single node at a time.
-
-
+There is no need to stop all nodes in a cluster to perform an upgrade.
 
 ## Maintenance Mode {#maintenance-mode}
 
-### What is Maintenance Mode?
-
 Maintenance mode is a special node operation mode that can be useful during upgrades.
 The mode is explicitly turned on and off by the operator using a bunch of new CLI commands covered below.
-For mixed-version cluster compatibility, this feature must be [enabled using a feature flag](./feature-flags)
-once all cluster members have been upgraded to a version that supports it:
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-rabbitmqctl enable_feature_flag maintenance_mode_status
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-rabbitmqctl.bat enable_feature_flag maintenance_mode_status
-```
-</TabItem>
-</Tabs>
-
-
-### Put a Node into Maintenance Mode
-
-To put a node under maintenance, use `rabbitmq-upgrade drain`:
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-rabbitmq-upgrade drain
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-rabbitmq-upgrade.bat drain
-```
-</TabItem>
-</Tabs>
-
-As all other CLI commands, this command can be invoked against an arbitrary node (including remote ones)
-using the `-n` switch:
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-# puts node rabbit@node2.cluster.rabbitmq.svc into maintenance mode
-rabbitmq-upgrade drain -n rabbit@node2.cluster.rabbitmq.svc
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-# puts node rabbit@node2.cluster.rabbitmq.svc into maintenance mode
-rabbitmq-upgrade.bat drain -n rabbit@node2.cluster.rabbitmq.svc
-```
-</TabItem>
-</Tabs>
 
 When a node is in maintenance mode, it **will not be available for serving client traffic**
 and will try to transfer as many of its responsibilities as practically possible and safe.
@@ -529,14 +315,27 @@ A node in maintenance mode is expected to be shut down, upgraded or reconfigured
 time window (say, 5-30 minutes). Nodes are not expected to be running in this mode permanently or
 for long periods of time.
 
-### Revive a Node from Maintenance Mode
+### Enabling Maintenance Mode
+
+To put a node into maintenance, use `rabbitmq-upgrade drain`:
+
+<Tabs groupId="shell-specific">
+<TabItem value="bash" label="bash" default>
+```bash
+rabbitmq-upgrade drain
+```
+</TabItem>
+<TabItem value="PowerShell" label="PowerShell">
+```PowerShell
+rabbitmq-upgrade.bat drain
+```
+</TabItem>
+</Tabs>
+
+### Disabling Maintenance Mode
 
 :::tip
-The command described below exists to roll back (to the extent possible) the effects of
-the `drain` one mentioned above.
-
-It is not necessary to run it after a node restart because a restarted node will reset its
-maintenance mode state.
+A restart takes the node out of maintenance mode automatically.
 :::
 
 A node in maintenance mode can be *revived*, that is, **brought back into its regular operational state**,
@@ -555,330 +354,17 @@ rabbitmq-upgrade.bat revive
 </TabItem>
 </Tabs>
 
-The command exists to roll back (to the extent possible) the effects of the `drain` one.
+The command exists to roll back (to the extent possible) the effects of the `drain` command.
+It is only necessary to run this command if you decided you can't restart the node as planned. 
 
-It is not necessary to run it after a node restart because a restarted node will reset its
-maintenance mode state.
+It is **not** necessary to revive a node after it was restarted/upgraded, because the restart
+automatically takes the node out of maintenance mode.
 
-As all other CLI commands, this command can be invoked against an arbitrary node (including remote ones)
-using the `-n` switch:
+### Checking Maintenance Status
 
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-# revives node rabbit@node2.cluster.rabbitmq.svc from maintenance
-rabbitmq-upgrade revive -n rabbit@node2.cluster.rabbitmq.svc
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-# revives node rabbit@node2.cluster.rabbitmq.svc from maintenance
-rabbitmq-upgrade.bat revive -n rabbit@node2.cluster.rabbitmq.svc
-```
-</TabItem>
-</Tabs>
-
-When a node is revived or restarted (e.g. after an upgrade), it will again accept client connections
-and be considered for primary queue replica placements.
-
-It will not recover previous client connections as RabbitMQ never initiates connections
-to clients, but clients will be able to reconnect to it.
-
-### Verify Maintenance Status of a Node
-
-If the maintenance mode status feature flag is enabled, node maintenance status will be reported
-in `rabbitmq-diagnostics status` and `rabbitmq-diagnostics cluster_status`.
-
-Here's an example `rabbitmq-diagnostics status` output of a node under maintenance:
-
-```
-Status of node rabbit@hostname ...
-Runtime
-
-OS PID: 25531
-OS: macOS
-Uptime (seconds): 48540
-Is under maintenance?: true
-
-# ...
-```
-
-Compare this to this example output from a node in regular operating mode:
-
-```
-Status of node rabbit@hostname ...
-Runtime
-
-OS PID: 25531
-OS: macOS
-Uptime (seconds): 48540
-Is under maintenance?: false
-
-# ...
-```
-
-
-## Full-Stop Upgrades {#full-stop-upgrades}
-
-When an entire cluster is stopped for upgrade, the order in which nodes are
-stopped and started is important.
-
-RabbitMQ will automatically update its data directory
-if necessary when upgrading between major or minor versions.
-In a cluster, this task is performed by the first disc node to be started
-(the "upgrader" node).
-
-When upgrading a RabbitMQ cluster using the "full stop" method,
-a node with stable durable storage must start first.
-
-During an upgrade, the last disc node to go down must be the first node to
-be brought online. Otherwise the started node will emit an error message and
-fail to start up. Unlike an ordinary cluster restart, upgrading nodes will not wait
-for the last disc node to come back online.
-
-While not strictly necessary, it is a good idea to decide ahead of time
-which disc node will be the upgrader, stop that node last, and start it first.
-Otherwise changes to the cluster configuration that were made between the
-upgrader node stopping and the last node stopping will be lost.
-
-
-## Recommended Upgrade Steps {#recommended-upgrade-steps}
-
-### Understand What the Most Recent Release Is
-
- See [Release Information](/release-information) to find out what the most recent
- available version is.
-
- Upgrading to the oldest series is highly recommended.
-
-
-### Carefully Read the Release Notes Up to the Selected RabbitMQ Version
-
-The release notes may indicate specific additional upgrade steps.
-Always consult with the release notes of all versions between the
-one currently deployed and the target one.
-
-
-### Enable Required Feature Flags Before Attempting the Upgrade
-
-Some versions, such as 3.11 and 3.12, [require some or all previously existing feature flags](./feature-flags#core-feature-flags)
-to be enabled **before** the upgrade. If all feature flags were enabled after the
-previous upgrade, this should already be the case. However, it's better to verify
-the state of feature flags with
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-rabbitmqctl list_feature_flags --formatter=pretty_table
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-rabbitmqctl.bat list_feature_flags --formatter=pretty_table
-```
-</TabItem>
-</Tabs>
-
-
-and enable all feature flags with
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-rabbitmqctl enable_feature_flag all
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-rabbitmqctl.bat enable_feature_flag all
-```
-</TabItem>
-</Tabs>
-
-Repeat these steps [at the end of the upgrade process](#enable-ff-after-upgrade)
-to fully take advantage of the new features and be prepared for the next upgrade in the future.
-
-### Check Currently Used RabbitMQ Version
-
-Some upgrade paths, e.g. from 3.10.x to 3.13.x, will require an intermediate upgrade
-or even multiple intermediate upgrades.
-
-See the [RabbitMQ Version Upgradability](#rabbitmq-version-upgradability) section above.
-
-
-### Check Erlang Version Requirements
-
-Check if the current Erlang version is supported by the new RabbitMQ version.
-See the [Erlang Version Requirements](./which-erlang) guide.
-If not, Erlang should be upgraded together with RabbitMQ.
-
-It's generally recommended to upgrade to the latest Erlang version supported to
-get all the latest bugfixes.
-
-### Make Sure All Package Dependencies (including Erlang) are Available.
-
-If you are using Debian or RPM packages, you must ensure
-that all dependencies are available. In particular, the
-correct version of Erlang. You may have to setup additional
-third-party package repositories to achieve that.
-
-Please read recommendations for
-[Debian-based](./which-erlang#debian) and
-[RPM-based](./which-erlang#redhat) distributions to find the
-appropriate repositories for Erlang.
-
-### If running RabbitMQ in a cluster, select the cluster upgrade strategy.
-
-It can be possible to do a rolling upgrade,
-if Erlang version and RabbitMQ version changes support it.
-
-See the [Upgrading Multiple Nodes](#multiple-nodes-upgrade) section above.
-
-### Assess Cluster Health
-
-Make sure nodes are healthy and there are no [network partition](./partitions) or [disk or memory alarms](./alarms) in effect.
-
-RabbitMQ management UI, CLI tools or HTTP API can be used for
-assessing the health of the system.
-
-The overview page in the management UI displays effective RabbitMQ
-and Erlang versions, multiple cluster-wide metrics and rates. From
-this page ensure that all nodes are running and they are all "green"
-(w.r.t. file descriptors, memory, disk space, and so on).
-
-We recommend recording the number of durable queues, the number
-of messages they hold and other pieces of information about the
-topology that are relevant. This data will help verify that the
-system operates within reasonable parameters after the upgrade.
-
-Use [node health checks](./monitoring#health-checks) to
-vet individual nodes.
-
-Queues in flow state or blocked/blocking connections might be ok,
-depending on your workload. It's up to you to determine if this is
-a normal situation or if the cluster is under unexpected load and
-thus, decide if it's safe to continue with the upgrade.
-
-However, if there are queues in an undefined state (a.k.a. `NaN` or
-"ghost" queues), you should first start by understanding what is
-wrong before starting an upgrade.
-
-### Ensure Cluster Has the Capacity for Upgrading
-
-The upgrade process can require additional resources.
-Make sure there are enough resources available to proceed, in particular free
-memory and free disk space.
-
-When upgrading a cluster using the rolling upgrade strategy,
-be aware that queues and connections can migrate to other nodes
-during the upgrade.
-
-If clients support connections recovery and can connect to different nodes, they will reconnect
-to the nodes that are still running. If clients are configured to create exclusive queues,
-these queues might be recreated on different nodes after client reconnection.
-This will lead to additional memory usage on the running nodes, while
-one of the nodes is being upgraded.
-
-To handle such migrations, make sure you have enough
-spare resources on the remaining nodes so they can handle the extra load.
-Depending on the load balancing strategy all the connections from
-the stopped node can go to a single node, so it should be able to
-handle up to twice as many.
-It's generally a good practice to run a cluster with N+1 redundancy
-(resource-wise), so you always have a capacity to handle a single
-node being down.
-
-### Take a Backup
-
-It's always good to have a backup before upgrading.
-See [backup](./backup) guide for instructions.
-
-To make a proper backup, you may need to stop the entire cluster.
-Depending on your use case, you may make the backup while the
-cluster is stopped for the upgrade.
-
-
-### Perform the Upgrade
-
-It's recommended to upgrade Erlang version together with RabbitMQ, because both
-actions require restart and recent RabbitMQ work better with recent Erlang.
-
-Depending on cluster configuration, you can use either [single node upgrade](#single-node-upgrade),
-[rolling upgrade](#multiple-nodes-upgrade) or [full-stop upgrade](#full-stop-upgrades) strategy.
-
-### Verify that the Upgrade Has Succeeded
-
-Like you did before the upgrade, verify the health and [monitoring data](./monitoring/) to
-make sure all cluster nodes are in good shape and the service is
-running again.
-
-### Enable New Feature Flags {#enable-ff-after-upgrade}
-
-If the new version provides new feature flags, you should
-now enable them if you upgraded all nodes and you are
-sure you do not want to rollback. See the [feature flags guide](./feature-flags).
-
-
-
-## Caveats {#caveats}
-
-There are some minor things to consider during upgrade process when stopping and
-restarting nodes.
-
-### Known Erlang OTP Bugs that Can Affect Upgrades {#otp-bugs}
-
-There are currently no known bugs in the [supported Erlang series](./which-erlang) that can affect upgrades.
-
-### Quorum Queues {#quorum-queues}
-
-[Quorum queues](./quorum-queues) depend on a [quorum](./quorum-queues#what-is-quorum) of nodes to
-be online for any queue operations to succeed. This includes successful new leader election should
-a cluster node that hosts some leaders shut down.
-
-In the context of rolling upgrades, this means that a quorum of nodes must be present at all times
-during an upgrade. If this is not the case, quorum queues will become unavailable and will be not
-able to satisfy their data safety guarantees.
-
-Latest RabbitMQ releases provide a [health check](./monitoring#health-checks) command that would fail
-should any quorum queues on the target node lose their quorum in case the node was to be shut down:
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-# Exits with a non-zero code if one or more quorum queues will lose online quorum
-# should target node be shut down
-rabbitmq-diagnostics check_if_node_is_quorum_critical
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-# Exits with a non-zero code if one or more quorum queues will lose online quorum
-# should target node be shut down
-rabbitmq-diagnostics.bat check_if_node_is_quorum_critical
-```
-</TabItem>
-</Tabs>
-
-For example, consider a three node cluster with nodes A, B, and C. If node B is currently down
-and there are quorum queues having their leader replica on node A, this check will fail if executed
-against node A. When node B comes back online, the same check would succeed because
-the quorum queues with leader on node A would have a quorum of replicas online.
-
-Quorum queue quorum state can be verified by listing queues in the management UI or using `rabbitmq-queues`:
-
-<Tabs groupId="shell-specific">
-<TabItem value="bash" label="bash" default>
-```bash
-rabbitmq-queues -n rabbit@to-be-stopped quorum_status <queue name>
-```
-</TabItem>
-<TabItem value="PowerShell" label="PowerShell">
-```PowerShell
-rabbitmq-queues.bat -n rabbit@to-be-stopped quorum_status <queue name>
-```
-</TabItem>
-</Tabs>
-
+You can check whether any of the nodes in the cluster is in the maintenance mode
+by running `rabbitmqctl cluster_status`. You can also check the status of a specific
+node by running `rabbitmqctl status`.
 
 ## Handling Node Restarts in Applications {#rabbitmq-restart-handling}
 
@@ -925,8 +411,3 @@ Many client libraries libraries support host lists, for example:
 * [Bunny](http://api.rubybunny.info/Bunny/Session.html#constructor_details)
 
 
-## Windows {#windows-upgrade-caveats}
-
-If the value of the environment variable `COMPUTERNAME` does not equal
-`HOSTNAME` (upper vs lower case, or other differences) please see the [Windows Configuration guide](./windows-configuration#computername-vs-hostname)
-for instructions on how to upgrade RabbitMQ.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -48,7 +48,7 @@ Refer to the [rolling upgrade guide](./rolling-upgrade) page for more details, b
   * check [version upgradability](#rabbitmq-version-upgradability)
   * check [Erlang version requirements](#rabbitmq-erlang-version-requirement)
   * check [the release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.0)
-  * verify that all stable [feature flags are enabled](.//feature-flags#how-to-enable-feature-flags)
+  * verify that all stable [feature flags are enabled](./feature-flags#how-to-enable-feature-flags)
 * Check that the node or cluster is in a good state in order to be upgraded
   * no [alarms](./alarms) are in effect
   * no ongoing queue or stream replica sync operations
@@ -261,7 +261,7 @@ this check will fail if executed against node A or C, because if A or C went dow
 When automating the upgrade process, you can use `rabbitmq-upgrade await_online_quorum_plus_one` command
 to block the node shutdown process until there is enough nodes running to maintain quorum. Note that
 some deployment options already incorporate this check - for example, when running RabbitMQ on Kubernetes
-using the [Cluster Operator](./kubernetes/operator/operator-overview), this is already a part of the `preStop` hook.
+using the [Cluster Operator](/kubernetes/operator/operator-overview), this is already a part of the `preStop` hook.
 
 ### Rebalancing Queue Leaders {#rebalance}
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -73,7 +73,7 @@ temporary increasing infrastructure footprint. The safety aspect comes from the 
 can abort an upgrade by switching applications back to the old cluster.
 
 A blue-green upgrade usually involves the following steps performed by a deployment tool or manually
-by an operator. Refer to the [blue-green upgrade guide](./blue-green-upgrade) for more details about these steps:
+by an operator. Refer to the [blue-green deployment guide](./blue-green-upgrade) for more details about these steps:
 
 * Deploy a new cluster with the desired version
 * Synchronie metadata between the old and the new cluster (unless applications can declare their own metadata)
@@ -150,7 +150,7 @@ The following shows the supported upgrade paths.
 RabbitMQ 3.13 included experimental support for Khepri. However, major changes
 had to be introduced since then, leading to incompatibilities between Khepri support
 in 3.13 and 4.0. Therefore, RabbitMQ 3.13 with Khepri enabled **cannot** be upgraded
-to 4.0. [Blue-Green Upgrade](./blue-green-upgrade) can still be used in this situation,
+to 4.0. [Blue-Green Deployment](./blue-green-upgrade) can still be used in this situation,
 since technically it is not an upgrade, but rather a migration to a fresh cluster.
 :::
 

--- a/docs/which-erlang.md
+++ b/docs/which-erlang.md
@@ -60,6 +60,36 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
   <tr>
     <td>
       <ul>
+        <li>4.0.0</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>26.2</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>26.2.x</li>
+      </ul>
+    </td>
+        <td>
+      <ul class="notes">
+        <li>
+          The 4.0 release series is compatible with Erlang 26.2.
+        </li>
+        :::warning
+        RabbitMQ 4.0 works with Erlang/OTP 27. However, there are known performance regressions,
+        which will be addressed in patch releases. Running RabbitMQ 4.0 on Erlang 27 is not recommended
+        in production but is perfectly ok in a development environment.
+        :::
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <ul>
         <li>3.13.7</li>
         <li>3.13.6</li>
         <li>3.13.5</li>

--- a/docs/windows-configuration.md
+++ b/docs/windows-configuration.md
@@ -171,20 +171,6 @@ One of these options can be used to mitigate:
 See [How CLI Tools Authenticate to Nodes (and Nodes to Each Other](./cli#erlang-cookie) in the CLI guide.
 
 
-## COMPUTERNAME is different from HOSTNAME {#computername-vs-hostname}
-
-Older versions of RabbitMQ calculated the node name using the `COMPUTERNAME`
-environment variable, which is always upper-case. Later versions of RabbitMQ
-use `HOSTNAME` which may be lowercase. If you are upgrading from an old
-(pre-`3.6.0`) version of RabbitMQ to a current one and see [the issue described
-here](https://github.com/rabbitmq/rabbitmq-server/issues/1568), you should set
-a system-wide environment variable named `RABBITMQ_NODENAME` with the following
-value: `rabbit@ALL_CAPS_HOSTNAME`.
-
-Then, RabbitMQ will continue to use the all-caps hostname and the upgrade will
-succeed.
-
-
 ## Setting `net_ticktime` {#net-ticktime}
 
 Due to how RabbitMQ starts as a Windows service, you can't use a configuration

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -115,7 +115,7 @@ const sidebars = {
             {
               type: 'doc',
               id: 'blue-green-upgrade',
-              label: 'Blue-Green Upgrade',
+              label: 'Blue-Green Deployment',
             },
             {
               type: 'doc',

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -109,13 +109,23 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              id: 'feature-flags/index',
-              label: 'Feature Flags',
+              id: 'rolling-upgrade',
+              label: 'Rolling Upgrade',
             },
             {
               type: 'doc',
               id: 'blue-green-upgrade',
               label: 'Blue-Green Upgrade',
+            },
+            {
+              type: 'doc',
+              id: 'grow-then-shrink-upgrade',
+              label: 'Grow-Then-Shrink Upgrade',
+            },
+            {
+              type: 'doc',
+              id: 'feature-flags/index',
+              label: 'Feature Flags',
             },
           ],
         },


### PR DESCRIPTION
* split the `upgrade` page into multiple pages
* each upgrade strategy has a dedicated page
* right-hand side table of contents should outline the main steps
* remove references to full-stop upgrades - there has been no need for a full stop upgrade since feature flags were introduced
* remove other notes that are no longer relevant