### PR TITLE
Delete trailing slashes in internal links

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -198,7 +198,7 @@ and more.
 
 ## rabbitmq-queues {#rabbitmq-queues}
 
-[rabbitmq-queues](./man/rabbitmq-queues.8) allows the operator to manage replicas of [replicated queues](./quorum-queues/).
+[rabbitmq-queues](./man/rabbitmq-queues.8) allows the operator to manage replicas of [replicated queues](./quorum-queues).
 It ships with RabbitMQ.
 
 Most commands only support the online mode (when target node is running).
@@ -207,7 +207,7 @@ Most commands only support the online mode (when target node is running).
 
 ## rabbitmq-streams {#rabbitmq-streams}
 
-[rabbitmq-streams](./man/rabbitmq-streams.8) allows the operator to manage replicas of [streams](./streams/).
+[rabbitmq-streams](./man/rabbitmq-streams.8) allows the operator to manage replicas of [streams](./streams).
 It ships with RabbitMQ.
 
 Most commands only support the online mode (when target node is running).

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -420,7 +420,7 @@ the target stream. The protocol includes a topology discovery operation, so well
 libraries will select one of the suitable nodes. This won't be the case when a load balancer is used,
 however.
 
-See [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-to-streams/#well-behaved-clients)
+See [Connecting to Streams](/blog/2021/07/23/connecting-to-streams#well-behaved-clients)
 to learn more.
 
 ### Queue and Stream Leader Replica Placement {#replica-placement}

--- a/docs/confirms.md
+++ b/docs/confirms.md
@@ -486,7 +486,7 @@ to memory consumption growth on the node they are connected to. Finding
 a suitable prefetch value is a matter of trial and error and will vary from
 workload to workload. Values in the 100 through 300 range usually offer
 optimal throughput and do not run significant risk of overwhelming consumers.
-Higher values often [run into the law of diminishing returns](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
+Higher values often [run into the law of diminishing returns](/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3).
 
 Prefetch value of 1 is the most conservative. It will
 significantly reduce throughput, in particular in

--- a/docs/feature-flags/index.md
+++ b/docs/feature-flags/index.md
@@ -473,7 +473,7 @@ The following feature flags are provided by RabbitMQ core.
     <td>3.11.0</td>
     <td>stream_single_active_consumer</td>
     <td>
-      <a href="https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/">Single active consumer for streams</a>
+      <a href="/blog/2022/07/05/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams">Single active consumer for streams</a>
     </td>
   </tr>
   <tr>
@@ -603,7 +603,7 @@ The following feature flags are provided by plugin
     <td>3.12.0</td>
     <td>delete_ra_cluster_mqtt_node</td>
 	<td>
-	  <a href="https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#what-else-improves-with-native-mqtt-in-312">Delete Ra cluster mqtt_node since MQTT client IDs are tracked locally</a>
+	  <a href="/blog/2023/03/21/native-mqtt#what-else-improves-with-native-mqtt-in-312">Delete Ra cluster mqtt_node since MQTT client IDs are tracked locally</a>
 	</td>
   </tr>
   <tr>
@@ -611,7 +611,7 @@ The following feature flags are provided by plugin
     <td>3.12.0</td>
     <td>rabbit_mqtt_qos0_queue</td>
 	<td>
-	  Support <a href="https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type">pseudo queue type for MQTT QoS 0 subscribers</a> omitting a queue process
+	  Support <a href="/blog/2023/03/21/native-mqtt#new-mqtt-qos-0-queue-type">pseudo queue type for MQTT QoS 0 subscribers</a> omitting a queue process
 	</td>
   </tr>
 </table>

--- a/docs/federation-reference.md
+++ b/docs/federation-reference.md
@@ -199,7 +199,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
       <td>
         The queue type of the [internal upstream queue](./federated-exchanges#details) used by exchange federation.
 
-        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues/).
+        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues).
 
         Changing the queue type will delete and recreate the upstream queue by default.
         This may lead to messages getting lost or not routed anywhere during the re-declaration.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -112,7 +112,7 @@ enable it, use [rabbitmq-plugins](./cli):
 rabbitmq-plugins enable rabbitmq_federation
 ```
 
-If [management UI](./management/) is used, it is recommended that
+If [management UI](./management) is used, it is recommended that
 `rabbitmq_federation_management` is also enabled:
 
 ```bash
@@ -462,7 +462,7 @@ Therefore, in order to narrow down the problem, the recommended steps are:
 
  * Inspect federation upstreams
  * Inspect [policies](./parameters#policies), in particular looking for policies with conflicting [priorities](./parameters#policy-priorities)
- * Inspect [node logs](./logging/)
+ * Inspect [node logs](./logging)
 
 #### Inspect Federation Upstreams
 
@@ -480,7 +480,7 @@ rabbitmq-diagnostics.bat list_parameters --formatter=pretty_table
 </TabItem>
 
 <TabItem value="Management UI" label="Management UI">
-Make sure that the `rabbitmq_federation_management` [plugin](./plugins/) is enabled.
+Make sure that the `rabbitmq_federation_management` [plugin](./plugins) is enabled.
 
 Navigate to `Admin` > `Federation Upstreams`.
 </TabItem>

--- a/docs/flow-control.md
+++ b/docs/flow-control.md
@@ -51,5 +51,5 @@ Other components than connections can be in the
 can apply flow control that eventually propagates back to publishing connections.
 
 To find out if consumers and [prefetch settings](./confirms)
-can be key limiting factors, [take a look at relevant metrics](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
+can be key limiting factors, [take a look at relevant metrics](/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3).
 See [Monitoring and Health Checks](./monitoring) guide to learn more.

--- a/docs/install-debian.md
+++ b/docs/install-debian.md
@@ -948,7 +948,7 @@ LimitNOFILE=64000
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 See [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to learn about
 the supported limits and other directives.
@@ -971,7 +971,7 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 ### Verifying the Limit {#verifying-limits}
 

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -70,7 +70,7 @@ Note that modern versions of Erlang can have incompatibilities with older distri
 or ship without much or any testing on older distributions or OS kernel versions.
 
 Older distributions can also lack a recent enough version of OpenSSL.
-[Supported Erlang versions](./which-erlang/) **cannot be used on distributions that do not provide OpenSSL 1.1** as a system library.
+[Supported Erlang versions](./which-erlang) **cannot be used on distributions that do not provide OpenSSL 1.1** as a system library.
 CentOS 7 and Fedora releases older than 26 are examples of such distributions.
 
 Currently the list of supported RPM-based distributions includes
@@ -576,7 +576,7 @@ LimitNOFILE=64000
 ```
 
 If `LimitNOFILE` is set to a value higher than 65536, [the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be
-updated accordingly to increase a [runtime](./runtime/) limit.
+updated accordingly to increase a [runtime](./runtime) limit.
 
 See [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to learn about
 the supported limits and other directives.
@@ -599,7 +599,7 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 ### Without systemd (Older Linux Distributions)
 
@@ -618,7 +618,7 @@ This `soft` limit cannot go higher than the `hard` limit (which defaults to 4096
 and re-login or reboot. Note that limits cannot be changed for running OS processes.
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 For more information about controlling `fs.file-max`
 with `sysctl`, please refer to the excellent

--- a/docs/local-random-exchange.md
+++ b/docs/local-random-exchange.md
@@ -42,7 +42,7 @@ cluster nodes. If this is not the case, some published messages **will be droppe
 
 Request/reply, often called RPC, is a popular pattern to implement with a messaging broker
 like RabbitMQ. One of the popular use cases is a microservices based architecture
-where one service requests data from another service. The pattern is covered in [tutorial six](/tutorials/).
+where one service requests data from another service. The pattern is covered in [tutorial six](/tutorials).
 
 Key requirements to support such a scenario include:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -586,7 +586,7 @@ was stopped using `rabbitmqctl stop_app`.
 
 When debug logging is enabled, the node will log **a lot** of information
 that can be useful for troubleshooting. This log severity is meant to be
-used when troubleshooting, say, the [peer discovery activity](./cluster-formation/).
+used when troubleshooting, say, the [peer discovery activity](./cluster-formation).
 
 For example to log debug messages to a file:
 

--- a/docs/memory-use/index.md
+++ b/docs/memory-use/index.md
@@ -164,7 +164,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>quorum_queue_procs</td>
     <td>Queues</td>
     <td>
-      <a href=".//./quorum-queues">Quorum queue</a> processes, both currently elected leaders and followers.
+      <a href="./quorum-queues">Quorum queue</a> processes, both currently elected leaders and followers.
       Memory footprint can be capped on a per-queue basis.
       See the <a href="./quorum-queues">Quorum Queues</a> guide for more information.
     </td>

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -233,7 +233,7 @@ The latter enables sending messages from an AMQP 0.9.1, AMQP 1.0 or STOMP client
 The benefits of using the MQTT QoS 0 queues type are:
 
 1. Support for larger fanouts, e.g. sending a message from the "cloud" (RabbitMQ) to all devices (MQTT clients).
-1. Lower [memory usage](./memory-use/)
+1. Lower [memory usage](./memory-use)
 1. Lower publisher confirm latency
 1. Lower end-to-end latency
 
@@ -242,7 +242,7 @@ This can happen when the network connection between MQTT subscribing client and 
 
 ### Overload protection
 
-To protect against high [memory usage](./memory-use/) due to MQTT QoS 0 messages piling up in the MQTT connection process mailbox, RabbitMQ intentionally drops QoS 0 messages from the MQTT QoS 0 queue if both conditions are true:
+To protect against high [memory usage](./memory-use) due to MQTT QoS 0 messages piling up in the MQTT connection process mailbox, RabbitMQ intentionally drops QoS 0 messages from the MQTT QoS 0 queue if both conditions are true:
 
 1. the number of messages in the MQTT connection process mailbox exceeds the configured `mqtt.mailbox_soft_limit` (defaults to 200), and
 1. the socket sending to the MQTT client is busy (not sending fast enough due to TCP backpressure).
@@ -724,7 +724,7 @@ Unlike AMQP 0.9.1 and AMQP 1.0, MQTT is not designed to maximise throughput: For
 Every [PUBLISH](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100) packet with QoS 1 needs to be acknowledged individually.
 1. Decrease TCP buffer sizes as described in section [TCP Listener Options](#listener-opts).
 
-This substantially reduces [memory usage](./memory-use/) in environments with many concurrently connected clients.
+This substantially reduces [memory usage](./memory-use) in environments with many concurrently connected clients.
 
 1. Less topic levels (in an MQTT topic and MQTT topic filter) perform better than more topic levels.
 For example, prefer to structure your topic as `city/name` instead of `continent/country/city/name`, if possible.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -71,7 +71,7 @@ RabbitMQ supports most MQTT 5.0 features including the following:
 * [Retained](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901104) messages with the limitations described in section [Retained Messages and Stores](#retained)
 * [MQTT over a WebSocket](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901285) via the [RabbitMQ Web MQTT Plugin](./web-mqtt)
 
-The [MQTT 5.0 blog post](https://blog.rabbitmq.com/posts/2023/07/mqtt5) provides a complete list of supported MQTT 5.0 features including their usage and implementation details.
+The [MQTT 5.0 blog post](/blog/2023/07/21/mqtt5) provides a complete list of supported MQTT 5.0 features including their usage and implementation details.
 
 MQTT clients can interoperate with other protocols.
 For example, MQTT publishers can send messages to AMQP 0.9.1 or AMQP 1.0 consumers if these consumers consume from a queue
@@ -263,7 +263,7 @@ The following Prometheus metric reported by a given RabbitMQ node shows how many
 rabbitmq_global_messages_dead_lettered_maxlen_total{queue_type="rabbit_mqtt_qos0_queue",dead_letter_strategy="disabled"} 0
 ```
 
-The [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
+The [Native MQTT](/blog/2023/03/21/native-mqtt#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
 
 ## Users and Authentication {#authentication}
 
@@ -712,13 +712,13 @@ However, Management API metrics that are tied to AMQP 0.9.1 [channels](./channel
 MQTT is the standard protocol for the Internet of Things (IoT).
 A common IoT workload is that many MQTT devices publish sensor data periodically to the MQTT broker.
 There could be hundreds of thousands, sometimes even millions of IoT devices that connect to the MQTT broker.
-The blog post [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt) demonstrates performance benchmarks of such workloads.
+The blog post [Native MQTT](/blog/2023/03/21/native-mqtt) demonstrates performance benchmarks of such workloads.
 
 This section aims at providing a non-exhaustive checklist with tips and tricks to configure RabbitMQ as an efficient MQTT broker that supports many client connections:
 
 1. Set `management_agent.disable_metrics_collector = true` to disable metrics collection in the [Management plugin](./management).
 The RabbitMQ Management plugin has not been designed for excessive metrics collection.
-In fact, metrics delivery via the management API is [deprecated](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#disable-metrics-delivery-via-the-management-api--ui). Instead, use a tool that has been designed for collecting and querying a huge number of metrics: Prometheus.
+In fact, metrics delivery via the management API is [deprecated](/blog/2021/08/21/4.0-deprecation-announcements#disable-metrics-delivery-via-the-management-api--ui). Instead, use a tool that has been designed for collecting and querying a huge number of metrics: Prometheus.
 1. MQTT packets and subscriptions with QoS 0 provide much better performance than QoS 1.
 Unlike AMQP 0.9.1 and AMQP 1.0, MQTT is not designed to maximise throughput: For example, there are no [multi-acks](./confirms#consumer-acks-multiple-parameter).
 Every [PUBLISH](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100) packet with QoS 1 needs to be acknowledged individually.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -666,7 +666,7 @@ On Windows, the limit for the Erlang runtime is controlled exclusively using the
 
 #### The ERL_MAX_PORTS Environment Variable {#erl-max-ports}
 
-The [runtime](./runtime/) has a related limit, controlled via the `ERL_MAX_PORTS` environment
+The [runtime](./runtime) has a related limit, controlled via the `ERL_MAX_PORTS` environment
 variable.
 
 By default the limit is usually set to 65536. When overriding the max open file handle limit to
@@ -1268,10 +1268,10 @@ reverse_dns_lookups = false
 
 ### The inetrc File
 
-The [Erlang runtime](./runtime/) allows for a number of hostname resolution-related settings to be tuned
+The [Erlang runtime](./runtime) allows for a number of hostname resolution-related settings to be tuned
 using a file known as the [inetrc file](http://erlang.org/doc/apps/erts/inet_cfg.html).
 
-The path to the file can be specified by adding an extra runtime argument using the [`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable](./configure/):
+The path to the file can be specified by adding an extra runtime argument using the [`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable](./configure):
 
 <Tabs groupId="shell-specific">
 <TabItem value="bash" label="bash" default>

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -646,7 +646,7 @@ can be opened at the same time. When an OS process (such as RabbitMQ's Erlang VM
 the limit, it won't be able to open any new files or accept any more
 TCP connections. The limit will also affect how much memory the [Erlang runtime](./runtime)
 will allocate upfront. This means that the limit on some modern distributions
-[can be too high](https://blog.rabbitmq.com/posts/2022/08/high-initial-memory-consumption-of-rabbitmq-nodes-on-centos-stream-9/) and need
+[can be too high](/blog/2022/08/30/high-initial-memory-consumption-of-rabbitmq-nodes-on-centos-stream-9) and need
 lowering.
 
 #### How to Override the Limit

--- a/docs/queues.md
+++ b/docs/queues.md
@@ -323,7 +323,7 @@ the queue is connected to), regardless of the `queue_leader_locator` value.
 [Quorum queues](./quorum-queues) is replicated, data safety and consistency-oriented queue type.
 Classic queues historically supported replication but this feature was **removed** for RabbitMQ 4.x.
 
-Any client [connection](./connections/) can use any queue, whether it is replicated or not,
+Any client [connection](./connections) can use any queue, whether it is replicated or not,
 regardless of the node the queue replica is hosted on or the node the client is connected to.
 RabbitMQ will route the operations to the appropriate node transparently for clients.
 
@@ -335,7 +335,7 @@ Client libraries or applications **may** choose to connect to the node that host
 for improved data locality.
 
 This general rule applies to all messaging data types supported by RabbitMQ except for one.
-[Streams](./streams/) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
+[Streams](./streams) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
 that hosts a replica (a leader of rollower) of the target stream.
 Consequently, RabbitMQ Stream protocol clients will [connect to multiple nodes in parallel](https://www.rabbitmq.com/blog/2021/07/23/connecting-to-streams).
 
@@ -351,7 +351,7 @@ set of supported operations and features.
 
 ## Non-Replicated Queues and Client Operations {#transparent-operation-routing}
 
-Any client [connection](./connections/) can use any queue, including non-replicated (single replica) queues,
+Any client [connection](./connections) can use any queue, including non-replicated (single replica) queues,
 regardless of the node the queue replica is hosted on or the node the client is connected to.
 RabbitMQ will route the operations to the appropriate node transparently for clients.
 
@@ -363,7 +363,7 @@ Client libraries or applications **may** choose to connect to the node that host
 for improved data locality.
 
 This general rule applies to all messaging data types supported by RabbitMQ except for one.
-[Streams](./streams/) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
+[Streams](./streams) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
 that hosts a replica (a leader of rollower) of the target stream.
 Consequently, RabbitMQ Stream protocol clients will [connect to multiple nodes in parallel](https://www.rabbitmq.com/blog/2021/07/23/connecting-to-streams).
 

--- a/docs/quorum-queues/index.md
+++ b/docs/quorum-queues/index.md
@@ -170,7 +170,7 @@ With some queue operations there are minor differences:
 | Global [QoS Prefetch](#global-qos) | yes | no |
 | [Server-named queues](./queues#server-named-queues) | yes | no |
 
-Modern quorum queues also offer [higher throughput and less latency variability](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
+Modern quorum queues also offer [higher throughput and less latency variability](/blog/2022/05/16/rabbitmq-3.10-performance-improvements)
 for many workloads.
 
 ### Queue and Per-Message TTL 
@@ -799,7 +799,7 @@ Note that a node or quorum queue replica failure does not trigger automatic memb
 If a node is failed in an unrecoverable way and cannot be brought back, it must be explicitly removed from the cluster
 or the operator must opt-in and enable the `quorum_queue.continuous_membership_reconciliation.auto_remove` setting.
 
-This also means that [upgrades](./upgrade/) do not trigger automatic membership reconciliation since nodes
+This also means that [upgrades](./upgrade) do not trigger automatic membership reconciliation since nodes
 are expected to come back and only a minority (often just one) node is stopped for upgrading at a time.
 :::
 
@@ -1051,8 +1051,8 @@ in 3, 5 and 7 node configurations with several different message sizes.
 In scenarios using both consumer acks and publisher confirms
 quorum queues have been observed to have superior throughput to
 classic mirrored queues (deprecated in 2021, removed in 2024 for RabbitMQ 4.0).
-For example, take a look at [these benchmarks with 3.10](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
-and [another with 3.12](https://blog.rabbitmq.com/posts/2023/05/rabbitmq-3.12-performance-improvements/#significant-improvements-to-quorum-queues).
+For example, take a look at [these benchmarks with 3.10](/blog/2022/05/16/rabbitmq-3.10-performance-improvements)
+and [another with 3.12](/blog/2023/05/17/rabbitmq-3.12-performance-improvements#significant-improvements-to-quorum-queues).
 
 As quorum queues persist all data to disks before doing anything it is recommended
 to use the fastest disks possible and certain [Performance Tuning](#performance-tuning) settings.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -171,7 +171,7 @@ See [VM flag documentation](http://erlang.org/doc/man/erl.html) for more detaile
 ### Reducing CPU Usage {#cpu-reduce-idle-usage}
 
 CPU usage is by definition very workload-dependent metric. Some workloads naturally use more CPU resources.
-Others use [disk-heavy features such as quorum queues](https://blog.rabbitmq.com/posts/2020/04/quorum-queues-and-why-disks-matter/),
+Others use [disk-heavy features such as quorum queues](/blog/2020/04/21/quorum-queues-and-why-disks-matter),
 and if disk I/O throughput is insufficient, CPU resources will be wasted while nodes are busy waiting for I/O operations to complete.
 
 A couple of general recommendations can be applied to "moderately loaded" systems where a large percentage or

--- a/docs/shovel-dynamic.md
+++ b/docs/shovel-dynamic.md
@@ -227,7 +227,7 @@ For example, this may be necessary when the topology is [imported from a definit
 Using a pre-declared topology avoids a chicken-and-egg problem between the import of definitions and
 Shovel plugin startup: the plugin must be enabled for definitions to pass validation (of the runtime parameters part).
 
-Here is how the plugin can be configured to wait until the source is available [using `rabbitmq.conf`](./configure/):
+Here is how the plugin can be configured to wait until the source is available [using `rabbitmq.conf`](./configure):
 
 ```ini
 # all shovels started on this node will use pre-declared topology

--- a/docs/stomp.md
+++ b/docs/stomp.md
@@ -614,9 +614,9 @@ The default value is `next`.
 When delivering messages from a stream, the message offset (that is the position of the
 message in the stream) is included in the `x-stream-offset` header of the `MESSAGE` frame.
 
-[Stream filtering](https://blog.rabbitmq.com/posts/2023/10/stream-filtering/) is also supported.
+[Stream filtering](/blog/2023/10/16/stream-filtering) is also supported.
 The [stream protocol](./stream) is the preferred way to interact with streams, but most features are also available with other protocols.
-Stream filtering is no exception, it works the same way with STOMP as with [AMQP](https://blog.rabbitmq.com/posts/2023/10/stream-filtering-internals/#bonus-stream-filtering-on-amqp):
+Stream filtering is no exception, it works the same way with STOMP as with [AMQP](/blog/2023/10/24/stream-filtering-internals#bonus-stream-filtering-on-amqp):
 
 * Declaration: a stream can be created on subscription.
 Set the `x-queue-type` header to `stream` and use the `x-stream-filter-size-bytes` header to set the filter size (optional).

--- a/docs/stream-core-plugin-comparison.md
+++ b/docs/stream-core-plugin-comparison.md
@@ -39,7 +39,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
-|[Super stream](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
+|[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
 |Throughput| Hundreds of thousands per second | Millions messages per second    |
 |TLS|Supported (default port: 5671)                     | Supported (default port: 5551)
 

--- a/docs/stream.md
+++ b/docs/stream.md
@@ -202,7 +202,7 @@ stream.advertised_host = rabbitmq-1
 stream.advertised_port = 12345
 ```
 
-The [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-to-streams/) blog post covers why the `advertised_host` and `advertised_port` settings are necessary in some deployments.
+The [Connecting to Streams](/blog/2021/07/23/connecting-to-streams) blog post covers why the `advertised_host` and `advertised_port` settings are necessary in some deployments.
 
 
 ### Maximum Frame Size {#frame-size}

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -274,7 +274,7 @@ The single active consumer feature provides 2 benefits:
 * Messages are processed in order: there is only one consumer at a time.
 * Consumption continuity is maintained: a consumer from the group will take over if the active one stops or crashes.
 
-A [blog post](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/) provides more details on single active consumer for streams.
+A [blog post](/blog/2022/07/05/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams) provides more details on single active consumer for streams.
 
 ### Super Streams {#super-streams}
 
@@ -301,7 +301,7 @@ Use `rabbitmq-streams add_super_stream --help` to learn more about the command.
 Super streams add complexity compared to individual streams, so they should not be considered the default solution for all use cases involving streams.
 Consider using super streams only if you are sure you reached the limits of individual streams.
 
-A [blog post](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams) provides an overview of super streams.
+A [blog post](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) provides an overview of super streams.
 
 ### Filtering {#filtering}
 
@@ -358,7 +358,7 @@ Additional notes on filtering:
 Set the `x-stream-match-unfiltered` argument to `true` to change this behavior and receive _unfiltered_ messages as well.
 * The `x-stream-filter` consumer argument accepts a string but also an array of strings to receive messages for different filter values.
 
-A [first blog post](https://blog.rabbitmq.com/posts/2023/10/stream-filtering/) provides an overview of stream filtering and a [second blog post](https://blog.rabbitmq.com/posts/2023/10/stream-filtering-internals/) covers internals.
+A [first blog post](/blog/2023/10/16/stream-filtering) provides an overview of stream filtering and a [second blog post](/blog/2023/10/24/stream-filtering-internals) covers internals.
 
 ## Feature Comparison: Regular Queues versus Streams {#feature-comparison}
 

--- a/docs/troubleshooting-oauth2.md
+++ b/docs/troubleshooting-oauth2.md
@@ -23,7 +23,7 @@ limitations under the License.
 
 ## Overview {#overview}
 
-This guide covers the most common errors encountered using [OAuth 2.0](./oauth2/) and the [management plugin](./management) and how to diagnose them.
+This guide covers the most common errors encountered using [OAuth 2.0](./oauth2) and the [management plugin](./management) and how to diagnose them.
 
 ## Troubleshooting OAuth 2 in the management UI {#management-ui}
 

--- a/docs/which-erlang.md
+++ b/docs/which-erlang.md
@@ -685,7 +685,7 @@ source, including specific tags from GitHub, a much more pleasant experience.
     <td>
       <ul class="notes">
         <li>
-          <a href="https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/">Erlang/OTP <code>24</code> support announcement</a>
+          <a href="/blog/2021/03/23/erlang-24-support-roadmap">Erlang/OTP <code>24</code> support announcement</a>
         </li>
         <li>Erlang 24 was released on May 12, 2021</li>
         <li>Some community plugins and tools may be incompatible with Erlang 24</li>

--- a/versioned_docs/version-3.13/cli.md
+++ b/versioned_docs/version-3.13/cli.md
@@ -198,7 +198,7 @@ and more.
 
 ## rabbitmq-queues {#rabbitmq-queues}
 
-[rabbitmq-queues](./man/rabbitmq-queues.8) allows the operator to manage replicas of [replicated queues](./quorum-queues/).
+[rabbitmq-queues](./man/rabbitmq-queues.8) allows the operator to manage replicas of [replicated queues](./quorum-queues).
 It ships with RabbitMQ.
 
 Most commands only support the online mode (when target node is running).
@@ -207,7 +207,7 @@ Most commands only support the online mode (when target node is running).
 
 ## rabbitmq-streams {#rabbitmq-streams}
 
-[rabbitmq-streams](./man/rabbitmq-streams.8) allows the operator to manage replicas of [streams](./streams/).
+[rabbitmq-streams](./man/rabbitmq-streams.8) allows the operator to manage replicas of [streams](./streams).
 It ships with RabbitMQ.
 
 Most commands only support the online mode (when target node is running).

--- a/versioned_docs/version-3.13/clustering.md
+++ b/versioned_docs/version-3.13/clustering.md
@@ -425,7 +425,7 @@ the target stream. The protocol includes a topology discovery operation, so well
 libraries will select one of the suitable nodes. This won't be the case when a load balancer is used,
 however.
 
-See [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-to-streams/#well-behaved-clients)
+See [Connecting to Streams](/blog/2021/07/23/connecting-to-streams#well-behaved-clients)
 to learn more.
 
 ### Queue and Stream Leader Replica Placement {#replica-placement}

--- a/versioned_docs/version-3.13/confirms.md
+++ b/versioned_docs/version-3.13/confirms.md
@@ -486,7 +486,7 @@ to memory consumption growth on the node they are connected to. Finding
 a suitable prefetch value is a matter of trial and error and will vary from
 workload to workload. Values in the 100 through 300 range usually offer
 optimal throughput and do not run significant risk of overwhelming consumers.
-Higher values often [run into the law of diminishing returns](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
+Higher values often [run into the law of diminishing returns](/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3).
 
 Prefetch value of 1 is the most conservative. It will
 significantly reduce throughput, in particular in

--- a/versioned_docs/version-3.13/feature-flags/index.md
+++ b/versioned_docs/version-3.13/feature-flags/index.md
@@ -472,7 +472,7 @@ The following feature flags are provided by RabbitMQ core.
     <td>3.11.0</td>
     <td>stream_single_active_consumer</td>
     <td>
-      <a href="https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/">Single active consumer for streams</a>
+      <a href="/blog/2022/07/05/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams">Single active consumer for streams</a>
     </td>
   </tr>
   <tr>
@@ -602,7 +602,7 @@ The following feature flags are provided by plugin
     <td>3.12.0</td>
     <td>delete_ra_cluster_mqtt_node</td>
 	<td>
-	  <a href="https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#what-else-improves-with-native-mqtt-in-312">Delete Ra cluster mqtt_node since MQTT client IDs are tracked locally</a>
+	  <a href="/blog/2023/03/21/native-mqtt#what-else-improves-with-native-mqtt-in-312">Delete Ra cluster mqtt_node since MQTT client IDs are tracked locally</a>
 	</td>
   </tr>
   <tr>
@@ -610,7 +610,7 @@ The following feature flags are provided by plugin
     <td>3.12.0</td>
     <td>rabbit_mqtt_qos0_queue</td>
 	<td>
-	  Support <a href="https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type">pseudo queue type for MQTT QoS 0 subscribers</a> omitting a queue process
+	  Support <a href="/blog/2023/03/21/native-mqtt#new-mqtt-qos-0-queue-type">pseudo queue type for MQTT QoS 0 subscribers</a> omitting a queue process
 	</td>
   </tr>
 </table>

--- a/versioned_docs/version-3.13/federation-reference.md
+++ b/versioned_docs/version-3.13/federation-reference.md
@@ -199,7 +199,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
       <td>
         The queue type of the [internal upstream queue](./federated-exchanges#details) used by exchange federation.
 
-        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues/).
+        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues).
 
         Changing the queue type will delete and recreate the upstream queue by default.
         This may lead to messages getting lost or not routed anywhere during the re-declaration.

--- a/versioned_docs/version-3.13/federation.md
+++ b/versioned_docs/version-3.13/federation.md
@@ -112,7 +112,7 @@ enable it, use [rabbitmq-plugins](./cli):
 rabbitmq-plugins enable rabbitmq_federation
 ```
 
-If [management UI](./management/) is used, it is recommended that
+If [management UI](./management) is used, it is recommended that
 `rabbitmq_federation_management` is also enabled:
 
 ```bash
@@ -462,7 +462,7 @@ Therefore, in order to narrow down the problem, the recommended steps are:
 
  * Inspect federation upstreams
  * Inspect [policies](./parameters#policies), in particular looking for policies with conflicting [priorities](./parameters#policy-priorities)
- * Inspect [node logs](./logging/)
+ * Inspect [node logs](./logging)
 
 #### Inspect Federation Upstreams
 
@@ -480,7 +480,7 @@ rabbitmq-diagnostics.bat list_parameters --formatter=pretty_table
 </TabItem>
 
 <TabItem value="Management UI" label="Management UI">
-Make sure that the `rabbitmq_federation_management` [plugin](./plugins/) is enabled.
+Make sure that the `rabbitmq_federation_management` [plugin](./plugins) is enabled.
 
 Navigate to `Admin` > `Federation Upstreams`.
 </TabItem>

--- a/versioned_docs/version-3.13/flow-control.md
+++ b/versioned_docs/version-3.13/flow-control.md
@@ -51,5 +51,5 @@ Other components than connections can be in the
 can apply flow control that eventually propagates back to publishing connections.
 
 To find out if consumers and [prefetch settings](./confirms)
-can be key limiting factors, [take a look at relevant metrics](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
+can be key limiting factors, [take a look at relevant metrics](/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3).
 See [Monitoring and Health Checks](./monitoring) guide to learn more.

--- a/versioned_docs/version-3.13/install-debian.md
+++ b/versioned_docs/version-3.13/install-debian.md
@@ -948,7 +948,7 @@ LimitNOFILE=64000
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 See [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to learn about
 the supported limits and other directives.
@@ -971,7 +971,7 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 ### Verifying the Limit {#verifying-limits}
 

--- a/versioned_docs/version-3.13/install-rpm.md
+++ b/versioned_docs/version-3.13/install-rpm.md
@@ -70,7 +70,7 @@ Note that modern versions of Erlang can have incompatibilities with older distri
 or ship without much or any testing on older distributions or OS kernel versions.
 
 Older distributions can also lack a recent enough version of OpenSSL.
-[Supported Erlang versions](./which-erlang/) **cannot be used on distributions that do not provide OpenSSL 1.1** as a system library.
+[Supported Erlang versions](./which-erlang) **cannot be used on distributions that do not provide OpenSSL 1.1** as a system library.
 CentOS 7 and Fedora releases older than 26 are examples of such distributions.
 
 Currently the list of supported RPM-based distributions includes
@@ -576,7 +576,7 @@ LimitNOFILE=64000
 ```
 
 If `LimitNOFILE` is set to a value higher than 65536, [the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be
-updated accordingly to increase a [runtime](./runtime/) limit.
+updated accordingly to increase a [runtime](./runtime) limit.
 
 See [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to learn about
 the supported limits and other directives.
@@ -599,7 +599,7 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 ### Without systemd (Older Linux Distributions)
 
@@ -618,7 +618,7 @@ This `soft` limit cannot go higher than the `hard` limit (which defaults to 4096
 and re-login or reboot. Note that limits cannot be changed for running OS processes.
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 For more information about controlling `fs.file-max`
 with `sysctl`, please refer to the excellent

--- a/versioned_docs/version-3.13/logging.md
+++ b/versioned_docs/version-3.13/logging.md
@@ -592,7 +592,7 @@ was stopped using `rabbitmqctl stop_app`.
 
 When debug logging is enabled, the node will log **a lot** of information
 that can be useful for troubleshooting. This log severity is meant to be
-used when troubleshooting, say, the [peer discovery activity](./cluster-formation/).
+used when troubleshooting, say, the [peer discovery activity](./cluster-formation).
 
 For example to log debug messages to a file:
 

--- a/versioned_docs/version-3.13/memory-use/index.md
+++ b/versioned_docs/version-3.13/memory-use/index.md
@@ -164,7 +164,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>quorum_queue_procs</td>
     <td>Queues</td>
     <td>
-      <a href=".//./quorum-queues">Quorum queue</a> processes, both currently elected leaders and followers.
+      <a href="./quorum-queues">Quorum queue</a> processes, both currently elected leaders and followers.
       Memory footprint can be capped on a per-queue basis.
       See the <a href="./quorum-queues">Quorum Queues</a> guide for more information.
     </td>

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -233,7 +233,7 @@ The latter enables sending messages from an AMQP 0.9.1, AMQP 1.0 or STOMP client
 The benefits of using the MQTT QoS 0 queues type are:
 
 1. Support for larger fanouts, e.g. sending a message from the "cloud" (RabbitMQ) to all devices (MQTT clients).
-1. Lower [memory usage](./memory-use/)
+1. Lower [memory usage](./memory-use)
 1. Lower publisher confirm latency
 1. Lower end-to-end latency
 
@@ -242,7 +242,7 @@ This can happen when the network connection between MQTT subscribing client and 
 
 ### Overload protection
 
-To protect against high [memory usage](./memory-use/) due to MQTT QoS 0 messages piling up in the MQTT connection process mailbox, RabbitMQ intentionally drops QoS 0 messages from the MQTT QoS 0 queue if both conditions are true:
+To protect against high [memory usage](./memory-use) due to MQTT QoS 0 messages piling up in the MQTT connection process mailbox, RabbitMQ intentionally drops QoS 0 messages from the MQTT QoS 0 queue if both conditions are true:
 
 1. the number of messages in the MQTT connection process mailbox exceeds the configured `mqtt.mailbox_soft_limit` (defaults to 200), and
 1. the socket sending to the MQTT client is busy (not sending fast enough due to TCP backpressure).
@@ -688,7 +688,7 @@ Unlike AMQP 0.9.1 and AMQP 1.0, MQTT is not designed to maximise throughput: For
 Every [PUBLISH](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100) packet with QoS 1 needs to be acknowledged individually.
 1. Decrease TCP buffer sizes as described in section [TCP Listener Options](#listener-opts).
 
-This substantially reduces [memory usage](./memory-use/) in environments with many concurrently connected clients.
+This substantially reduces [memory usage](./memory-use) in environments with many concurrently connected clients.
 
 1. Less topic levels (in an MQTT topic and MQTT topic filter) perform better than more topic levels.
 For example, prefer to structure your topic as `city/name` instead of `continent/country/city/name`, if possible.

--- a/versioned_docs/version-3.13/mqtt.md
+++ b/versioned_docs/version-3.13/mqtt.md
@@ -71,7 +71,7 @@ RabbitMQ supports most MQTT 5.0 features including the following:
 * [Retained](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901104) messages with the limitations described in section [Retained Messages and Stores](#retained)
 * [MQTT over a WebSocket](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901285) via the [RabbitMQ Web MQTT Plugin](./web-mqtt)
 
-The [MQTT 5.0 blog post](https://blog.rabbitmq.com/posts/2023/07/mqtt5) provides a complete list of supported MQTT 5.0 features including their usage and implementation details.
+The [MQTT 5.0 blog post](/blog/2023/07/21/mqtt5) provides a complete list of supported MQTT 5.0 features including their usage and implementation details.
 
 MQTT clients can interoperate with other protocols.
 For example, MQTT publishers can send messages to AMQP 0.9.1 or AMQP 1.0 consumers if these consumers consume from a queue
@@ -263,7 +263,7 @@ The following Prometheus metric reported by a given RabbitMQ node shows how many
 rabbitmq_global_messages_dead_lettered_maxlen_total{queue_type="rabbit_mqtt_qos0_queue",dead_letter_strategy="disabled"} 0
 ```
 
-The [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
+The [Native MQTT](/blog/2023/03/21/native-mqtt#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
 
 ## Users and Authentication {#authentication}
 MQTT clients will be able to connect provided that they have a set of credentials for an existing user with the appropriate permissions.
@@ -676,13 +676,13 @@ However, Management API metrics that are tied to AMQP 0.9.1 [channels](./channel
 MQTT is the standard protocol for the Internet of Things (IoT).
 A common IoT workload is that many MQTT devices publish sensor data periodically to the MQTT broker.
 There could be hundreds of thousands, sometimes even millions of IoT devices that connect to the MQTT broker.
-The blog post [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt) demonstrates performance benchmarks of such workloads.
+The blog post [Native MQTT](/blog/2023/03/21/native-mqtt) demonstrates performance benchmarks of such workloads.
 
 This section aims at providing a non-exhaustive checklist with tips and tricks to configure RabbitMQ as an efficient MQTT broker that supports many client connections:
 
 1. Set `management_agent.disable_metrics_collector = true` to disable metrics collection in the [Management plugin](./management).
 The RabbitMQ Management plugin has not been designed for excessive metrics collection.
-In fact, metrics delivery via the management API is [deprecated](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#disable-metrics-delivery-via-the-management-api--ui). Instead, use a tool that has been designed for collecting and querying a huge number of metrics: Prometheus.
+In fact, metrics delivery via the management API is [deprecated](/blog/2021/08/21/4.0-deprecation-announcements#disable-metrics-delivery-via-the-management-api--ui). Instead, use a tool that has been designed for collecting and querying a huge number of metrics: Prometheus.
 1. MQTT packets and subscriptions with QoS 0 provide much better performance than QoS 1.
 Unlike AMQP 0.9.1 and AMQP 1.0, MQTT is not designed to maximise throughput: For example, there are no [multi-acks](./confirms#consumer-acks-multiple-parameter).
 Every [PUBLISH](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100) packet with QoS 1 needs to be acknowledged individually.

--- a/versioned_docs/version-3.13/networking.md
+++ b/versioned_docs/version-3.13/networking.md
@@ -666,7 +666,7 @@ On Windows, the limit for the Erlang runtime is controlled exclusively using the
 
 #### The ERL_MAX_PORTS Environment Variable {#erl-max-ports}
 
-The [runtime](./runtime/) has a related limit, controlled via the `ERL_MAX_PORTS` environment
+The [runtime](./runtime) has a related limit, controlled via the `ERL_MAX_PORTS` environment
 variable.
 
 By default the limit is usually set to 65536. When overriding the max open file handle limit to
@@ -1268,10 +1268,10 @@ reverse_dns_lookups = false
 
 ### The inetrc File
 
-The [Erlang runtime](./runtime/) allows for a number of hostname resolution-related settings to be tuned
+The [Erlang runtime](./runtime) allows for a number of hostname resolution-related settings to be tuned
 using a file known as the [inetrc file](http://erlang.org/doc/apps/erts/inet_cfg.html).
 
-The path to the file can be specified by adding an extra runtime argument using the [`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable](./configure/):
+The path to the file can be specified by adding an extra runtime argument using the [`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable](./configure):
 
 <Tabs groupId="shell-specific">
 <TabItem value="bash" label="bash" default>

--- a/versioned_docs/version-3.13/networking.md
+++ b/versioned_docs/version-3.13/networking.md
@@ -646,7 +646,7 @@ can be opened at the same time. When an OS process (such as RabbitMQ's Erlang VM
 the limit, it won't be able to open any new files or accept any more
 TCP connections. The limit will also affect how much memory the [Erlang runtime](./runtime)
 will allocate upfront. This means that the limit on some modern distributions
-[can be too high](https://blog.rabbitmq.com/posts/2022/08/high-initial-memory-consumption-of-rabbitmq-nodes-on-centos-stream-9/) and need
+[can be too high](/blog/2022/08/30/high-initial-memory-consumption-of-rabbitmq-nodes-on-centos-stream-9) and need
 lowering.
 
 #### How to Override the Limit

--- a/versioned_docs/version-3.13/queues.md
+++ b/versioned_docs/version-3.13/queues.md
@@ -322,7 +322,7 @@ the queue is connected to), regardless of the `queue_leader_locator` value.
 [Quorum queues](./quorum-queues) is replicated, data safety and consistency-oriented queue type.
 Classic queues historically supported replication but this feature was **removed** for RabbitMQ 4.x.
 
-Any client [connection](./connections/) can use any queue, whether it is replicated or not,
+Any client [connection](./connections) can use any queue, whether it is replicated or not,
 regardless of the node the queue replica is hosted on or the node the client is connected to.
 RabbitMQ will route the operations to the appropriate node transparently for clients.
 
@@ -334,7 +334,7 @@ Client libraries or applications **may** choose to connect to the node that host
 for improved data locality.
 
 This general rule applies to all messaging data types supported by RabbitMQ except for one.
-[Streams](./streams/) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
+[Streams](./streams) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
 that hosts a replica (a leader of rollower) of the target stream.
 Consequently, RabbitMQ Stream protocol clients will [connect to multiple nodes in parallel](https://www.rabbitmq.com/blog/2021/07/23/connecting-to-streams).
 
@@ -350,7 +350,7 @@ set of supported operations and features.
 
 ## Non-Replicated Queues and Client Operations {#transparent-operation-routing}
 
-Any client [connection](./connections/) can use any queue, including non-replicated (single replica) queues,
+Any client [connection](./connections) can use any queue, including non-replicated (single replica) queues,
 regardless of the node the queue replica is hosted on or the node the client is connected to.
 RabbitMQ will route the operations to the appropriate node transparently for clients.
 
@@ -362,7 +362,7 @@ Client libraries or applications **may** choose to connect to the node that host
 for improved data locality.
 
 This general rule applies to all messaging data types supported by RabbitMQ except for one.
-[Streams](./streams/) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
+[Streams](./streams) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
 that hosts a replica (a leader of rollower) of the target stream.
 Consequently, RabbitMQ Stream protocol clients will [connect to multiple nodes in parallel](https://www.rabbitmq.com/blog/2021/07/23/connecting-to-streams).
 

--- a/versioned_docs/version-3.13/quorum-queues/index.md
+++ b/versioned_docs/version-3.13/quorum-queues/index.md
@@ -31,7 +31,7 @@ replicated FIFO queue based on the [Raft consensus algorithm](https://raft.githu
 
 Quorum queues are designed to be safer and provide simpler, well defined failure handling semantics that users should find easier to reason about when designing and operating their systems.
 
-Quorum queues and [streams](./streams) now replace the original, replicated [mirrored classic queue](./ha). Mirrored classic queues are [have long been deprecated](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/) and were [removed from RabbitMQ 4.x](https://github.com/rabbitmq/rabbitmq-server/pull/9815).
+Quorum queues and [streams](./streams) now replace the original, replicated [mirrored classic queue](./ha). Mirrored classic queues are [have long been deprecated](/blog/2021/08/21/4.0-deprecation-announcements) and were [removed from RabbitMQ 4.x](https://github.com/rabbitmq/rabbitmq-server/pull/9815).
 Use the [Migrate your RabbitMQ Mirrored Classic Queues to Quorum Queues](./migrate-mcq-to-qq) guide for migrating
 RabbitMQ installations that currently use classic mirrored queues.
 
@@ -132,7 +132,7 @@ Some features are not currently supported by quorum queues.
 | [Exclusivity](./queues) | yes | no |
 | Per message persistence | per message | always |
 | Membership changes | automatic | manual  |
-| [Message TTL (Time-To-Live)](./ttl) | yes | yes ([since 3.10](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-release-overview/)) |
+| [Message TTL (Time-To-Live)](./ttl) | yes | yes ([since 3.10](/blog/2022/05/05/rabbitmq-3.10-release-overview)) |
 | [Queue TTL](./ttl#queue-ttl) | yes | partially (lease is not renewed on queue re-declaration) |
 | [Queue length limits](./maxlength) | yes | yes (except `x-overflow`: `reject-publish-dlx`) |
 | [Lazy behaviour](./lazy-queues) | yes | always (since 3.10) |
@@ -146,7 +146,7 @@ Some features are not currently supported by quorum queues.
 | Global [QoS Prefetch](#global-qos) | yes | no |
 | [Server-named queues](./queues#server-named-queues) | yes | no |
 
-Modern quorum queues also offer [higher throughput and less latency variability](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
+Modern quorum queues also offer [higher throughput and less latency variability](/blog/2022/05/16/rabbitmq-3.10-performance-improvements)
 for many workloads.
 
 #### Non-durable Queues
@@ -572,7 +572,7 @@ Note that a node or quorum queue replica failure does not trigger automatic memb
 If a node is failed in an unrecoverable way and cannot be brought back, it must be explicitly removed from the cluster
 or the operator must opt-in and enable the `quorum_queue.continuous_membership_reconciliation.auto_remove` setting.
 
-This also means that [upgrades](./upgrade/) do not trigger automatic membership reconciliation since nodes
+This also means that [upgrades](./upgrade) do not trigger automatic membership reconciliation since nodes
 are expected to come back and only a minority (often just one) node is stopped for upgrading at a time.
 :::
 
@@ -828,8 +828,8 @@ message sizes.
 
 In scenarios using both consumer acks and publisher confirms
 quorum queues have been observed to have superior throughput to
-classic mirrored queues. For example, take a look at [these benchmarks with 3.10](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
-and [another with 3.12](https://blog.rabbitmq.com/posts/2023/05/rabbitmq-3.12-performance-improvements/#significant-improvements-to-quorum-queues).
+classic mirrored queues. For example, take a look at [these benchmarks with 3.10](/blog/2022/05/16/rabbitmq-3.10-performance-improvements)
+and [another with 3.12](/blog/2023/05/17/rabbitmq-3.12-performance-improvements#significant-improvements-to-quorum-queues).
 
 As quorum queues persist all data to disks before doing anything it is recommended
 to use the fastest disks possible and certain [Performance Tuning](#performance-tuning) settings.

--- a/versioned_docs/version-3.13/runtime.md
+++ b/versioned_docs/version-3.13/runtime.md
@@ -171,7 +171,7 @@ See [VM flag documentation](http://erlang.org/doc/man/erl.html) for more detaile
 ### Reducing CPU Usage {#cpu-reduce-idle-usage}
 
 CPU usage is by definition very workload-dependent metric. Some workloads naturally use more CPU resources.
-Others use [disk-heavy features such as quorum queues](https://blog.rabbitmq.com/posts/2020/04/quorum-queues-and-why-disks-matter/),
+Others use [disk-heavy features such as quorum queues](/blog/2020/04/21/quorum-queues-and-why-disks-matter),
 and if disk I/O throughput is insufficient, CPU resources will be wasted while nodes are busy waiting for I/O operations to complete.
 
 A couple of general recommendations can be applied to "moderately loaded" systems where a large percentage or

--- a/versioned_docs/version-3.13/stomp.md
+++ b/versioned_docs/version-3.13/stomp.md
@@ -614,9 +614,9 @@ The default value is `next`.
 When delivering messages from a stream, the message offset (that is the position of the
 message in the stream) is included in the `x-stream-offset` header of the `MESSAGE` frame.
 
-[Stream filtering](https://blog.rabbitmq.com/posts/2023/10/stream-filtering/) is also supported.
+[Stream filtering](/blog/2023/10/16/stream-filtering) is also supported.
 The [stream protocol](./stream) is the preferred way to interact with streams, but most features are also available with other protocols.
-Stream filtering is no exception, it works the same way with STOMP as with [AMQP](https://blog.rabbitmq.com/posts/2023/10/stream-filtering-internals/#bonus-stream-filtering-on-amqp):
+Stream filtering is no exception, it works the same way with STOMP as with [AMQP](/blog/2023/10/24/stream-filtering-internals#bonus-stream-filtering-on-amqp):
 
 * Declaration: a stream can be created on subscription.
 Set the `x-queue-type` header to `stream` and use the `x-stream-filter-size-bytes` header to set the filter size (optional).

--- a/versioned_docs/version-3.13/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-3.13/stream-core-plugin-comparison.md
@@ -39,7 +39,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
-|[Super stream](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
+|[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
 |Throughput| Hundreds of thousands per second | Millions messages per second    |
 |TLS|Supported (default port: 5671)                     | Supported (default port: 5551)
 

--- a/versioned_docs/version-3.13/stream.md
+++ b/versioned_docs/version-3.13/stream.md
@@ -202,7 +202,7 @@ stream.advertised_host = rabbitmq-1
 stream.advertised_port = 12345
 ```
 
-The [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-to-streams/) blog post covers why the `advertised_host` and `advertised_port` settings are necessary in some deployments.
+The [Connecting to Streams](/blog/2021/07/23/connecting-to-streams) blog post covers why the `advertised_host` and `advertised_port` settings are necessary in some deployments.
 
 
 ### Maximum Frame Size {#frame-size}

--- a/versioned_docs/version-3.13/streams.md
+++ b/versioned_docs/version-3.13/streams.md
@@ -274,7 +274,7 @@ The single active consumer feature provides 2 benefits:
 * Messages are processed in order: there is only one consumer at a time.
 * Consumption continuity is maintained: a consumer from the group will take over if the active one stops or crashes.
 
-A [blog post](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/) provides more details on single active consumer for streams.
+A [blog post](/blog/2022/07/05/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams) provides more details on single active consumer for streams.
 
 ### Super Streams {#super-streams}
 
@@ -301,7 +301,7 @@ Use `rabbitmq-streams add_super_stream --help` to learn more about the command.
 Super streams add complexity compared to individual streams, so they should not be considered the default solution for all use cases involving streams.
 Consider using super streams only if you are sure you reached the limits of individual streams.
 
-A [blog post](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams) provides an overview of super streams.
+A [blog post](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) provides an overview of super streams.
 
 ### Filtering {#filtering}
 
@@ -358,7 +358,7 @@ Additional notes on filtering:
 Set the `x-stream-match-unfiltered` argument to `true` to change this behavior and receive _unfiltered_ messages as well.
 * The `x-stream-filter` consumer argument accepts a string but also an array of strings to receive messages for different filter values.
 
-A [first blog post](https://blog.rabbitmq.com/posts/2023/10/stream-filtering/) provides an overview of stream filtering and a [second blog post](https://blog.rabbitmq.com/posts/2023/10/stream-filtering-internals/) covers internals.
+A [first blog post](/blog/2023/10/16/stream-filtering) provides an overview of stream filtering and a [second blog post](/blog/2023/10/24/stream-filtering-internals) covers internals.
 
 ## Feature Comparison: Regular Queues versus Streams {#feature-comparison}
 

--- a/versioned_docs/version-3.13/troubleshooting-oauth2.md
+++ b/versioned_docs/version-3.13/troubleshooting-oauth2.md
@@ -23,7 +23,7 @@ limitations under the License.
 
 ## Overview {#overview}
 
-This guide covers the most common errors encountered using [OAuth 2.0](./oauth2/) and the [management plugin](./management) and how to diagnose them.
+This guide covers the most common errors encountered using [OAuth 2.0](./oauth2) and the [management plugin](./management) and how to diagnose them.
 
 ## Troubleshooting OAuth 2 in the management UI {#management-ui}
 

--- a/versioned_docs/version-3.13/which-erlang.md
+++ b/versioned_docs/version-3.13/which-erlang.md
@@ -655,7 +655,7 @@ source, including specific tags from GitHub, a much more pleasant experience.
     <td>
       <ul class="notes">
         <li>
-          <a href="https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/">Erlang/OTP <code>24</code> support announcement</a>
+          <a href="/blog/2021/03/23/erlang-24-support-roadmap">Erlang/OTP <code>24</code> support announcement</a>
         </li>
         <li>Erlang 24 was released on May 12, 2021</li>
         <li>Some community plugins and tools may be incompatible with Erlang 24</li>

--- a/versioned_docs/version-4.0/cli.md
+++ b/versioned_docs/version-4.0/cli.md
@@ -198,7 +198,7 @@ and more.
 
 ## rabbitmq-queues {#rabbitmq-queues}
 
-[rabbitmq-queues](./man/rabbitmq-queues.8) allows the operator to manage replicas of [replicated queues](./quorum-queues/).
+[rabbitmq-queues](./man/rabbitmq-queues.8) allows the operator to manage replicas of [replicated queues](./quorum-queues).
 It ships with RabbitMQ.
 
 Most commands only support the online mode (when target node is running).
@@ -207,7 +207,7 @@ Most commands only support the online mode (when target node is running).
 
 ## rabbitmq-streams {#rabbitmq-streams}
 
-[rabbitmq-streams](./man/rabbitmq-streams.8) allows the operator to manage replicas of [streams](./streams/).
+[rabbitmq-streams](./man/rabbitmq-streams.8) allows the operator to manage replicas of [streams](./streams).
 It ships with RabbitMQ.
 
 Most commands only support the online mode (when target node is running).

--- a/versioned_docs/version-4.0/clustering.md
+++ b/versioned_docs/version-4.0/clustering.md
@@ -420,7 +420,7 @@ the target stream. The protocol includes a topology discovery operation, so well
 libraries will select one of the suitable nodes. This won't be the case when a load balancer is used,
 however.
 
-See [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-to-streams/#well-behaved-clients)
+See [Connecting to Streams](/blog/2021/07/23/connecting-to-streams#well-behaved-clients)
 to learn more.
 
 ### Queue and Stream Leader Replica Placement {#replica-placement}

--- a/versioned_docs/version-4.0/confirms.md
+++ b/versioned_docs/version-4.0/confirms.md
@@ -486,7 +486,7 @@ to memory consumption growth on the node they are connected to. Finding
 a suitable prefetch value is a matter of trial and error and will vary from
 workload to workload. Values in the 100 through 300 range usually offer
 optimal throughput and do not run significant risk of overwhelming consumers.
-Higher values often [run into the law of diminishing returns](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
+Higher values often [run into the law of diminishing returns](/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3).
 
 Prefetch value of 1 is the most conservative. It will
 significantly reduce throughput, in particular in

--- a/versioned_docs/version-4.0/feature-flags/index.md
+++ b/versioned_docs/version-4.0/feature-flags/index.md
@@ -473,7 +473,7 @@ The following feature flags are provided by RabbitMQ core.
     <td>3.11.0</td>
     <td>stream_single_active_consumer</td>
     <td>
-      <a href="https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/">Single active consumer for streams</a>
+      <a href="/blog/2022/07/05/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams">Single active consumer for streams</a>
     </td>
   </tr>
   <tr>
@@ -603,7 +603,7 @@ The following feature flags are provided by plugin
     <td>3.12.0</td>
     <td>delete_ra_cluster_mqtt_node</td>
 	<td>
-	  <a href="https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#what-else-improves-with-native-mqtt-in-312">Delete Ra cluster mqtt_node since MQTT client IDs are tracked locally</a>
+	  <a href="/blog/2023/03/21/native-mqtt#what-else-improves-with-native-mqtt-in-312">Delete Ra cluster mqtt_node since MQTT client IDs are tracked locally</a>
 	</td>
   </tr>
   <tr>
@@ -611,7 +611,7 @@ The following feature flags are provided by plugin
     <td>3.12.0</td>
     <td>rabbit_mqtt_qos0_queue</td>
 	<td>
-	  Support <a href="https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type">pseudo queue type for MQTT QoS 0 subscribers</a> omitting a queue process
+	  Support <a href="/blog/2023/03/21/native-mqtt#new-mqtt-qos-0-queue-type">pseudo queue type for MQTT QoS 0 subscribers</a> omitting a queue process
 	</td>
   </tr>
 </table>

--- a/versioned_docs/version-4.0/federation-reference.md
+++ b/versioned_docs/version-4.0/federation-reference.md
@@ -199,7 +199,7 @@ The following upstream parameters are only applicable to <a href="./federated-ex
       <td>
         The queue type of the [internal upstream queue](./federated-exchanges#details) used by exchange federation.
 
-        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues/).
+        Defaults to `classic` (a single replica queue type). Set to `quorum` to use a [replicated queue type](./quorum-queues).
 
         Changing the queue type will delete and recreate the upstream queue by default.
         This may lead to messages getting lost or not routed anywhere during the re-declaration.

--- a/versioned_docs/version-4.0/federation.md
+++ b/versioned_docs/version-4.0/federation.md
@@ -112,7 +112,7 @@ enable it, use [rabbitmq-plugins](./cli):
 rabbitmq-plugins enable rabbitmq_federation
 ```
 
-If [management UI](./management/) is used, it is recommended that
+If [management UI](./management) is used, it is recommended that
 `rabbitmq_federation_management` is also enabled:
 
 ```bash
@@ -462,7 +462,7 @@ Therefore, in order to narrow down the problem, the recommended steps are:
 
  * Inspect federation upstreams
  * Inspect [policies](./parameters#policies), in particular looking for policies with conflicting [priorities](./parameters#policy-priorities)
- * Inspect [node logs](./logging/)
+ * Inspect [node logs](./logging)
 
 #### Inspect Federation Upstreams
 
@@ -480,7 +480,7 @@ rabbitmq-diagnostics.bat list_parameters --formatter=pretty_table
 </TabItem>
 
 <TabItem value="Management UI" label="Management UI">
-Make sure that the `rabbitmq_federation_management` [plugin](./plugins/) is enabled.
+Make sure that the `rabbitmq_federation_management` [plugin](./plugins) is enabled.
 
 Navigate to `Admin` > `Federation Upstreams`.
 </TabItem>

--- a/versioned_docs/version-4.0/flow-control.md
+++ b/versioned_docs/version-4.0/flow-control.md
@@ -51,5 +51,5 @@ Other components than connections can be in the
 can apply flow control that eventually propagates back to publishing connections.
 
 To find out if consumers and [prefetch settings](./confirms)
-can be key limiting factors, [take a look at relevant metrics](https://blog.rabbitmq.com/posts/2014/04/finding-bottlenecks-with-rabbitmq-3-3/).
+can be key limiting factors, [take a look at relevant metrics](/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3).
 See [Monitoring and Health Checks](./monitoring) guide to learn more.

--- a/versioned_docs/version-4.0/install-debian.md
+++ b/versioned_docs/version-4.0/install-debian.md
@@ -948,7 +948,7 @@ LimitNOFILE=64000
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 See [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to learn about
 the supported limits and other directives.
@@ -971,7 +971,7 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 ### Verifying the Limit {#verifying-limits}
 

--- a/versioned_docs/version-4.0/install-rpm.md
+++ b/versioned_docs/version-4.0/install-rpm.md
@@ -70,7 +70,7 @@ Note that modern versions of Erlang can have incompatibilities with older distri
 or ship without much or any testing on older distributions or OS kernel versions.
 
 Older distributions can also lack a recent enough version of OpenSSL.
-[Supported Erlang versions](./which-erlang/) **cannot be used on distributions that do not provide OpenSSL 1.1** as a system library.
+[Supported Erlang versions](./which-erlang) **cannot be used on distributions that do not provide OpenSSL 1.1** as a system library.
 CentOS 7 and Fedora releases older than 26 are examples of such distributions.
 
 Currently the list of supported RPM-based distributions includes
@@ -576,7 +576,7 @@ LimitNOFILE=64000
 ```
 
 If `LimitNOFILE` is set to a value higher than 65536, [the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be
-updated accordingly to increase a [runtime](./runtime/) limit.
+updated accordingly to increase a [runtime](./runtime) limit.
 
 See [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to learn about
 the supported limits and other directives.
@@ -599,7 +599,7 @@ The file has to be installed on Docker hosts at `/etc/docker/daemon.json`:
 ```
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 ### Without systemd (Older Linux Distributions)
 
@@ -618,7 +618,7 @@ This `soft` limit cannot go higher than the `hard` limit (which defaults to 4096
 and re-login or reboot. Note that limits cannot be changed for running OS processes.
 
 If the limits above are set to a value higher than 65536,
-[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime/) limit.
+[the `ERL_MAX_PORTS` environment variable](./networking#erl-max-ports) must be updated accordingly to increase a [runtime](./runtime) limit.
 
 For more information about controlling `fs.file-max`
 with `sysctl`, please refer to the excellent

--- a/versioned_docs/version-4.0/local-random-exchange.md
+++ b/versioned_docs/version-4.0/local-random-exchange.md
@@ -42,7 +42,7 @@ cluster nodes. If this is not the case, some published messages **will be droppe
 
 Request/reply, often called RPC, is a popular pattern to implement with a messaging broker
 like RabbitMQ. One of the popular use cases is a microservices based architecture
-where one service requests data from another service. The pattern is covered in [tutorial six](/tutorials/).
+where one service requests data from another service. The pattern is covered in [tutorial six](/tutorials).
 
 Key requirements to support such a scenario include:
 

--- a/versioned_docs/version-4.0/logging.md
+++ b/versioned_docs/version-4.0/logging.md
@@ -586,7 +586,7 @@ was stopped using `rabbitmqctl stop_app`.
 
 When debug logging is enabled, the node will log **a lot** of information
 that can be useful for troubleshooting. This log severity is meant to be
-used when troubleshooting, say, the [peer discovery activity](./cluster-formation/).
+used when troubleshooting, say, the [peer discovery activity](./cluster-formation).
 
 For example to log debug messages to a file:
 

--- a/versioned_docs/version-4.0/memory-use/index.md
+++ b/versioned_docs/version-4.0/memory-use/index.md
@@ -164,7 +164,7 @@ reserved_unallocated: 0.0 gb (0.0%)
     <td>quorum_queue_procs</td>
     <td>Queues</td>
     <td>
-      <a href=".//./quorum-queues">Quorum queue</a> processes, both currently elected leaders and followers.
+      <a href="./quorum-queues">Quorum queue</a> processes, both currently elected leaders and followers.
       Memory footprint can be capped on a per-queue basis.
       See the <a href="./quorum-queues">Quorum Queues</a> guide for more information.
     </td>

--- a/versioned_docs/version-4.0/mqtt.md
+++ b/versioned_docs/version-4.0/mqtt.md
@@ -233,7 +233,7 @@ The latter enables sending messages from an AMQP 0.9.1, AMQP 1.0 or STOMP client
 The benefits of using the MQTT QoS 0 queues type are:
 
 1. Support for larger fanouts, e.g. sending a message from the "cloud" (RabbitMQ) to all devices (MQTT clients).
-1. Lower [memory usage](./memory-use/)
+1. Lower [memory usage](./memory-use)
 1. Lower publisher confirm latency
 1. Lower end-to-end latency
 
@@ -242,7 +242,7 @@ This can happen when the network connection between MQTT subscribing client and 
 
 ### Overload protection
 
-To protect against high [memory usage](./memory-use/) due to MQTT QoS 0 messages piling up in the MQTT connection process mailbox, RabbitMQ intentionally drops QoS 0 messages from the MQTT QoS 0 queue if both conditions are true:
+To protect against high [memory usage](./memory-use) due to MQTT QoS 0 messages piling up in the MQTT connection process mailbox, RabbitMQ intentionally drops QoS 0 messages from the MQTT QoS 0 queue if both conditions are true:
 
 1. the number of messages in the MQTT connection process mailbox exceeds the configured `mqtt.mailbox_soft_limit` (defaults to 200), and
 1. the socket sending to the MQTT client is busy (not sending fast enough due to TCP backpressure).
@@ -724,7 +724,7 @@ Unlike AMQP 0.9.1 and AMQP 1.0, MQTT is not designed to maximise throughput: For
 Every [PUBLISH](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100) packet with QoS 1 needs to be acknowledged individually.
 1. Decrease TCP buffer sizes as described in section [TCP Listener Options](#listener-opts).
 
-This substantially reduces [memory usage](./memory-use/) in environments with many concurrently connected clients.
+This substantially reduces [memory usage](./memory-use) in environments with many concurrently connected clients.
 
 1. Less topic levels (in an MQTT topic and MQTT topic filter) perform better than more topic levels.
 For example, prefer to structure your topic as `city/name` instead of `continent/country/city/name`, if possible.

--- a/versioned_docs/version-4.0/mqtt.md
+++ b/versioned_docs/version-4.0/mqtt.md
@@ -71,7 +71,7 @@ RabbitMQ supports most MQTT 5.0 features including the following:
 * [Retained](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901104) messages with the limitations described in section [Retained Messages and Stores](#retained)
 * [MQTT over a WebSocket](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901285) via the [RabbitMQ Web MQTT Plugin](./web-mqtt)
 
-The [MQTT 5.0 blog post](https://blog.rabbitmq.com/posts/2023/07/mqtt5) provides a complete list of supported MQTT 5.0 features including their usage and implementation details.
+The [MQTT 5.0 blog post](/blog/2023/07/21/mqtt5) provides a complete list of supported MQTT 5.0 features including their usage and implementation details.
 
 MQTT clients can interoperate with other protocols.
 For example, MQTT publishers can send messages to AMQP 0.9.1 or AMQP 1.0 consumers if these consumers consume from a queue
@@ -263,7 +263,7 @@ The following Prometheus metric reported by a given RabbitMQ node shows how many
 rabbitmq_global_messages_dead_lettered_maxlen_total{queue_type="rabbit_mqtt_qos0_queue",dead_letter_strategy="disabled"} 0
 ```
 
-The [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt/#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
+The [Native MQTT](/blog/2023/03/21/native-mqtt#new-mqtt-qos-0-queue-type) blog post describes the MQTT QoS 0 queue type in more detail.
 
 ## Users and Authentication {#authentication}
 
@@ -712,13 +712,13 @@ However, Management API metrics that are tied to AMQP 0.9.1 [channels](./channel
 MQTT is the standard protocol for the Internet of Things (IoT).
 A common IoT workload is that many MQTT devices publish sensor data periodically to the MQTT broker.
 There could be hundreds of thousands, sometimes even millions of IoT devices that connect to the MQTT broker.
-The blog post [Native MQTT](https://blog.rabbitmq.com/posts/2023/03/native-mqtt) demonstrates performance benchmarks of such workloads.
+The blog post [Native MQTT](/blog/2023/03/21/native-mqtt) demonstrates performance benchmarks of such workloads.
 
 This section aims at providing a non-exhaustive checklist with tips and tricks to configure RabbitMQ as an efficient MQTT broker that supports many client connections:
 
 1. Set `management_agent.disable_metrics_collector = true` to disable metrics collection in the [Management plugin](./management).
 The RabbitMQ Management plugin has not been designed for excessive metrics collection.
-In fact, metrics delivery via the management API is [deprecated](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#disable-metrics-delivery-via-the-management-api--ui). Instead, use a tool that has been designed for collecting and querying a huge number of metrics: Prometheus.
+In fact, metrics delivery via the management API is [deprecated](/blog/2021/08/21/4.0-deprecation-announcements#disable-metrics-delivery-via-the-management-api--ui). Instead, use a tool that has been designed for collecting and querying a huge number of metrics: Prometheus.
 1. MQTT packets and subscriptions with QoS 0 provide much better performance than QoS 1.
 Unlike AMQP 0.9.1 and AMQP 1.0, MQTT is not designed to maximise throughput: For example, there are no [multi-acks](./confirms#consumer-acks-multiple-parameter).
 Every [PUBLISH](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100) packet with QoS 1 needs to be acknowledged individually.

--- a/versioned_docs/version-4.0/networking.md
+++ b/versioned_docs/version-4.0/networking.md
@@ -666,7 +666,7 @@ On Windows, the limit for the Erlang runtime is controlled exclusively using the
 
 #### The ERL_MAX_PORTS Environment Variable {#erl-max-ports}
 
-The [runtime](./runtime/) has a related limit, controlled via the `ERL_MAX_PORTS` environment
+The [runtime](./runtime) has a related limit, controlled via the `ERL_MAX_PORTS` environment
 variable.
 
 By default the limit is usually set to 65536. When overriding the max open file handle limit to
@@ -1268,10 +1268,10 @@ reverse_dns_lookups = false
 
 ### The inetrc File
 
-The [Erlang runtime](./runtime/) allows for a number of hostname resolution-related settings to be tuned
+The [Erlang runtime](./runtime) allows for a number of hostname resolution-related settings to be tuned
 using a file known as the [inetrc file](http://erlang.org/doc/apps/erts/inet_cfg.html).
 
-The path to the file can be specified by adding an extra runtime argument using the [`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable](./configure/):
+The path to the file can be specified by adding an extra runtime argument using the [`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable](./configure):
 
 <Tabs groupId="shell-specific">
 <TabItem value="bash" label="bash" default>

--- a/versioned_docs/version-4.0/networking.md
+++ b/versioned_docs/version-4.0/networking.md
@@ -646,7 +646,7 @@ can be opened at the same time. When an OS process (such as RabbitMQ's Erlang VM
 the limit, it won't be able to open any new files or accept any more
 TCP connections. The limit will also affect how much memory the [Erlang runtime](./runtime)
 will allocate upfront. This means that the limit on some modern distributions
-[can be too high](https://blog.rabbitmq.com/posts/2022/08/high-initial-memory-consumption-of-rabbitmq-nodes-on-centos-stream-9/) and need
+[can be too high](/blog/2022/08/30/high-initial-memory-consumption-of-rabbitmq-nodes-on-centos-stream-9) and need
 lowering.
 
 #### How to Override the Limit

--- a/versioned_docs/version-4.0/queues.md
+++ b/versioned_docs/version-4.0/queues.md
@@ -323,7 +323,7 @@ the queue is connected to), regardless of the `queue_leader_locator` value.
 [Quorum queues](./quorum-queues) is replicated, data safety and consistency-oriented queue type.
 Classic queues historically supported replication but this feature was **removed** for RabbitMQ 4.x.
 
-Any client [connection](./connections/) can use any queue, whether it is replicated or not,
+Any client [connection](./connections) can use any queue, whether it is replicated or not,
 regardless of the node the queue replica is hosted on or the node the client is connected to.
 RabbitMQ will route the operations to the appropriate node transparently for clients.
 
@@ -335,7 +335,7 @@ Client libraries or applications **may** choose to connect to the node that host
 for improved data locality.
 
 This general rule applies to all messaging data types supported by RabbitMQ except for one.
-[Streams](./streams/) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
+[Streams](./streams) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
 that hosts a replica (a leader of rollower) of the target stream.
 Consequently, RabbitMQ Stream protocol clients will [connect to multiple nodes in parallel](https://www.rabbitmq.com/blog/2021/07/23/connecting-to-streams).
 
@@ -351,7 +351,7 @@ set of supported operations and features.
 
 ## Non-Replicated Queues and Client Operations {#transparent-operation-routing}
 
-Any client [connection](./connections/) can use any queue, including non-replicated (single replica) queues,
+Any client [connection](./connections) can use any queue, including non-replicated (single replica) queues,
 regardless of the node the queue replica is hosted on or the node the client is connected to.
 RabbitMQ will route the operations to the appropriate node transparently for clients.
 
@@ -363,7 +363,7 @@ Client libraries or applications **may** choose to connect to the node that host
 for improved data locality.
 
 This general rule applies to all messaging data types supported by RabbitMQ except for one.
-[Streams](./streams/) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
+[Streams](./streams) are an exception to this rule, and require clients, regardless of the protocol they use, to connect to a node
 that hosts a replica (a leader of rollower) of the target stream.
 Consequently, RabbitMQ Stream protocol clients will [connect to multiple nodes in parallel](https://www.rabbitmq.com/blog/2021/07/23/connecting-to-streams).
 

--- a/versioned_docs/version-4.0/quorum-queues/index.md
+++ b/versioned_docs/version-4.0/quorum-queues/index.md
@@ -170,7 +170,7 @@ With some queue operations there are minor differences:
 | Global [QoS Prefetch](#global-qos) | yes | no |
 | [Server-named queues](./queues#server-named-queues) | yes | no |
 
-Modern quorum queues also offer [higher throughput and less latency variability](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
+Modern quorum queues also offer [higher throughput and less latency variability](/blog/2022/05/16/rabbitmq-3.10-performance-improvements)
 for many workloads.
 
 ### Queue and Per-Message TTL 
@@ -799,7 +799,7 @@ Note that a node or quorum queue replica failure does not trigger automatic memb
 If a node is failed in an unrecoverable way and cannot be brought back, it must be explicitly removed from the cluster
 or the operator must opt-in and enable the `quorum_queue.continuous_membership_reconciliation.auto_remove` setting.
 
-This also means that [upgrades](./upgrade/) do not trigger automatic membership reconciliation since nodes
+This also means that [upgrades](./upgrade) do not trigger automatic membership reconciliation since nodes
 are expected to come back and only a minority (often just one) node is stopped for upgrading at a time.
 :::
 
@@ -1051,8 +1051,8 @@ in 3, 5 and 7 node configurations with several different message sizes.
 In scenarios using both consumer acks and publisher confirms
 quorum queues have been observed to have superior throughput to
 classic mirrored queues (deprecated in 2021, removed in 2024 for RabbitMQ 4.0).
-For example, take a look at [these benchmarks with 3.10](https://blog.rabbitmq.com/posts/2022/05/rabbitmq-3.10-performance-improvements/)
-and [another with 3.12](https://blog.rabbitmq.com/posts/2023/05/rabbitmq-3.12-performance-improvements/#significant-improvements-to-quorum-queues).
+For example, take a look at [these benchmarks with 3.10](/blog/2022/05/16/rabbitmq-3.10-performance-improvements)
+and [another with 3.12](/blog/2023/05/17/rabbitmq-3.12-performance-improvements#significant-improvements-to-quorum-queues).
 
 As quorum queues persist all data to disks before doing anything it is recommended
 to use the fastest disks possible and certain [Performance Tuning](#performance-tuning) settings.

--- a/versioned_docs/version-4.0/runtime.md
+++ b/versioned_docs/version-4.0/runtime.md
@@ -171,7 +171,7 @@ See [VM flag documentation](http://erlang.org/doc/man/erl.html) for more detaile
 ### Reducing CPU Usage {#cpu-reduce-idle-usage}
 
 CPU usage is by definition very workload-dependent metric. Some workloads naturally use more CPU resources.
-Others use [disk-heavy features such as quorum queues](https://blog.rabbitmq.com/posts/2020/04/quorum-queues-and-why-disks-matter/),
+Others use [disk-heavy features such as quorum queues](/blog/2020/04/21/quorum-queues-and-why-disks-matter),
 and if disk I/O throughput is insufficient, CPU resources will be wasted while nodes are busy waiting for I/O operations to complete.
 
 A couple of general recommendations can be applied to "moderately loaded" systems where a large percentage or

--- a/versioned_docs/version-4.0/shovel-dynamic.md
+++ b/versioned_docs/version-4.0/shovel-dynamic.md
@@ -227,7 +227,7 @@ For example, this may be necessary when the topology is [imported from a definit
 Using a pre-declared topology avoids a chicken-and-egg problem between the import of definitions and
 Shovel plugin startup: the plugin must be enabled for definitions to pass validation (of the runtime parameters part).
 
-Here is how the plugin can be configured to wait until the source is available [using `rabbitmq.conf`](./configure/):
+Here is how the plugin can be configured to wait until the source is available [using `rabbitmq.conf`](./configure):
 
 ```ini
 # all shovels started on this node will use pre-declared topology

--- a/versioned_docs/version-4.0/stomp.md
+++ b/versioned_docs/version-4.0/stomp.md
@@ -614,9 +614,9 @@ The default value is `next`.
 When delivering messages from a stream, the message offset (that is the position of the
 message in the stream) is included in the `x-stream-offset` header of the `MESSAGE` frame.
 
-[Stream filtering](https://blog.rabbitmq.com/posts/2023/10/stream-filtering/) is also supported.
+[Stream filtering](/blog/2023/10/16/stream-filtering) is also supported.
 The [stream protocol](./stream) is the preferred way to interact with streams, but most features are also available with other protocols.
-Stream filtering is no exception, it works the same way with STOMP as with [AMQP](https://blog.rabbitmq.com/posts/2023/10/stream-filtering-internals/#bonus-stream-filtering-on-amqp):
+Stream filtering is no exception, it works the same way with STOMP as with [AMQP](/blog/2023/10/24/stream-filtering-internals#bonus-stream-filtering-on-amqp):
 
 * Declaration: a stream can be created on subscription.
 Set the `x-queue-type` header to `stream` and use the `x-stream-filter-size-bytes` header to set the filter size (optional).

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -39,7 +39,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
-|[Super stream](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
+|[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
 |Throughput| Hundreds of thousands per second | Millions messages per second    |
 |TLS|Supported (default port: 5671)                     | Supported (default port: 5551)
 

--- a/versioned_docs/version-4.0/stream.md
+++ b/versioned_docs/version-4.0/stream.md
@@ -202,7 +202,7 @@ stream.advertised_host = rabbitmq-1
 stream.advertised_port = 12345
 ```
 
-The [Connecting to Streams](https://blog.rabbitmq.com/posts/2021/07/connecting-to-streams/) blog post covers why the `advertised_host` and `advertised_port` settings are necessary in some deployments.
+The [Connecting to Streams](/blog/2021/07/23/connecting-to-streams) blog post covers why the `advertised_host` and `advertised_port` settings are necessary in some deployments.
 
 
 ### Maximum Frame Size {#frame-size}

--- a/versioned_docs/version-4.0/streams.md
+++ b/versioned_docs/version-4.0/streams.md
@@ -274,7 +274,7 @@ The single active consumer feature provides 2 benefits:
 * Messages are processed in order: there is only one consumer at a time.
 * Consumption continuity is maintained: a consumer from the group will take over if the active one stops or crashes.
 
-A [blog post](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/) provides more details on single active consumer for streams.
+A [blog post](/blog/2022/07/05/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams) provides more details on single active consumer for streams.
 
 ### Super Streams {#super-streams}
 
@@ -301,7 +301,7 @@ Use `rabbitmq-streams add_super_stream --help` to learn more about the command.
 Super streams add complexity compared to individual streams, so they should not be considered the default solution for all use cases involving streams.
 Consider using super streams only if you are sure you reached the limits of individual streams.
 
-A [blog post](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams) provides an overview of super streams.
+A [blog post](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) provides an overview of super streams.
 
 ### Filtering {#filtering}
 
@@ -358,7 +358,7 @@ Additional notes on filtering:
 Set the `x-stream-match-unfiltered` argument to `true` to change this behavior and receive _unfiltered_ messages as well.
 * The `x-stream-filter` consumer argument accepts a string but also an array of strings to receive messages for different filter values.
 
-A [first blog post](https://blog.rabbitmq.com/posts/2023/10/stream-filtering/) provides an overview of stream filtering and a [second blog post](https://blog.rabbitmq.com/posts/2023/10/stream-filtering-internals/) covers internals.
+A [first blog post](/blog/2023/10/16/stream-filtering) provides an overview of stream filtering and a [second blog post](/blog/2023/10/24/stream-filtering-internals) covers internals.
 
 ## Feature Comparison: Regular Queues versus Streams {#feature-comparison}
 

--- a/versioned_docs/version-4.0/troubleshooting-oauth2.md
+++ b/versioned_docs/version-4.0/troubleshooting-oauth2.md
@@ -23,7 +23,7 @@ limitations under the License.
 
 ## Overview {#overview}
 
-This guide covers the most common errors encountered using [OAuth 2.0](./oauth2/) and the [management plugin](./management) and how to diagnose them.
+This guide covers the most common errors encountered using [OAuth 2.0](./oauth2) and the [management plugin](./management) and how to diagnose them.
 
 ## Troubleshooting OAuth 2 in the management UI {#management-ui}
 

--- a/versioned_docs/version-4.0/which-erlang.md
+++ b/versioned_docs/version-4.0/which-erlang.md
@@ -685,7 +685,7 @@ source, including specific tags from GitHub, a much more pleasant experience.
     <td>
       <ul class="notes">
         <li>
-          <a href="https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/">Erlang/OTP <code>24</code> support announcement</a>
+          <a href="/blog/2021/03/23/erlang-24-support-roadmap">Erlang/OTP <code>24</code> support announcement</a>
         </li>
         <li>Erlang 24 was released on May 12, 2021</li>
         <li>Some community plugins and tools may be incompatible with Erlang 24</li>


### PR DESCRIPTION
Trailing slashes are useless and bloat the Algolia index.

Another problem was that `docs/memory-use` pointed to `docs/quorum-queues` using `.//./quorum-queues`. This was an error with a batched links conversion. This caused the Algolia crawler to visit `/docs//quorum-queues`, then all pages again with two slashes, then `/docs///quorum-queues`, then all pages with three slashes and so on, leading to a massive bloat of the index.

One last fix: all the blog post links are converted to internal links.