### PR TITLE
Fix broken links

### DIFF
--- a/blog/2011-08-16-using-the-rabbitmq-service-on-cloud-foundry-with-nodejs/index.md
+++ b/blog/2011-08-16-using-the-rabbitmq-service-on-cloud-foundry-with-nodejs/index.md
@@ -4,7 +4,7 @@ tags: ["HowTo", ]
 authors: [mikeb]
 ---
 
-Recently we launched a [RabbitMQ service for Cloud Foundry](http://blog.cloudfoundry.com/post/8713844574/rabbitmq-cloud-foundry-cloud-messaging-that-just-works), making it simple to spin up a message broker to use with your apps on Cloud Foundry. There are tutorials online for using it with [Ruby on Rails](https://www.rabbitmq.com/cloudfoundry/rails) and with [Java apps using Spring](https://www.rabbitmq.com/cloudfoundry/spring). Here we are going to look at using the RabbitMQ service with Node.JS apps.
+Recently we launched a [RabbitMQ service for Cloud Foundry](http://blog.cloudfoundry.com/post/8713844574/rabbitmq-cloud-foundry-cloud-messaging-that-just-works), making it simple to spin up a message broker to use with your apps on Cloud Foundry. There are tutorials online for using it with Ruby on Rails and with Java apps using Spring. Here we are going to look at using the RabbitMQ service with Node.JS apps.
 
 <!-- truncate -->
 

--- a/docs/man/rabbitmq-diagnostics.8.md
+++ b/docs/man/rabbitmq-diagnostics.8.md
@@ -26,7 +26,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -93,7 +93,7 @@
 #### <code class="Cm">wait</code> {#wait}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">wait</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">wait</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -104,7 +104,7 @@
 #### <code class="Cm">cluster_status</code> {#cluster_status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">cluster_status</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">cluster_status</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -115,7 +115,7 @@
 #### <code class="Cm">list_users</code> {#list_users}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_users</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_users</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -126,31 +126,31 @@
 #### <code class="Cm">list_permissions</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_topic_permissions</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_topic_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_user_permissions</code> <var class="Ar">username</var> {#list_user_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_user_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_user_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_user_topic_permissions</code> <var class="Ar">username</var> {#list_user_topic_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_user_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_user_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_vhosts</code> [<var class="Ar">vhostinfoitem ...</var>] {#list_vhosts}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_vhosts</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_vhosts</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -326,7 +326,7 @@ years
 #### <code class="Cm">environment</code> {#environment}
         </dt>
         <dd>
-          See <code class="Cm">environment</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>
+          See <code class="Cm">environment</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>
         </dd>
         <dt >
 #### <code class="Cm">erlang_cookie_hash</code> {#erlang_cookie_hash}
@@ -373,55 +373,55 @@ years
 #### <code class="Cm">list_bindings</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] [<var class="Ar">bindinginfoitem ...</var>] {#list_bindings}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_bindings</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_bindings</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_channels</code> [<var class="Ar">channelinfoitem ...</var>] {#list_channels}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_channels</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_channels</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_ciphers</code> {#list_ciphers}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_ciphers</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_ciphers</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_connections</code> [<var class="Ar">connectioninfoitem ...</var>] {#list_connections}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_connections</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_connections</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_consumers</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_consumers}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_consumers</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_consumers</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_exchanges</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] [<var class="Ar">exchangeinfoitem ...</var>] {#list_exchanges}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_exchanges</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_exchanges</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_hashes</code> {#list_hashes}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_hashes</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_hashes</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_queues</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] [<code class="Fl">--offline</code> | <code class="Fl">--online</code> | <code class="Fl">--local</code>] [<var class="Ar">queueinfoitem ...</var>] {#list_queues}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_queues</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_queues</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_unresponsive_queues</code> [<code class="Fl">--local</code>] [<code class="Fl">--queue-timeout</code> <var class="Ar">milliseconds</var>] [<var class="Ar">column ...</var>] [<code class="Fl">--no-table-headers</code>] {#list_unresponsive_queues}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_unresponsive_queues</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_unresponsive_queues</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">listeners</code> {#listeners}
@@ -517,7 +517,7 @@ terabytes
 #### <code class="Cm">report</code> {#report}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">report</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">report</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">runtime_thread_stats</code> [<code class="Fl">--sample-interval</code> <var class="Ar">interval</var>] {#runtime_thread_stats}
@@ -534,7 +534,7 @@ terabytes
 #### <code class="Cm">schema_info</code> [<code class="Fl">--no_table_headers</code>] [<var class="Ar">column ...</var>] [<code class="Fl">--timeout</code> <var class="Ar">milliseconds</var>] {#schema_info}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">schema_info</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">schema_info</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">server_version</code> {#server_version}
@@ -550,7 +550,7 @@ terabytes
 #### <code class="Cm">status</code> {#status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">status</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">status</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">tls_versions</code> {#tls_versions}
@@ -572,13 +572,13 @@ terabytes
 #### <code class="Cm">list_global_parameters</code> {#list_global_parameters}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_global_parameters</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_global_parameters</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_parameters</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_parameters}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_parameters</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_parameters</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -589,13 +589,13 @@ terabytes
 #### <code class="Cm">list_operator_policies</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_operator_policies}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_operator_policies</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_operator_policies</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_policies</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_policies}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_policies</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_policies</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -606,7 +606,7 @@ terabytes
 #### <code class="Cm">list_vhost_limits</code> [<code class="Fl">--vhost</code> <var class="Ar">vhost</var>] [<code class="Fl">--global</code>] [<code class="Fl">--no-table-headers</code>] {#list_vhost_limits}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_vhost_limits</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_vhost_limits</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -632,7 +632,7 @@ terabytes
 #### <code class="Cm">list_feature_flags</code> [<var class="Ar">column ...</var>] [<code class="Fl">--timeout</code> <var class="Ar">milliseconds</var>] {#list_feature_flags}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_feature_flags</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_feature_flags</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -643,26 +643,26 @@ terabytes
 #### <code class="Cm">quorum_status</code> <var class="Ar">queue</var> [<code class="Fl">--vhost</code> <var class="Ar">vhost</var>] {#quorum_status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">quorum_status</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">quorum_status</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> {#check_if_cluster_has_classic_queue_mirroring_policy}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">check_if_node_is_quorum_critical</code> {#check_if_node_is_quorum_critical}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">check_if_node_is_quorum_critical</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">check_if_node_is_quorum_critical</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
       </dl>
     </section>
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-echopid.8.md
+++ b/docs/man/rabbitmq-echopid.8.md
@@ -17,7 +17,7 @@
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
     <p class="Pp">Running <code class="Nm">rabbitmq-echopid.bat</code> will attempt to discover and echo the process id (PID) of the Erlang runtime process (<span class="Pa">erl.exe</span>) that is hosting RabbitMQ. To allow <span class="Pa">erl.exe</span> time to start up and load RabbitMQ, the script will wait for ten seconds before timing out if a suitable PID cannot be found.</p>
     <p class="Pp">If a PID is discovered, the script will echo it to stdout before exiting with a <code class="Ev">ERRORLEVEL</code> of 0. If no PID is discovered before the timeout, nothing is written to stdout and the script exits setting <code class="Ev">ERRORLEVEL</code> to 1.</p>
-    <p class="Pp">Note that this script only exists on Windows due to the need to wait for <span class="Pa">erl.exe</span> and possibly time-out. To obtain the PID on Unix set <code class="Ev">RABBITMQ_PID_FILE</code> before starting <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> and do not use <code class="Fl">-detached</code>.</p>
+    <p class="Pp">Note that this script only exists on Windows due to the need to wait for <span class="Pa">erl.exe</span> and possibly time-out. To obtain the PID on Unix set <code class="Ev">RABBITMQ_PID_FILE</code> before starting <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> and do not use <code class="Fl">-detached</code>.</p>
   </section>
   <section class="Sh">
 ## OPTIONS {#OPTIONS}
@@ -28,7 +28,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-env.conf.5.md
+++ b/docs/man/rabbitmq-env.conf.5.md
@@ -43,7 +43,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-plugins.8.md
+++ b/docs/man/rabbitmq-plugins.8.md
@@ -26,7 +26,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "<var class="Ar">rabbit@target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "<var class="Ar">rabbit@target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -203,7 +203,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-queues.8.md
+++ b/docs/man/rabbitmq-queues.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -199,7 +199,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-server.8.md
+++ b/docs/man/rabbitmq-server.8.md
@@ -15,7 +15,7 @@
   <section class="Sh">
 ## DESCRIPTION {#DESCRIPTION}
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
-    <p class="Pp">Running <code class="Nm">rabbitmq-server</code> starts a RabbitMQ node in the foreground. The node will display a startup banner and report when startup is complete. To shut down the server, use service management tools or <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>.</p>
+    <p class="Pp">Running <code class="Nm">rabbitmq-server</code> starts a RabbitMQ node in the foreground. The node will display a startup banner and report when startup is complete. To shut down the server, use service management tools or <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>.</p>
   </section>
   <section class="Sh">
 ## ENVIRONMENT {#ENVIRONMENT}
@@ -76,7 +76,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-service.8.md
+++ b/docs/man/rabbitmq-service.8.md
@@ -16,7 +16,7 @@
 ## DESCRIPTION {#DESCRIPTION}
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
     <p class="Pp">Running <code class="Nm">rabbitmq-service.bat</code> allows the RabbitMQ broker to be run as a service in Windows® environments. The RabbitMQ broker service can be started and stopped using the Windows® services panel.</p>
-    <p class="Pp">By default the service will run in the authentication context of the local system account. It is therefore necessary to synchronise Erlang cookies between the local system account (typically <span class="Pa">C:\Windows\.erlang.cookie</span> and the account that will be used to run <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>.</p>
+    <p class="Pp">By default the service will run in the authentication context of the local system account. It is therefore necessary to synchronise Erlang cookies between the local system account (typically <span class="Pa">C:\Windows\.erlang.cookie</span> and the account that will be used to run <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>.</p>
   </section>
   <section class="Sh">
 ## COMMANDS {#COMMANDS}
@@ -33,7 +33,7 @@
 ### <code class="Cm">remove</code> {#remove}
       </dt>
       <dd>
-        Remove the service. If the service is running then it will automatically be stopped before being removed. No files will be deleted as a consequence and <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> will remain operable.
+        Remove the service. If the service is running then it will automatically be stopped before being removed. No files will be deleted as a consequence and <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> will remain operable.
       </dd>
       <dt >
 ### <code class="Cm">start</code> {#start}
@@ -98,7 +98,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-streams.8.md
+++ b/docs/man/rabbitmq-streams.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -441,7 +441,7 @@ inactive
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmq-upgrade.8.md
+++ b/docs/man/rabbitmq-upgrade.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -90,7 +90,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/man/rabbitmqctl.8.md
+++ b/docs/man/rabbitmqctl.8.md
@@ -1198,13 +1198,13 @@ fanout
 #### <code class="Cm">mirror_pids</code> {#mirror_pids}
             </dt>
             <dd>
-              If the queue is mirrored, this lists the IDs of the mirrors (follower replicas). To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Mirroring guide</a>
+              If the queue is mirrored, this lists the IDs of the mirrors (follower replicas). To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Mirroring guide</a>
             </dd>
             <dt >
 #### <code class="Cm">synchronised_mirror_pids</code> {#synchronised_mirror_pids}
             </dt>
             <dd>
-              If the queue is mirrored, this gives the IDs of the mirrors (follower replicas) which are in sync with the leader replica. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Mirroring guide</a>
+              If the queue is mirrored, this gives the IDs of the mirrors (follower replicas) which are in sync with the leader replica. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Mirroring guide</a>
             </dd>
             <dt >
 #### <code class="Cm">state</code> {#state~2}

--- a/docs/man/rabbitmqctl.8.md
+++ b/docs/man/rabbitmqctl.8.md
@@ -31,7 +31,7 @@
 ### <code class="Fl">--longnames</code> {#longnames}
       </dt>
       <dd>
-        ). The output of "hostname -s" is usually the correct hostname to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        ). The output of "hostname -s" is usually the correct hostname to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -195,7 +195,7 @@ returns a non-zero exit code if the RabbitMQ node is not running
           <p class="Pp">Waits for the RabbitMQ application to start.</p>
           <p class="Pp">This command will wait for the RabbitMQ application to start at the node. It will wait for the pid file to be created if <var class="Ar">pidfile</var> is specified, then for a process with a pid specified in the pid file or the <code class="Fl">--pid</code> argument, and then for the RabbitMQ application to start in that process. It will fail if the process terminates without starting the RabbitMQ application.</p>
           <p class="Pp">If the specified pidfile is not created or the erlang node is not started within <code class="Fl">--timeout</code> the command will fail. The default timeout is 10 seconds.</p>
-          <p class="Pp">A suitable pid file is created by the <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> script. By default, this is located in the Mnesia directory. Modify the <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change the location.</p>
+          <p class="Pp">A suitable pid file is created by the <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> script. By default, this is located in the Mnesia directory. Modify the <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change the location.</p>
           <p class="Pp">For example, this command will return when the RabbitMQ node has started up:</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
@@ -2553,7 +2553,7 @@ stomp_headers
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -35,41 +35,41 @@ displayed_sidebar: docsSidebar
                     <td>AMQP 0-9-1 (incl. extensions)</td>
                     <td></td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.extended.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9-1.stripped.extended.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9-1.extended.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9-1.stripped.extended.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-9-1</td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-9-1.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-9-1.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-9-1.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9-1.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9-1.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9-1.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-9</td>
                     <td>
-                        <a href="resources/specs/amqp0-9.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-9.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-9.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-9.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-9.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-8</td>
                     <td>
-                        <a href="resources/specs/amqp0-8.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-8.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-8.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-8.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-8.xml">Full</a> |
-                        <a href="resources/specs/amqp0-8.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-8.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-8.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
             </tbody>

--- a/versioned_docs/version-3.13/man/rabbitmq-diagnostics.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-diagnostics.8.md
@@ -26,7 +26,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -93,7 +93,7 @@
 #### <code class="Cm">wait</code> {#wait}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">wait</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">wait</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -104,7 +104,7 @@
 #### <code class="Cm">cluster_status</code> {#cluster_status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">cluster_status</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">cluster_status</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -115,7 +115,7 @@
 #### <code class="Cm">list_users</code> {#list_users}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_users</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_users</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -126,31 +126,31 @@
 #### <code class="Cm">list_permissions</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_topic_permissions</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_topic_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_user_permissions</code> <var class="Ar">username</var> {#list_user_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_user_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_user_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_user_topic_permissions</code> <var class="Ar">username</var> {#list_user_topic_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_user_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_user_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_vhosts</code> [<var class="Ar">vhostinfoitem ...</var>] {#list_vhosts}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_vhosts</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_vhosts</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -326,7 +326,7 @@ years
 #### <code class="Cm">environment</code> {#environment}
         </dt>
         <dd>
-          See <code class="Cm">environment</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>
+          See <code class="Cm">environment</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>
         </dd>
         <dt >
 #### <code class="Cm">erlang_cookie_hash</code> {#erlang_cookie_hash}
@@ -373,55 +373,55 @@ years
 #### <code class="Cm">list_bindings</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] [<var class="Ar">bindinginfoitem ...</var>] {#list_bindings}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_bindings</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_bindings</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_channels</code> [<var class="Ar">channelinfoitem ...</var>] {#list_channels}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_channels</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_channels</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_ciphers</code> {#list_ciphers}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_ciphers</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_ciphers</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_connections</code> [<var class="Ar">connectioninfoitem ...</var>] {#list_connections}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_connections</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_connections</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_consumers</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_consumers}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_consumers</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_consumers</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_exchanges</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] [<var class="Ar">exchangeinfoitem ...</var>] {#list_exchanges}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_exchanges</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_exchanges</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_hashes</code> {#list_hashes}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_hashes</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_hashes</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_queues</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] [<code class="Fl">--offline</code> | <code class="Fl">--online</code> | <code class="Fl">--local</code>] [<var class="Ar">queueinfoitem ...</var>] {#list_queues}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_queues</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_queues</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_unresponsive_queues</code> [<code class="Fl">--local</code>] [<code class="Fl">--queue-timeout</code> <var class="Ar">milliseconds</var>] [<var class="Ar">column ...</var>] [<code class="Fl">--no-table-headers</code>] {#list_unresponsive_queues}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_unresponsive_queues</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_unresponsive_queues</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">listeners</code> {#listeners}
@@ -517,7 +517,7 @@ terabytes
 #### <code class="Cm">report</code> {#report}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">report</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">report</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">runtime_thread_stats</code> [<code class="Fl">--sample-interval</code> <var class="Ar">interval</var>] {#runtime_thread_stats}
@@ -534,7 +534,7 @@ terabytes
 #### <code class="Cm">schema_info</code> [<code class="Fl">--no_table_headers</code>] [<var class="Ar">column ...</var>] [<code class="Fl">--timeout</code> <var class="Ar">milliseconds</var>] {#schema_info}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">schema_info</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">schema_info</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">server_version</code> {#server_version}
@@ -550,7 +550,7 @@ terabytes
 #### <code class="Cm">status</code> {#status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">status</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">status</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">tls_versions</code> {#tls_versions}
@@ -572,13 +572,13 @@ terabytes
 #### <code class="Cm">list_global_parameters</code> {#list_global_parameters}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_global_parameters</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_global_parameters</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_parameters</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_parameters}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_parameters</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_parameters</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -589,13 +589,13 @@ terabytes
 #### <code class="Cm">list_operator_policies</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_operator_policies}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_operator_policies</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_operator_policies</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_policies</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_policies}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_policies</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_policies</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -606,7 +606,7 @@ terabytes
 #### <code class="Cm">list_vhost_limits</code> [<code class="Fl">--vhost</code> <var class="Ar">vhost</var>] [<code class="Fl">--global</code>] [<code class="Fl">--no-table-headers</code>] {#list_vhost_limits}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_vhost_limits</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_vhost_limits</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -632,7 +632,7 @@ terabytes
 #### <code class="Cm">list_feature_flags</code> [<var class="Ar">column ...</var>] [<code class="Fl">--timeout</code> <var class="Ar">milliseconds</var>] {#list_feature_flags}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_feature_flags</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_feature_flags</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -643,26 +643,26 @@ terabytes
 #### <code class="Cm">quorum_status</code> <var class="Ar">queue</var> [<code class="Fl">--vhost</code> <var class="Ar">vhost</var>] {#quorum_status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">quorum_status</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">quorum_status</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> {#check_if_cluster_has_classic_queue_mirroring_policy}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">check_if_node_is_quorum_critical</code> {#check_if_node_is_quorum_critical}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">check_if_node_is_quorum_critical</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">check_if_node_is_quorum_critical</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
       </dl>
     </section>
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-echopid.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-echopid.8.md
@@ -17,7 +17,7 @@
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
     <p class="Pp">Running <code class="Nm">rabbitmq-echopid.bat</code> will attempt to discover and echo the process id (PID) of the Erlang runtime process (<span class="Pa">erl.exe</span>) that is hosting RabbitMQ. To allow <span class="Pa">erl.exe</span> time to start up and load RabbitMQ, the script will wait for ten seconds before timing out if a suitable PID cannot be found.</p>
     <p class="Pp">If a PID is discovered, the script will echo it to stdout before exiting with a <code class="Ev">ERRORLEVEL</code> of 0. If no PID is discovered before the timeout, nothing is written to stdout and the script exits setting <code class="Ev">ERRORLEVEL</code> to 1.</p>
-    <p class="Pp">Note that this script only exists on Windows due to the need to wait for <span class="Pa">erl.exe</span> and possibly time-out. To obtain the PID on Unix set <code class="Ev">RABBITMQ_PID_FILE</code> before starting <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> and do not use <code class="Fl">-detached</code>.</p>
+    <p class="Pp">Note that this script only exists on Windows due to the need to wait for <span class="Pa">erl.exe</span> and possibly time-out. To obtain the PID on Unix set <code class="Ev">RABBITMQ_PID_FILE</code> before starting <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> and do not use <code class="Fl">-detached</code>.</p>
   </section>
   <section class="Sh">
 ## OPTIONS {#OPTIONS}
@@ -28,7 +28,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-env.conf.5.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-env.conf.5.md
@@ -43,7 +43,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-plugins.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-plugins.8.md
@@ -26,7 +26,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "<var class="Ar">rabbit@target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "<var class="Ar">rabbit@target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -203,7 +203,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-queues.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-queues.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -199,7 +199,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-server.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-server.8.md
@@ -15,7 +15,7 @@
   <section class="Sh">
 ## DESCRIPTION {#DESCRIPTION}
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
-    <p class="Pp">Running <code class="Nm">rabbitmq-server</code> starts a RabbitMQ node in the foreground. The node will display a startup banner and report when startup is complete. To shut down the server, use service management tools or <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>.</p>
+    <p class="Pp">Running <code class="Nm">rabbitmq-server</code> starts a RabbitMQ node in the foreground. The node will display a startup banner and report when startup is complete. To shut down the server, use service management tools or <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>.</p>
   </section>
   <section class="Sh">
 ## ENVIRONMENT {#ENVIRONMENT}
@@ -76,7 +76,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-service.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-service.8.md
@@ -16,7 +16,7 @@
 ## DESCRIPTION {#DESCRIPTION}
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
     <p class="Pp">Running <code class="Nm">rabbitmq-service.bat</code> allows the RabbitMQ broker to be run as a service in Windows® environments. The RabbitMQ broker service can be started and stopped using the Windows® services panel.</p>
-    <p class="Pp">By default the service will run in the authentication context of the local system account. It is therefore necessary to synchronise Erlang cookies between the local system account (typically <span class="Pa">C:\Windows\.erlang.cookie</span> and the account that will be used to run <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>.</p>
+    <p class="Pp">By default the service will run in the authentication context of the local system account. It is therefore necessary to synchronise Erlang cookies between the local system account (typically <span class="Pa">C:\Windows\.erlang.cookie</span> and the account that will be used to run <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>.</p>
   </section>
   <section class="Sh">
 ## COMMANDS {#COMMANDS}
@@ -33,7 +33,7 @@
 ### <code class="Cm">remove</code> {#remove}
       </dt>
       <dd>
-        Remove the service. If the service is running then it will automatically be stopped before being removed. No files will be deleted as a consequence and <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> will remain operable.
+        Remove the service. If the service is running then it will automatically be stopped before being removed. No files will be deleted as a consequence and <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> will remain operable.
       </dd>
       <dt >
 ### <code class="Cm">start</code> {#start}
@@ -98,7 +98,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-streams.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-streams.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -441,7 +441,7 @@ inactive
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmq-upgrade.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmq-upgrade.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -90,7 +90,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmqctl.8.md
@@ -31,7 +31,7 @@
 ### <code class="Fl">--longnames</code> {#longnames}
       </dt>
       <dd>
-        ). The output of "hostname -s" is usually the correct hostname to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        ). The output of "hostname -s" is usually the correct hostname to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -195,7 +195,7 @@ returns a non-zero exit code if the RabbitMQ node is not running
           <p class="Pp">Waits for the RabbitMQ application to start.</p>
           <p class="Pp">This command will wait for the RabbitMQ application to start at the node. It will wait for the pid file to be created if <var class="Ar">pidfile</var> is specified, then for a process with a pid specified in the pid file or the <code class="Fl">--pid</code> argument, and then for the RabbitMQ application to start in that process. It will fail if the process terminates without starting the RabbitMQ application.</p>
           <p class="Pp">If the specified pidfile is not created or the erlang node is not started within <code class="Fl">--timeout</code> the command will fail. The default timeout is 10 seconds.</p>
-          <p class="Pp">A suitable pid file is created by the <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> script. By default, this is located in the Mnesia directory. Modify the <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change the location.</p>
+          <p class="Pp">A suitable pid file is created by the <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> script. By default, this is located in the Mnesia directory. Modify the <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change the location.</p>
           <p class="Pp">For example, this command will return when the RabbitMQ node has started up:</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
@@ -2579,7 +2579,7 @@ stomp_headers
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-3.13/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmqctl.8.md
@@ -335,7 +335,7 @@ returns a non-zero exit code if the RabbitMQ node is not running
             <dt><var class="Ar">queue</var></dt>
             <dd>The name of the queue to synchronise.</dd>
           </dl>
-          <p class="Pp">Instructs a mirrored queue with unsynchronised mirrors (follower replicas) to synchronise them. The queue will block while synchronisation takes place (all publishers and consumers using the queue will block or temporarily see no activity). This command can only be used with mirrored queues. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Classic Queue Mirroring guide</a></p>
+          <p class="Pp">Instructs a mirrored queue with unsynchronised mirrors (follower replicas) to synchronise them. The queue will block while synchronisation takes place (all publishers and consumers using the queue will block or temporarily see no activity). This command can only be used with mirrored queues. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Classic Queue Mirroring guide</a></p>
           <p class="Pp">Note that queues with unsynchronised replicas and active consumers will become synchronised eventually (assuming that consumers make progress). This command is primarily useful for queues that do not have active consumers.</p>
         </dd>
         <dt >
@@ -1224,13 +1224,13 @@ fanout
 #### <code class="Cm">mirror_pids</code> {#mirror_pids}
             </dt>
             <dd>
-              If the queue is mirrored, this lists the IDs of the mirrors (follower replicas). To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Mirroring guide</a>
+              If the queue is mirrored, this lists the IDs of the mirrors (follower replicas). To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Mirroring guide</a>
             </dd>
             <dt >
 #### <code class="Cm">synchronised_mirror_pids</code> {#synchronised_mirror_pids}
             </dt>
             <dd>
-              If the queue is mirrored, this gives the IDs of the mirrors (follower replicas) which are in sync with the leader replica. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Mirroring guide</a>
+              If the queue is mirrored, this gives the IDs of the mirrors (follower replicas) which are in sync with the leader replica. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Mirroring guide</a>
             </dd>
             <dt >
 #### <code class="Cm">state</code> {#state~2}

--- a/versioned_docs/version-3.13/specification.md
+++ b/versioned_docs/version-3.13/specification.md
@@ -30,41 +30,41 @@ displayed_sidebar: docsSidebar
                     <td>AMQP 0-9-1 (incl. extensions)</td>
                     <td></td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.extended.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9-1.stripped.extended.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9-1.extended.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9-1.stripped.extended.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-9-1</td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-9-1.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-9-1.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-9-1.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9-1.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9-1.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9-1.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-9</td>
                     <td>
-                        <a href="resources/specs/amqp0-9.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-9.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-9.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-9.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-9.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-8</td>
                     <td>
-                        <a href="resources/specs/amqp0-8.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-8.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-8.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-8.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-8.xml">Full</a> |
-                        <a href="resources/specs/amqp0-8.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-8.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-8.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
             </tbody>

--- a/versioned_docs/version-4.0/man/rabbitmq-diagnostics.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-diagnostics.8.md
@@ -26,7 +26,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -93,7 +93,7 @@
 #### <code class="Cm">wait</code> {#wait}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">wait</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">wait</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -104,7 +104,7 @@
 #### <code class="Cm">cluster_status</code> {#cluster_status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">cluster_status</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">cluster_status</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -115,7 +115,7 @@
 #### <code class="Cm">list_users</code> {#list_users}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_users</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_users</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -126,31 +126,31 @@
 #### <code class="Cm">list_permissions</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_topic_permissions</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_topic_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_user_permissions</code> <var class="Ar">username</var> {#list_user_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_user_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_user_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_user_topic_permissions</code> <var class="Ar">username</var> {#list_user_topic_permissions}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_user_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_user_topic_permissions</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_vhosts</code> [<var class="Ar">vhostinfoitem ...</var>] {#list_vhosts}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_vhosts</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_vhosts</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -517,7 +517,7 @@ terabytes
 #### <code class="Cm">report</code> {#report}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">report</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">report</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">runtime_thread_stats</code> [<code class="Fl">--sample-interval</code> <var class="Ar">interval</var>] {#runtime_thread_stats}
@@ -534,7 +534,7 @@ terabytes
 #### <code class="Cm">schema_info</code> [<code class="Fl">--no_table_headers</code>] [<var class="Ar">column ...</var>] [<code class="Fl">--timeout</code> <var class="Ar">milliseconds</var>] {#schema_info}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">schema_info</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">schema_info</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">server_version</code> {#server_version}
@@ -572,13 +572,13 @@ terabytes
 #### <code class="Cm">list_global_parameters</code> {#list_global_parameters}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_global_parameters</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_global_parameters</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_parameters</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_parameters}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_parameters</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_parameters</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -589,13 +589,13 @@ terabytes
 #### <code class="Cm">list_operator_policies</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_operator_policies}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_operator_policies</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_operator_policies</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">list_policies</code> [<code class="Fl">-p</code> <var class="Ar">vhost</var>] {#list_policies}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_policies</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_policies</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -606,7 +606,7 @@ terabytes
 #### <code class="Cm">list_vhost_limits</code> [<code class="Fl">--vhost</code> <var class="Ar">vhost</var>] [<code class="Fl">--global</code>] [<code class="Fl">--no-table-headers</code>] {#list_vhost_limits}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_vhost_limits</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_vhost_limits</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -632,7 +632,7 @@ terabytes
 #### <code class="Cm">list_feature_flags</code> [<var class="Ar">column ...</var>] [<code class="Fl">--timeout</code> <var class="Ar">milliseconds</var>] {#list_feature_flags}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">list_feature_flags</code> in <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+          <p class="Pp">See <code class="Cm">list_feature_flags</code> in <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
         </dd>
       </dl>
     </section>
@@ -643,26 +643,26 @@ terabytes
 #### <code class="Cm">quorum_status</code> <var class="Ar">queue</var> [<code class="Fl">--vhost</code> <var class="Ar">vhost</var>] {#quorum_status}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">quorum_status</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">quorum_status</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> {#check_if_cluster_has_classic_queue_mirroring_policy}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">check_if_cluster_has_classic_queue_mirroring_policy</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
         <dt >
 #### <code class="Cm">check_if_node_is_quorum_critical</code> {#check_if_node_is_quorum_critical}
         </dt>
         <dd>
-          <p class="Pp">See <code class="Cm">check_if_node_is_quorum_critical</code> in <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a></p>
+          <p class="Pp">See <code class="Cm">check_if_node_is_quorum_critical</code> in <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a></p>
         </dd>
       </dl>
     </section>
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-echopid.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-echopid.8.md
@@ -17,7 +17,7 @@
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
     <p class="Pp">Running <code class="Nm">rabbitmq-echopid.bat</code> will attempt to discover and echo the process id (PID) of the Erlang runtime process (<span class="Pa">erl.exe</span>) that is hosting RabbitMQ. To allow <span class="Pa">erl.exe</span> time to start up and load RabbitMQ, the script will wait for ten seconds before timing out if a suitable PID cannot be found.</p>
     <p class="Pp">If a PID is discovered, the script will echo it to stdout before exiting with a <code class="Ev">ERRORLEVEL</code> of 0. If no PID is discovered before the timeout, nothing is written to stdout and the script exits setting <code class="Ev">ERRORLEVEL</code> to 1.</p>
-    <p class="Pp">Note that this script only exists on Windows due to the need to wait for <span class="Pa">erl.exe</span> and possibly time-out. To obtain the PID on Unix set <code class="Ev">RABBITMQ_PID_FILE</code> before starting <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> and do not use <code class="Fl">-detached</code>.</p>
+    <p class="Pp">Note that this script only exists on Windows due to the need to wait for <span class="Pa">erl.exe</span> and possibly time-out. To obtain the PID on Unix set <code class="Ev">RABBITMQ_PID_FILE</code> before starting <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> and do not use <code class="Fl">-detached</code>.</p>
   </section>
   <section class="Sh">
 ## OPTIONS {#OPTIONS}
@@ -28,7 +28,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-env.conf.5.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-env.conf.5.md
@@ -43,7 +43,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-plugins.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-plugins.8.md
@@ -26,7 +26,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "<var class="Ar">rabbit@target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "<var class="Ar">rabbit@target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -203,7 +203,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-queues.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-queues.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -199,7 +199,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-server.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-server.8.md
@@ -15,7 +15,7 @@
   <section class="Sh">
 ## DESCRIPTION {#DESCRIPTION}
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
-    <p class="Pp">Running <code class="Nm">rabbitmq-server</code> starts a RabbitMQ node in the foreground. The node will display a startup banner and report when startup is complete. To shut down the server, use service management tools or <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>.</p>
+    <p class="Pp">Running <code class="Nm">rabbitmq-server</code> starts a RabbitMQ node in the foreground. The node will display a startup banner and report when startup is complete. To shut down the server, use service management tools or <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>.</p>
   </section>
   <section class="Sh">
 ## ENVIRONMENT {#ENVIRONMENT}
@@ -76,7 +76,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-service.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-service.8.md
@@ -16,7 +16,7 @@
 ## DESCRIPTION {#DESCRIPTION}
     <p class="Pp">RabbitMQ is an open source multi-protocol messaging broker.</p>
     <p class="Pp">Running <code class="Nm">rabbitmq-service.bat</code> allows the RabbitMQ broker to be run as a service in Windows® environments. The RabbitMQ broker service can be started and stopped using the Windows® services panel.</p>
-    <p class="Pp">By default the service will run in the authentication context of the local system account. It is therefore necessary to synchronise Erlang cookies between the local system account (typically <span class="Pa">C:\Windows\.erlang.cookie</span> and the account that will be used to run <a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>.</p>
+    <p class="Pp">By default the service will run in the authentication context of the local system account. It is therefore necessary to synchronise Erlang cookies between the local system account (typically <span class="Pa">C:\Windows\.erlang.cookie</span> and the account that will be used to run <a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>.</p>
   </section>
   <section class="Sh">
 ## COMMANDS {#COMMANDS}
@@ -33,7 +33,7 @@
 ### <code class="Cm">remove</code> {#remove}
       </dt>
       <dd>
-        Remove the service. If the service is running then it will automatically be stopped before being removed. No files will be deleted as a consequence and <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> will remain operable.
+        Remove the service. If the service is running then it will automatically be stopped before being removed. No files will be deleted as a consequence and <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> will remain operable.
       </dd>
       <dt >
 ### <code class="Cm">start</code> {#start}
@@ -98,7 +98,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-streams.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-streams.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -441,7 +441,7 @@ inactive
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmq-upgrade.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmq-upgrade.8.md
@@ -23,7 +23,7 @@
 ### <code class="Fl">-n</code> <var class="Ar">node</var> {#n}
       </dt>
       <dd>
-        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        Default node is "rabbit@<var class="Ar">target-hostname</var>", where <var class="Ar">target-hostname</var> is the local host. On a host named "myserver.example.com", the node name will usually be "rabbit@myserver" (unless <code class="Ev">RABBITMQ_NODENAME</code> has been overridden). The output of "hostname -s" is usually the correct suffix to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -90,7 +90,7 @@
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmqctl.8.html">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmqctl.8">rabbitmqctl(8)</a>, <a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmqctl.8.md
@@ -1198,13 +1198,13 @@ fanout
 #### <code class="Cm">mirror_pids</code> {#mirror_pids}
             </dt>
             <dd>
-              If the queue is mirrored, this lists the IDs of the mirrors (follower replicas). To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Mirroring guide</a>
+              If the queue is mirrored, this lists the IDs of the mirrors (follower replicas). To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Mirroring guide</a>
             </dd>
             <dt >
 #### <code class="Cm">synchronised_mirror_pids</code> {#synchronised_mirror_pids}
             </dt>
             <dd>
-              If the queue is mirrored, this gives the IDs of the mirrors (follower replicas) which are in sync with the leader replica. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/ha">RabbitMQ Mirroring guide</a>
+              If the queue is mirrored, this gives the IDs of the mirrors (follower replicas) which are in sync with the leader replica. To learn more, see the <a class="Lk" href="https://www.rabbitmq.com/docs/3.13/ha">RabbitMQ Mirroring guide</a>
             </dd>
             <dt >
 #### <code class="Cm">state</code> {#state~2}

--- a/versioned_docs/version-4.0/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmqctl.8.md
@@ -31,7 +31,7 @@
 ### <code class="Fl">--longnames</code> {#longnames}
       </dt>
       <dd>
-        ). The output of "hostname -s" is usually the correct hostname to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
+        ). The output of "hostname -s" is usually the correct hostname to use after the "@" sign. See <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> for details of configuring a RabbitMQ node.
       </dd>
       <dt >
 ### <code class="Fl">-q</code>, <code class="Fl">--quiet</code> {#q}
@@ -195,7 +195,7 @@ returns a non-zero exit code if the RabbitMQ node is not running
           <p class="Pp">Waits for the RabbitMQ application to start.</p>
           <p class="Pp">This command will wait for the RabbitMQ application to start at the node. It will wait for the pid file to be created if <var class="Ar">pidfile</var> is specified, then for a process with a pid specified in the pid file or the <code class="Fl">--pid</code> argument, and then for the RabbitMQ application to start in that process. It will fail if the process terminates without starting the RabbitMQ application.</p>
           <p class="Pp">If the specified pidfile is not created or the erlang node is not started within <code class="Fl">--timeout</code> the command will fail. The default timeout is 10 seconds.</p>
-          <p class="Pp">A suitable pid file is created by the <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a> script. By default, this is located in the Mnesia directory. Modify the <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change the location.</p>
+          <p class="Pp">A suitable pid file is created by the <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a> script. By default, this is located in the Mnesia directory. Modify the <code class="Ev">RABBITMQ_PID_FILE</code> environment variable to change the location.</p>
           <p class="Pp">For example, this command will return when the RabbitMQ node has started up:</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
@@ -2553,7 +2553,7 @@ stomp_headers
   </section>
   <section class="Sh">
 ## SEE ALSO {#SEE_ALSO}
-    <p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8.html">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8.html">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8.html">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8.html">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8.html">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8.html">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8.html">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5.html">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8.html">rabbitmq-echopid(8)</a></p>
+    <p class="Pp"><a class="Xr" href="rabbitmq-diagnostics.8">rabbitmq-diagnostics(8)</a>, <a class="Xr" href="rabbitmq-plugins.8">rabbitmq-plugins(8)</a>, <a class="Xr" href="rabbitmq-server.8">rabbitmq-server(8)</a>, <a class="Xr" href="rabbitmq-queues.8">rabbitmq-queues(8)</a>, <a class="Xr" href="rabbitmq-streams.8">rabbitmq-streams(8)</a>, <a class="Xr" href="rabbitmq-upgrade.8">rabbitmq-upgrade(8)</a>, <a class="Xr" href="rabbitmq-service.8">rabbitmq-service(8)</a>, <a class="Xr" href="rabbitmq-env.conf.5">rabbitmq-env.conf(5)</a>, <a class="Xr" href="rabbitmq-echopid.8">rabbitmq-echopid(8)</a></p>
   </section>
   <section class="Sh">
 ## AUTHOR {#AUTHOR}

--- a/versioned_docs/version-4.0/specification.md
+++ b/versioned_docs/version-4.0/specification.md
@@ -35,41 +35,41 @@ displayed_sidebar: docsSidebar
                     <td>AMQP 0-9-1 (incl. extensions)</td>
                     <td></td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.extended.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9-1.stripped.extended.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9-1.extended.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9-1.stripped.extended.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-9-1</td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-9-1.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-9-1.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-9-1.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-9-1.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9-1.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9-1.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9-1.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-9</td>
                     <td>
-                        <a href="resources/specs/amqp0-9.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-9.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-9.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-9.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-9.xml">Full</a> |
-                        <a href="resources/specs/amqp0-9.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-9.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-9.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
                 <tr>
                     <td>AMQP 0-8</td>
                     <td>
-                        <a href="resources/specs/amqp0-8.pdf">Specification</a> |
-                        <a href="resources/specs/amqp-xml-doc0-8.pdf">Generated Doc</a>
+                        <a href="/resources/specs/amqp0-8.pdf">Specification</a> |
+                        <a href="/resources/specs/amqp-xml-doc0-8.pdf">Generated Doc</a>
                     </td>
                     <td>
-                        <a href="resources/specs/amqp0-8.xml">Full</a> |
-                        <a href="resources/specs/amqp0-8.stripped.xml">BSD-licensed</a>
+                        <a href="/resources/specs/amqp0-8.xml">Full</a> |
+                        <a href="/resources/specs/amqp0-8.stripped.xml">BSD-licensed</a>
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
The series of fixes continue:
* Fix broken links in `specification.md`
* Delete non-existing URLs from an old CloudFoundry-related blog post
* Import manpages with deleted `.html` from local URLs and fixed links to CMQ guide