### PR TITLE
Fix links

### DIFF
--- a/blog/2024-08-05-native-amqp/index.md
+++ b/blog/2024-08-05-native-amqp/index.md
@@ -213,7 +213,7 @@ This extensive effort was due to several factors:
 * **Rolling Upgrades:** We support rolling upgrades from RabbitMQ 3.13 to 4.0, allowing you to upgrade your AMQP 1.0 workloads without downtime.
 
 Even though RabbitMQ 4.0 supports AMQP 1.0 natively, this does not imply that RabbitMQ supports all AMQP 1.0 features.
-Like any other AMQP 1.0 broker, RabbitMQ's AMQP 1.0 implementation has [documented limitations](/docs/next/amqp#limitations).
+Like any other AMQP 1.0 broker, RabbitMQ's AMQP 1.0 implementation has [documented limitations](/docs/amqp#limitations).
 
 ## RabbitMQ AMQP 1.0 clients
 

--- a/blog/2024-08-21-amqp-benchmarks/index.md
+++ b/blog/2024-08-21-amqp-benchmarks/index.md
@@ -160,7 +160,7 @@ Time [s]      Count [m]  Rate [m/s]  CPU [%]  RSS [M]  Time [s]      Count [m]  
 For our AMQP 0.9.1 benchmarks we use [PerfTest](https://perftest.rabbitmq.com/).
 We try to run a somewhat fair comparison of our previous AMQP 1.0 benchmark.
 
-Since an AMQP 1.0 [/queues/:queue](/docs/next/amqp#target-address-v2) target address sends to the default exchange, we also send to the default exchange via AMQP 0.9.1.
+Since an AMQP 1.0 [/queues/:queue](/docs/amqp#target-address-v2) target address sends to the default exchange, we also send to the default exchange via AMQP 0.9.1.
 Since we used [durable](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header) messages with AMQP 1.0, we set the `persistent` flag in AMQP 0.9.1.
 Since RabbitMQ settles with the [released](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-released) outcome when a message cannot be routed, we set the `mandatory` flag in AMQP 0.9.1.
 Since RabbitMQ `v4.0.0-beta.5` uses a default `rabbit.max_link_credit` of 128 granting 128 more credits to the sending client when remaining credit falls below 0.5 * 128, we configure the AMQP 0.9.1 publisher to have at most 1.5 * 128 = 192 messages unconfirmed at a time.


### PR DESCRIPTION
Now that RabbitMQ 4.0 docs are released omit the `next` in the URL.