### PR TITLE
Fix even more broken links and trailing slashes

### DIFF
--- a/blog/2024-03-11-rabbitmq-3.13.0-announcement/index.md
+++ b/blog/2024-03-11-rabbitmq-3.13.0-announcement/index.md
@@ -80,7 +80,7 @@ policy. To make sure new queues are created as v2 by default, you can set
 classic_queue.default_version = 2
 ```
 
-in [`rabbitmq.conf`](/docs/configure/).
+in [`rabbitmq.conf`](/docs/configure).
 
 The reason v1 remains the default has nothing to do with any v2 shortcomings
 but rather with the fact that changing the node default led to some back and

--- a/client-libraries/erlang-client-user-guide.md
+++ b/client-libraries/erlang-client-user-guide.md
@@ -222,11 +222,11 @@ The `#amqp_params_network` record sets the following default values:
       <td>0</td>
     </tr>
     <tr>
-      <td><a href="./heartbeats">heartbeat</a></td>
+      <td><a href="/docs/heartbeats">heartbeat</a></td>
       <td>0</td>
     </tr>
     <tr>
-      <td><a href="./ssl">ssl_options</a></td>
+      <td><a href="/docs/ssl">ssl_options</a></td>
       <td>none</td>
     </tr>
     <tr>
@@ -311,7 +311,7 @@ The `#amqp_params_direct` record sets the following default values:
 ### Connecting to RabbitMQ Using an AMQP URI {#amqp-uris}
 
 Instead of working with records such `#amqp_params_network` directly,
-<a href="./uri-spec">AMQP URIs</a> may be used.
+<a href="/docs/uri-spec">AMQP URIs</a> may be used.
 
 The `amqp_uri:parse/1` function is provided for this purpose.
 It parses an URI and returns the equivalent `#amqp_params_network` or `#amqp_params_direct` record.
@@ -677,9 +677,9 @@ Applications are recommended to use a prefetch. Learn more in the
 ## Blocked Connections {#blocked}
 
 When a node detects that it is below a certain available resource threshold,
-it may <a href="./alarms">choose to stop reading from publishers' network sockets</a>.
+it may <a href="/docs/alarms">choose to stop reading from publishers' network sockets</a>.
 
-RabbitMQ supports <a href="./connection-blocked">a mechanism to allow clients to be told this has taken place</a>.
+RabbitMQ supports [a mechanism to allow clients to be told this has taken place](/docs/connection-blocked).
 
 Use `amqp_connection:register_blocked_handler/2` giving the
 pid of a process to which `#'connection.blocked'{}` and

--- a/docs/quorum-queues/index.md
+++ b/docs/quorum-queues/index.md
@@ -1086,7 +1086,7 @@ The `rabbit` application has several quorum queue related configuration items av
 <table>
   <thead>
     <tr>
-      <td><code>advanced.config</code> <a href="./configure/">configuration key</a></td>
+      <td><code>advanced.config</code> <a href="./configure">configuration key</a></td>
       <td>Description</td>
       <td>Default value</td>
     </tr>

--- a/docs/shovel-dynamic.md
+++ b/docs/shovel-dynamic.md
@@ -471,24 +471,24 @@ the declaration process.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>
@@ -730,24 +730,24 @@ counterparts.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>

--- a/docs/shovel-static.md
+++ b/docs/shovel-static.md
@@ -153,24 +153,24 @@ They are described in the table below.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>
@@ -207,7 +207,7 @@ AMQP 0-9-1-specific source keys are covered in a separate table:
   ]}
 ```
         <p>
-          The declarations follow method and property names used by the <a href="./erlang-client-user-guide">RabbitMQ Erlang Client</a>.
+          The declarations follow method and property names used by the <a href="/client-libraries/erlang-client-user-guide">RabbitMQ Erlang Client</a>.
         </p>
         <p>
           A minimalistic declaration example:

--- a/src/pages/plugin-development.md
+++ b/src/pages/plugin-development.md
@@ -199,7 +199,7 @@ The following table should explain the purpose of the various files in the repos
     <td><a href="https://github.com/rabbitmq/rabbitmq-metronome/blob/master/priv/schema/rabbitmq_metronome.schema"><code>rabbitmq_metronome.schema</code></a></td>
     <td>
       A <a href="https://github.com/Kyorai/cuttlefish">Cuttlefish</a> configuration schema.
-      Used to translate <a href="./configure#configuration-files">configuration file</a>
+      Used to translate <a href="/docs/configure#configuration-files">configuration file</a>
       to the internal format used by RabbitMQ and its runtime.
 
       Metronome schema contains mappings for the <code>metronome.exchange</code> setting,

--- a/versioned_docs/version-3.13/quorum-queues/index.md
+++ b/versioned_docs/version-3.13/quorum-queues/index.md
@@ -863,7 +863,7 @@ The `rabbit` application has several quorum queue related configuration items av
 <table>
   <thead>
     <tr>
-      <td><code>advanced.config</code> <a href="./configure/">configuration key</a></td>
+      <td><code>advanced.config</code> <a href="./configure">configuration key</a></td>
       <td>Description</td>
       <td>Default value</td>
     </tr>

--- a/versioned_docs/version-3.13/shovel-dynamic.md
+++ b/versioned_docs/version-3.13/shovel-dynamic.md
@@ -416,24 +416,24 @@ the declaration process.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>
@@ -675,24 +675,24 @@ counterparts.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>

--- a/versioned_docs/version-3.13/shovel-static.md
+++ b/versioned_docs/version-3.13/shovel-static.md
@@ -153,24 +153,24 @@ They are described in the table below.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>
@@ -207,7 +207,7 @@ AMQP 0-9-1-specific source keys are covered in a separate table:
   ]}
 ```
         <p>
-          The declarations follow method and property names used by the <a href="./erlang-client-user-guide">RabbitMQ Erlang Client</a>.
+          The declarations follow method and property names used by the <a href="/client-libraries/erlang-client-user-guide">RabbitMQ Erlang Client</a>.
         </p>
         <p>
           A minimalistic declaration example:

--- a/versioned_docs/version-3.13/specification.md
+++ b/versioned_docs/version-3.13/specification.md
@@ -113,7 +113,7 @@ displayed_sidebar: docsSidebar
     <div class="docSection">
         <a name="interop" class="anchor" id="interop"></a>
         <h2 class="docHeading"><a class="anchor" href="#interop">Interoperability</a></h2>
-        <p>Please see the <a href="./nteroperability">interoperability page</a>.</p>
+        <p>Please see the <a href="/client-libraries/interoperability">interoperability page</a>.</p>
     </div>
 
     <div class="docSection">

--- a/versioned_docs/version-4.0/quorum-queues/index.md
+++ b/versioned_docs/version-4.0/quorum-queues/index.md
@@ -1086,7 +1086,7 @@ The `rabbit` application has several quorum queue related configuration items av
 <table>
   <thead>
     <tr>
-      <td><code>advanced.config</code> <a href="./configure/">configuration key</a></td>
+      <td><code>advanced.config</code> <a href="./configure">configuration key</a></td>
       <td>Description</td>
       <td>Default value</td>
     </tr>

--- a/versioned_docs/version-4.0/shovel-dynamic.md
+++ b/versioned_docs/version-4.0/shovel-dynamic.md
@@ -471,24 +471,24 @@ the declaration process.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>
@@ -730,24 +730,24 @@ counterparts.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>

--- a/versioned_docs/version-4.0/shovel-static.md
+++ b/versioned_docs/version-4.0/shovel-static.md
@@ -153,24 +153,24 @@ They are described in the table below.
       <td>ack-mode</td>
       <td>
         <p>
-          Determines how the shovel should <a href="./confirms/">acknowledge</a> consumed messages.
+          Determines how the shovel should <a href="./confirms">acknowledge</a> consumed messages.
           Valid values are <code>on-confirm</code>, <code>on-publish</code>, and <code>no-ack</code>.
           <code>on-confirm</code> is used by default.
         </p>
         <p>
           If set to <code>on-confirm</code> (the default), messages are
-          <a href="./confirms/">acknowledged</a> to the source broker after they have been confirmed
+          <a href="./confirms">acknowledged</a> to the source broker after they have been confirmed
           by the destination. This handles network errors and broker
           failures without losing messages, and is the slowest option.
         </p>
         <p>
-          If set to <code>on-publish</code>, messages are <a href="./confirms/">acknowledged</a> to
+          If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
           destination (but not yet confirmed). This handles network errors without losing messages,
           but may lose messages in the event of broker failures.
         </p>
         <p>
-          If set to <code>no-ack</code>, <a href="./confirms/">automatic message acknowledgements</a> will be used.
+          If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
           This option will offer the highest throughput but is not safe (will lose messages in the event of network or broker failures).
         </p>
       </td>
@@ -207,7 +207,7 @@ AMQP 0-9-1-specific source keys are covered in a separate table:
   ]}
 ```
         <p>
-          The declarations follow method and property names used by the <a href="./erlang-client-user-guide">RabbitMQ Erlang Client</a>.
+          The declarations follow method and property names used by the <a href="/client-libraries/erlang-client-user-guide">RabbitMQ Erlang Client</a>.
         </p>
         <p>
           A minimalistic declaration example:


### PR DESCRIPTION
They were all reported by the Algolia crawler because they use the HTML syntax and are skipped by the Docusaurus link checker.