### PR TITLE
Fix several broken link anchors

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1140,9 +1140,9 @@ contents will be replicated if the node will be selected to host a replica.
 Non-replicated queue contents on a reset node will be lost.
 
 ## Upgrading clusters {#upgrading}
-You can find instructions for upgrading a cluster in
-[the upgrade guide](./upgrade#clusters).
 
+You can find instructions for upgrading a cluster in [the upgrade
+guide](./upgrade).
 
 ## A Cluster on a Single Machine {#single-machine}
 

--- a/docs/feature-flags/index.md
+++ b/docs/feature-flags/index.md
@@ -38,8 +38,8 @@ despite having different versions and thus potentially having different
 feature sets or implementation details.
 
 This subsystem was introduced to allow for **[rolling
-upgrades](./upgrade#rolling-upgrades) of cluster members without shutting
-down the entire cluster**.
+upgrades](./upgrade#rolling-upgrade) of cluster members without shutting down
+the entire cluster**.
 
 :::caution
 Feature flags are not meant to be used as a form of cluster configuration.

--- a/docs/grow-then-shrink-upgrade.md
+++ b/docs/grow-then-shrink-upgrade.md
@@ -27,7 +27,8 @@ This strategy involves node identity changes and replica transfers to the newly 
 With quorum queues and streams that have large data sets, this means that the cluster will
 experience substantial network traffic volume and disk I/O spikes that a rolling in-place upgrade would not.
 
-Consider using [in-place upgrades](#in-place) or [Blue/Green deployment upgrades](./blue-green-upgrade) instead.
+Consider using [in-place upgrades](./upgrade#rolling-upgrade) or [Blue/Green
+deployment upgrades](./blue-green-upgrade) instead.
 :::
 
 :::danger

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -94,12 +94,14 @@ There's also a simplfied version of the blue-green strategy, if some downtime is
 ### Grow-then-Shrink Upgrade
 
 :::danger
-This upgrade strategy changes replica identities, can result in massive unnecessary data transfers between
-nodes, and is only safe with important precautions. Therefore, it is [highly recommended against](#grow-then-shrink).
+This upgrade strategy changes replica identities, can result in massive
+unnecessary data transfers between nodes, and is only safe with important
+precautions. Therefore, it is [highly recommended
+against](./grow-then-shrink-upgrade).
 :::
 
-A [grow-and-shrink upgrade](#grow-then-shrink) usually involves the following steps. Consider a three node cluster with nodes
-A, B, and C:
+A [grow-and-shrink upgrade](./grow-then-shrink-upgrade) usually involves the
+following steps. Consider a three node cluster with nodes A, B, and C:
 
 * Investigate if the current and target versions can be clustered together
   * check [version upgradability](#rabbitmq-version-upgradability); if a rolling upgrade between the old and new version is not supported,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,6 +30,7 @@ const config = {
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
Fix several link anchors broken by #2068. This went unnoticed because Docusaurus emitted warnings only, not errors.

While here, consider broker anchors as errors, si that it doesn’t pass CI in the future.