### PR TITLE
docs: Change rabbitmq:3.13-management by rabbitmq:4.0.2-management

### DIFF
--- a/versioned_docs/version-4.0/download.md
+++ b/versioned_docs/version-4.0/download.md
@@ -35,8 +35,8 @@ See [RabbitMQ support timeline](/release-information) to find out what release s
 Experimenting with RabbitMQ on your workstation? Try the [community Docker image](https://hub.docker.com/_/rabbitmq/):
 
 ```bash
-# latest RabbitMQ 3.13
-docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.13-management
+# latest RabbitMQ 4.0.2
+docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:4.0.2-management
 ```
 
 ## Open Source RabbitMQ Server


### PR DESCRIPTION
Changed the name of image to rabbitmq:4.0.2-management
because the page describes the version 4 of RabbitMQ and not the version 3