### PR TITLE
Fix docs for on-publish

### DIFF
--- a/docs/federation-reference.md
+++ b/docs/federation-reference.md
@@ -131,8 +131,7 @@ The upstream definition object can contain the following keys:
 
         If set to <code>on-publish</code>, messages are acknowledged to
         the upstream broker after they have been published
-        downstream. This handles network errors without losing messages,
-        but may lose messages in the event of broker failures.
+        downstream. This may lose messages in the event of network or broker failures.
 
 
         If set to <code>no-ack</code>, message acknowledgements are not

--- a/docs/shovel-dynamic.md
+++ b/docs/shovel-dynamic.md
@@ -484,8 +484,7 @@ the declaration process.
         <p>
           If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
-          destination (but not yet confirmed). This handles network errors without losing messages,
-          but may lose messages in the event of broker failures.
+          destination (but not yet confirmed). Messages may be lost in the event of network or broker failures.
         </p>
         <p>
           If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.
@@ -743,8 +742,7 @@ counterparts.
         <p>
           If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
-          destination (but not yet confirmed). This handles network errors without losing messages,
-          but may lose messages in the event of broker failures.
+          destination (but not yet confirmed). Messages may be lost in the event of network or broker failures.
         </p>
         <p>
           If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.

--- a/docs/shovel-static.md
+++ b/docs/shovel-static.md
@@ -166,8 +166,7 @@ They are described in the table below.
         <p>
           If set to <code>on-publish</code>, messages are <a href="./confirms">acknowledged</a> to
           the source broker after they have been published at the
-          destination (but not yet confirmed). This handles network errors without losing messages,
-          but may lose messages in the event of broker failures.
+          destination (but not yet confirmed). Messages may be lost in the event of network or broker failures.
         </p>
         <p>
           If set to <code>no-ack</code>, <a href="./confirms">automatic message acknowledgements</a> will be used.


### PR DESCRIPTION
The message may be lost if there are network failures between shovel worker and destination broker.