### PR TITLE
Update multi-resource example

### DIFF
--- a/docs/oauth2-examples-auth0.md
+++ b/docs/oauth2-examples-auth0.md
@@ -21,19 +21,18 @@ limitations under the License.
 
 # Use https://auth0.com/ as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Auth0 as Authorization Server using the following flows:
 
-* Access management UI via a browser
+* Access [management UI](./management/) via a browser
 * Access management rest api
-* Access AMQP protocol
+* Application authentication and authorization
 
 ## Prerequisites to follow this guide
 
 * Have an account in https://auth0.com/.
 * Docker
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Create RabbitMQ API
 

--- a/docs/oauth2-examples-entra-id/index.md
+++ b/docs/oauth2-examples-entra-id/index.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 # Use Microsoft Entra ID (formerly known as Microsoft Azure AD) as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Microsoft Entra ID as Authorization Server using the following flows:
 
 * Access the management UI via a browser
@@ -31,8 +31,7 @@ and Microsoft Entra ID as Authorization Server using the following flows:
 * Have an account in https://portal.azure.com.
 * Docker
 * Openssl
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Register your app
 
@@ -214,7 +213,7 @@ on port `15671`, see the management UI guide.
 
 :::
 
-When you run `make start-rabbitmq` for the first time with `MODE=entra`, before RabbitMQ is deployed, a TLS certificate is generated for RabbitMQ so that it listens on HTTPS port 15671.  
+When you run `make start-rabbitmq` for the first time with `MODE=entra`, before RabbitMQ is deployed, a TLS certificate is generated for RabbitMQ so that it listens on HTTPS port 15671.
 
 The script generates the following files in `conf/entra/certs`:
 * **cacert.pem**: a custom certificate authority that is used to generate and sign a self signed certificate for RabbitMQ

--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -21,19 +21,18 @@ limitations under the License.
 
 # Use Keycloak as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Keycloak as Authorization Server using the following flows:
 
-* Access management UI via a browser
+* Access [management UI](./management/) via a browser
 * Access management rest api
-* Access AMQP protocol
+* Application authentication and authorization
 
 ## Prerequisites to follow this guide
 
 * Docker
 * make
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Deploy Keycloak
 
@@ -69,7 +68,7 @@ To access the management api run the following command. It uses the client [mgt_
 make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=LWOuYqJ8gjKg3D2U8CJZDuID3KiRZVDa
 ```
 
-## Access AMQP protocol with PerfTest
+## Application authentication and authorization with PerfTest
 
 To test OAuth 2.0 authentication with AMQP protocol you are going to use RabbitMQ PerfTest tool which uses RabbitMQ Java Client.
 
@@ -81,7 +80,7 @@ make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/t
 
 **NOTE**: Initializing an application with a token has one drawback: the application cannot use the connection beyond the lifespan of the token. See the next section where you demonstrate how to refresh the token.
 
-## Access AMQP protocol with Pika
+## Application authentication and authorization with Pika
 
 In the following information, OAuth 2.0 authentication is tested with the AMQP protocol and the Pika library. These tests specifically demonstrate how to refresh a token on a live AMQP connection.
 
@@ -97,7 +96,7 @@ python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 
 Note: Ensure you install pika 1.3
 
-## Access Management UI
+## Access [management UI](./management/)
 
 1. Go to http://localhost:15672.
 2. Click on the single button on the page which redirects to **Keycloak** to authenticate.

--- a/docs/oauth2-examples-multiresource.md
+++ b/docs/oauth2-examples-multiresource.md
@@ -103,7 +103,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
     ```
 
     This is an access token generated for `prod_producer`.
-    ```
+    ```json
     {
       "exp": 1690974839,
       "iat": 1690974539,
@@ -171,11 +171,11 @@ This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
 Follow the steps to the management UI flows with two OAuth resources:
 
-1. Go to the [RabbitMQ Management UI](http://localhost:15672)
-2. Select `RabbitMQ Production` resource
-3. Login as `prod_user`:`prod_user`
-4. Keycloak prompts you to authorize various scopes for `prod_user`
-5. You should now get redirected to the Management UI as `prod_user` user
+1. Go to the [RabbitMQ Management UI](http://localhost:15672).
+2. Select `RabbitMQ Production` resource.
+3. Login as `prod_user`:`prod_user`.
+4. Keycloak prompts you to authorize various scopes for `prod_user`.
+5. You should now get redirected to the Management UI as `prod_user` user.
 
 Now, logout and repeat the same steps for `dev_user` user. For this user, RabbitMQ is configured to request the `rabbitmq.tag:management` scope only.
 
@@ -184,3 +184,196 @@ In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_
 
 The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
 :::
+
+
+## Scenario 2 - Two OAuth 2.0 resources on dedicated realm under the same many OAuth providers {#scenario2}
+
+This scenario uses the same OAuth 2.0 provider called **keycloak**, however, this time there are two realms, `dev` and `prod`:
+- Under Realm `dev` there are users and clients with granted access to the `rabbit_dev` resource:
+	- `dev_producer` (password: `SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8`).
+	- `rabbit_dev_admin` (password: `rabbit_dev_admin`).
+	- `rabbit_dev_mgt_api`.
+- Under Realm `prod` there are users and clients with granted access to the `rabbit_prod` resource:
+	- `prod_producer` with the audience `rabbit_prod` (password: `PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9`).
+	- `rabbit_prod_admin` (password: `rabbit_prod_admin`).
+
+Despite there is only one physical OAuth provider, you need to configure RabbitMQ with two OAuth 2.0 providers. Each tenant has its own `issuer` url. This is the configuration file used for this scenario is  [rabbitmq.scenario2.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario2.conf). For convenience here is the relevant part:
+```ini
+...
+## Oauth providers
+auth_oauth2.oauth_providers.devkeycloak.issuer = https://keycloak:8443/realms/dev
+auth_oauth2.oauth_providers.devkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.devkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.devkeycloak.https.hostname_verification = wildcard
+
+auth_oauth2.oauth_providers.prodkeycloak.issuer = https://keycloak:8443/realms/prod
+auth_oauth2.oauth_providers.prodkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.prodkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.prodkeycloak.https.hostname_verification = wildcard
+
+...
+```
+
+Follow these steps to deploy Keycloak and RabbitMQ:
+
+1. Launch Keycloak.
+```bash
+make start-keycloak
+```
+
+:::tip
+Run `docker ps | grep keycloak` to check when the instance has started.
+It is recommended to follow the logs until both instances are fully initialized: `docker logs keycloak -f`
+:::
+
+2. Launch RabbitMQ.
+```bash
+MODE=multi-keycloak OAUTH_PROVIDER=keycloak CONF=rabbitmq.scenario2.conf make start-rabbitmq
+```
+
+3. Launch AMQP producer registered in Keycloak with the **client_id** `prod_producer` and with the permission to access `rabbit_prod` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/keycloak/token prod_producer sIqZ5flmSz3r6uKXMSz8CWGeScdTpqq0 prod)
+```
+
+4. Launch AMQP producer registered in Keycloak with the **client_id** `dev_producer` and with the permission to access `rabbit_dev` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/keycloak/token dev_producer SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8 dev)
+```
+
+5. Stop both producers:
+```bash
+make stop-perftest-producer PRODUCER=dev_producer
+make stop-perftest-producer PRODUCER=prod_producer
+```
+
+6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=dev
+```
+
+You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
+
+8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+```
+
+You should see in the standard output the following:
+```json
+{"error":"not_authorized","reason":"Not_Authorized"}
+```
+
+9. Verify Management UI access:
+
+	- Go to http://localhost:15672.
+	- Select *RabbitMQ Development* OAuth 2.0 resource.
+	- Click on "Click here to login".
+	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
+	- Verify that user is redirected by to Management UI.
+	- Click on Logout.
+	- Repeat with *RabbitMQ Production* and user `rabbit_prod_admin` / `rabbit_prod_admin`.
+
+10. Shutdown RabbitMQ and Keycloak
+
+```bash
+make stop-keycloak
+make stop-rabbitmq
+```
+
+## Scenario 3 - Two OAuth 2.0 resources on dedicated OAuth provider {#scenario3}
+
+This scenario uses two separate OAuth 2.0 providers called `devkeycloak` and `prodkeycloak`, with the following setup:
+
+- `devkeycloak` has the following setup under the `dev` Realm and grants access to `rabbit_dev` resource:
+	- `dev_producer` with the audience `rabbit_dev` (password: `SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8`).
+	- `rabbit_dev_admin` (password: `rabbit_dev_admin`).
+	- `rabbit_dev_mgt_api`.
+- `prodkeycloak` has the following setup under the `prod` Realm and grants access to `rabbit_prod` resource:
+	- `prod_producer` with the audience `rabbit_prod` (password: `PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9`).
+	- `rabbit_prod_admin` (password: `rabbit_prod_admin`).
+
+Check out the section `oauth_providers` in the configuration file [rabbitmq.scenario3.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario3.conf) used by this scenario. Like in the scenario 2, there are two OAuth providers however this time the URL refers to two different hostnames. For convenience here is the relevant part:
+
+```ini
+...
+
+## Oauth providers
+auth_oauth2.oauth_providers.devkeycloak.issuer = https://devkeycloak:8443/realms/dev
+auth_oauth2.oauth_providers.devkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.devkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.devkeycloak.https.hostname_verification = wildcard
+
+auth_oauth2.oauth_providers.prodkeycloak.issuer = https://prodkeycloak:8442/realms/prod
+auth_oauth2.oauth_providers.prodkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.prodkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.prodkeycloak.https.hostname_verification = wildcard
+
+...
+```
+
+Follow these steps to deploy two Keycloaks and RabbitMQ:
+
+1. Launch Keycloak.
+```bash
+make start-dev-keycloak
+make start-prod-keycloak
+```
+:::tip
+Run `docker ps | grep keycloak` to see two instances have started.
+:::
+
+2. Launch RabbitMQ.
+```bash
+MODE=multi-keycloak CONF=rabbitmq.scenario3.conf make start-rabbitmq
+```
+
+3. Launch AMQP producer registered in Keycloak with the **client_id** `prod_producer` and with the permission to access `rabbit_prod` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/prodkeycloak/token prod_producer PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9)
+```
+
+4. Launch AMQP producer registered in Keycloak with the **client_id** `dev_producer` and with the permission to access `rabbit_dev` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/devkeycloak/token dev_producer z1PNm47wfWyulTnAaDOf1AggTy3MxX2H)
+```
+
+5. Stop both producers:
+```bash
+make stop-perftest-producer PRODUCER=dev_producer
+make stop-perftest-producer PRODUCER=prod_producer
+```
+
+6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
+```bash
+make curl-dev-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=p7v6DksWkcb6TUYK6payswovC0LqhU6A
+```
+
+You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
+
+8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+```
+
+You should see in the standard output the following:
+```json
+{"error":"not_authorized","reason":"Not_Authorized"}
+```
+
+9. Verify Management UI access:
+
+	- Go to http://localhost:15672.
+	- Select *RabbitMQ Development* OAuth 2.0 resource.
+	- Click on "Click here to login".
+	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
+	- Verify that user is redirected by to Management UI.
+	- Click on Logout.
+	- Repeat with *RabbitMQ Production* and user `rabbit_prod_admin` / `rabbit_prod_admin`.
+
+10. Shutdown RabbitMQ and the two Keycloaks:
+```bash
+make stop-dev-keycloak
+make stop-prod-keycloak
+make stop-rabbitmq
+```

--- a/docs/oauth2-examples-multiresource.md
+++ b/docs/oauth2-examples-multiresource.md
@@ -1,5 +1,5 @@
 ---
-title: Use multiple OAuth 2.0 servers and/or audiences
+title: Using Multiple OAuth 2.0 Servers and/or Audiences
 displayed_sidebar: docsSidebar
 ---
 <!--
@@ -19,34 +19,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Use multiple OAuth 2.0 servers and/or audiences
+# Using Multiple OAuth 2.0 Servers and/or Audiences
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and several OAuth resources using the following flows:
 
-* Access AMQP protocol
-* Access Management UI
+* Application authentication and authorization
+* Access [management UI](./management/)
 
 ## Prerequisites
 
 * Docker
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
 All the examples demonstrated so far, except for this one, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
 
-You could encounter scenarios where some management users and/or applications are registered in
-different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers.
+In some scenarios some management users and/or applications are registered in
+different OAuth 2 servers or they could be registered on the same OAuth 2 server but refer to RabbitMQ using different audience values. To support this scenario, as many OAuth 2 resources must be declared as audiences and/or authorization servers.
 
 The following three scenarios demonstrate various configurations you may encounter:
 
-* [Scenario 1](oauth2-examples-multiresource#scenario1) - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
-* [Scenario 2](./oauth2-examples-multiresource#scenario2) - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
-* [Scenario 3](./oauth2-examples-multiresource#scenario3) - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
+* [Scenario 1](oauth2-examples-multiresource#scenario1): messaging (AMQP) clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
+* [Scenario 2](./oauth2-examples-multiresource#scenario2): each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) that all use the same OAuth 2 (IDP) server, in this example accessible at `keycloak`.
+* [Scenario 3](./oauth2-examples-multiresource#scenario3): each resource is managed on a dedicated OAuth 2 (IDP) server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
 
-## Scenario 1 - AMQP clients and management users registered in same OAuth 2.0 server but with different audience {#scenario1}
+## Scenario 1: Messaging (AMQP) Clients and Management Users Registered in the Same OAuth 2.0 Server but with Different Audiences {#scenario1}
 
 RabbitMQ is configured with two OAuth2 resources one called `rabbit_prod` and another `rabbit_dev`. For example purposes, let's say, the production team refer to RabbitMQ with the `rabbit_prod` audience. And the development team with the `rabbit_dev` audience.
 As both teams are registered in the same OAuth2 server you are going to configure its settings such as `issuer` at the root level so that both resources share the same configuration.
@@ -55,8 +54,9 @@ As both teams are registered in the same OAuth2 server you are going to configur
 
 This is a summary of the configuration, found in [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
-- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
-- RabbitMQ OAuth2 plugin is configured:
+There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in Keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
+The RabbitMQ OAuth 2 plugin is configured like so:
+
     * With two resources: `rabbit_prod` and `rabbit_dev`:
     ```ini
     auth_oauth2.resource_servers.1.id = rabbit_prod
@@ -88,7 +88,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 
     :::tip
     It is recommended to follow the logs until keycloak is fully initialized: `docker logs keycloak -f`
-    :::    
+    :::
 
 2. Launch RabbitMQ with [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
@@ -109,7 +109,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
       "iat": 1690974539,
       "jti": "c8edec50-5f29-4bd0-b25b-d7a46dc3474e",
       "iss": "http://localhost:8081/realms/test",
-      "aud": "rabbit_prod",            
+      "aud": "rabbit_prod",
       "sub": "826065e7-bb58-4b65-bbf7-8982d6cca6c8",
       "typ": "Bearer",
       "azp": "prod_producer",
@@ -150,7 +150,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
 * There are two users declared in Keycloak: `prod_user` and `dev_user`.
-* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
+* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ management plugin with each with their own OAuth 2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
     ```ini
     management.oauth_resource_servers.1.id = rabbit_prod
     management.oauth_resource_servers.1.client_id = rabbit_prod_mgt_ui
@@ -186,7 +186,7 @@ The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the 
 :::
 
 
-## Scenario 2 - Two OAuth 2.0 resources on dedicated realm under the same many OAuth providers {#scenario2}
+## Scenario 2: Two OAuth 2 Resources on Dedicated Realm Under as Many OAuth Providers {#scenario2}
 
 This scenario uses the same OAuth 2.0 provider called **keycloak**, however, this time there are two realms, `dev` and `prod`:
 - Under Realm `dev` there are users and clients with granted access to the `rabbit_dev` resource:
@@ -222,8 +222,10 @@ make start-keycloak
 ```
 
 :::tip
+
 Run `docker ps | grep keycloak` to check when the instance has started.
 It is recommended to follow the logs until both instances are fully initialized: `docker logs keycloak -f`
+
 :::
 
 2. Launch RabbitMQ.
@@ -281,7 +283,7 @@ make stop-keycloak
 make stop-rabbitmq
 ```
 
-## Scenario 3 - Two OAuth 2.0 resources on dedicated OAuth provider {#scenario3}
+## Scenario 3: Two OAuth 2 Resources on Dedicated OAuth 2 Providers {#scenario3}
 
 This scenario uses two separate OAuth 2.0 providers called `devkeycloak` and `prodkeycloak`, with the following setup:
 

--- a/docs/oauth2-examples-multiresource.md
+++ b/docs/oauth2-examples-multiresource.md
@@ -35,16 +35,16 @@ contains all the configuration files and scripts used on this example.
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
-All the examples demonstrated by this tutorial, except for this use case, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
+All the examples demonstrated so far, except for this one, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
 
 You could encounter scenarios where some management users and/or applications are registered in
 different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers.
 
 The following three scenarios demonstrate various configurations you may encounter:
 
-* [Scenario 1]{#scenario1} - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
-* [Scenario 2]{#scenario2} - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
-* [Scenario 3]{#scenario3} - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
+* [Scenario 1](oauth2-examples-multiresource#scenario1) - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
+* [Scenario 2](./oauth2-examples-multiresource#scenario2) - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
+* [Scenario 3](./oauth2-examples-multiresource#scenario3) - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
 
 ## Scenario 1 - AMQP clients and management users registered in same OAuth 2.0 server but with different audience {#scenario1}
 
@@ -67,10 +67,7 @@ This is a summary of the configuration, found in [rabbitmq.scenario1.conf](https
     auth_oauth2.preferred_username_claims.1 = preferred_username
     auth_oauth2.preferred_username_claims.2 = user_name
     auth_oauth2.preferred_username_claims.3 = email
-    auth_oauth2.issuer = https://keycloak:8443/realms/test
     auth_oauth2.scope_prefix = rabbitmq.
-    auth_oauth2.https.peer_verification = verify_peer
-    auth_oauth2.https.cacertfile = /etc/rabbitmq/keycloak-cacert.pem
     ```
     * With one oauth provider:
     ```ini
@@ -153,7 +150,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
 * There are two users declared in Keycloak: `prod_user` and `dev_user`.
-* The two resources: `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
+* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
     ```ini
     management.oauth_resource_servers.1.id = rabbit_prod
     management.oauth_resource_servers.1.client_id = rabbit_prod_mgt_ui
@@ -165,7 +162,10 @@ This is a summary of the configuration to enable OAuth 2.0 in the management UI:
     management.oauth_resource_servers.2.label = RabbitMQ Development
     management.oauth_resource_servers.2.scopes = openid profile rabbitmq.tag:management
     ```
-* As there is only one OAuth2 server, both resources share the oauth provider called **keycloak**:
+
+    :::note
+    As there is only one OAuth2 server, both resources share the oauth provider called **keycloak**.
+    :::
 
 * Each OAuth2 client, `rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`, is declared in Keycloak so that they can only emit tokens for their respective audience, be it `rabbit_prod` and `rabbit_dev` respectively.
 
@@ -179,4 +179,8 @@ Follow the steps to the management UI flows with two OAuth resources:
 
 Now, logout and repeat the same steps for `dev_user` user. For this user, RabbitMQ is configured to request the `rabbitmq.tag:management` scope only.
 
-**Note**: In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_user` because RabbitMQ is configured to request the scope: `rabbitmq.tag:administrator` for `RabbitMQ Production`. The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
+:::warning
+In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_user` because RabbitMQ is configured to request the scope: `rabbitmq.tag:administrator` for `RabbitMQ Production`.
+
+The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
+:::

--- a/docs/oauth2-examples-okta.md
+++ b/docs/oauth2-examples-okta.md
@@ -24,7 +24,7 @@ limitations under the License.
 Demonstrate how to authenticate using OAuth 2.0 protocol
 and Okta as Authorization Server using the following flows:
 
-1. Access management UI via a browser
+1. Access [management UI](./management/) via a browser
 
 ## Prerequisites to follow this guide
 
@@ -63,9 +63,9 @@ In Trusted Origins (for Web and Native app integrations), choose **keep the defa
 
 In Assignments, choose **Allow everyone in your organization to access**.
 
-Finally, click on **Save** and write down the following values, as you will need them later to configure RabbitMQ:  
+Finally, click on **Save** and write down the following values, as you will need them later to configure RabbitMQ:
 
-  * **ClientID**  
+  * **ClientID**
   * **Okta domain name**
 
 
@@ -101,7 +101,7 @@ And below are the steps to create a claim for **role** to distinguish `admin` an
 
 6. Choose **Expression** as Value type
 
-7. In **Value** field enter the following expression:  
+7. In **Value** field enter the following expression:
   `isMemberOfGroupName("admin") ? "admin" : isMemberOfGroupName("monitoring") ? "monitoring" : ""`
 
 8. Click on create.
@@ -152,7 +152,7 @@ Once you've added the user to the appropriate groups and apps, they should have 
 
 The configuration on Okta side is done. You now have to configure RabbitMQ to use the resources you just created.
 
-[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta. 
+[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
 
 Update it with the following values (you should have noted these in the previous steps):
 

--- a/docs/oauth2-examples-proxy.md
+++ b/docs/oauth2-examples-proxy.md
@@ -43,8 +43,7 @@ Let's test the following flow:
 
 * Docker
 * make
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Deploy Keycloak
 
@@ -94,7 +93,7 @@ make start-oauth2-proxy
 Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
-## Access Management UI
+## Access [management UI](./management/)
 
 Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
 `rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/docs/oauth2-examples/index.md
+++ b/docs/oauth2-examples/index.md
@@ -40,7 +40,7 @@ which hosts all the scripts required to deploy the examples demonstrated on the 
 
 ### Management UI Access
 
-* [Access Management UI using OAuth 2.0 tokens](#access-management-ui)
+* [Access [management UI](./management/) using OAuth 2.0 tokens](#access-management-ui)
 * [Service-Provider initiated logon](#service-provider-initiated-logon)
 * [Identity-Provider initiated logon](#identity-provider-initiated-logon)
 
@@ -92,7 +92,7 @@ Run the following two commands to start UAA and RabbitMQ configured for UAA:
 
 The last command starts a RabbitMQ with a specific configuration file, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/uaa/rabbitmq.conf).
 
-## Access Management UI using OAuth 2.0 tokens {#access-management-ui}
+## Access [management UI](./management/) using OAuth 2.0 tokens {#access-management-ui}
 
 The RabbitMQ Management UI can be configured with one of these two login modes:
 
@@ -802,7 +802,7 @@ make curl-with-token URL=http://localhost:15672/api/overview TOKEN=$(bin/jwt_tok
 
 Note: You are using curl to go to the URL using a TOKEN which you have built using the command bin/jwt_token which takes the JWT payload, the name of the signing key and the private and public certificates to sign the token
 
-*Use a Rich Authorization Token to access AMQP protocol*
+*Use a Rich Authorization Token to Application authentication and authorization*
 
 This time, You are going to use the same token you used in the previous section to access the AMQP protocol via the PerfTest tool which acts as a AMQP producer application:
 

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -758,7 +758,9 @@ All resource servers share the variables you set so far under `auth_oauth2.` suc
 The list of supported resource servers is the combination of `auth_oauth2.resource_servers` and `auth_oauth2.resource_server_id`. You can use both or only one of them.
 
 :::info
-There is an [example](./oauth2-examples-multiresource) that demonstrate multiple OAuth 2 resources.
+
+There is an [example](./oauth2-examples-multiresource) that demonstrate how to use multiple OAuth 2 resources.
+
 :::
 
 A list of [all the configurable variables](#multiple-resource-servers-configuration) for

--- a/versioned_docs/version-3.13/oauth2-examples-auth0.md
+++ b/versioned_docs/version-3.13/oauth2-examples-auth0.md
@@ -21,19 +21,18 @@ limitations under the License.
 
 # Use https://auth0.com/ as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Auth0 as Authorization Server using the following flows:
 
-* Access management UI via a browser
+* Access [management UI](./management/) via a browser
 * Access management rest api
-* Access AMQP protocol
+* Application authentication and authorization
 
 ## Prerequisites to follow this guide
 
 * Have an account in https://auth0.com/.
 * Docker
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Create RabbitMQ API
 

--- a/versioned_docs/version-3.13/oauth2-examples-entra-id/index.md
+++ b/versioned_docs/version-3.13/oauth2-examples-entra-id/index.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 # Use Microsoft Entra ID (formerly known as Microsoft Azure AD) as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Microsoft Entra ID as Authorization Server using the following flows:
 
 * Access the management UI via a browser
@@ -31,8 +31,7 @@ and Microsoft Entra ID as Authorization Server using the following flows:
 * Have an account in https://portal.azure.com.
 * Docker
 * Openssl
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Register your app
 
@@ -75,7 +74,7 @@ When using **Entra ID as OAuth 2.0 server**, your client app (in our case Rabbit
     Note the value of the `jwks_uri` key (ex: `https://login.microsoftonline.com/{TENANT_ID}/discovery/v2.0/keys`), as you will also need it later to configure the `rabbitmq_auth_backend_oauth2` on RabbitMQ side.
 
     ![Entra ID JWKS URI](./entra-id-jwks-uri.png)
-8. If the **Endpoints** tab is not visible,     
+8. If the **Endpoints** tab is not visible,
 
 
 ## Create OAuth 2.0 roles for your app
@@ -214,7 +213,7 @@ on port `15671`, see the management UI guide.
 
 :::
 
-When you run `make start-rabbitmq` for the first time with `MODE=entra`, before RabbitMQ is deployed, a TLS certificate is generated for RabbitMQ so that it listens on HTTPS port 15671.  
+When you run `make start-rabbitmq` for the first time with `MODE=entra`, before RabbitMQ is deployed, a TLS certificate is generated for RabbitMQ so that it listens on HTTPS port 15671.
 
 The script generates the following files in `conf/entra/certs`:
 * **cacert.pem**: a custom certificate authority that is used to generate and sign a self signed certificate for RabbitMQ

--- a/versioned_docs/version-3.13/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-3.13/oauth2-examples-keycloak.md
@@ -21,19 +21,18 @@ limitations under the License.
 
 # Use Keycloak as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Keycloak as Authorization Server using the following flows:
 
-* Access management UI via a browser
+* Access [management UI](./management/) via a browser
 * Access management rest api
-* Access AMQP protocol
+* Application authentication and authorization
 
 ## Prerequisites to follow this guide
 
 * Docker
 * make
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Deploy Keycloak
 
@@ -69,7 +68,7 @@ To access the management api run the following command. It uses the client [mgt_
 make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=LWOuYqJ8gjKg3D2U8CJZDuID3KiRZVDa
 ```
 
-## Access AMQP protocol with PerfTest
+## Application authentication and authorization with PerfTest
 
 To test OAuth 2.0 authentication with AMQP protocol you are going to use RabbitMQ PerfTest tool which uses RabbitMQ Java Client.
 
@@ -81,7 +80,7 @@ make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/t
 
 **NOTE**: Initializing an application with a token has one drawback: the application cannot use the connection beyond the lifespan of the token. See the next section where you demonstrate how to refresh the token.
 
-## Access AMQP protocol with Pika
+## Application authentication and authorization with Pika
 
 In the following information, OAuth 2.0 authentication is tested with the AMQP protocol and the Pika library. These tests specifically demonstrate how to refresh a token on a live AMQP connection.
 
@@ -97,7 +96,7 @@ python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 
 Note: Ensure you install pika 1.3
 
-## Access Management UI
+## Access [management UI](./management/)
 
 1. Go to http://localhost:15672.
 2. Click on the single button on the page which redirects to **Keycloak** to authenticate.

--- a/versioned_docs/version-3.13/oauth2-examples-multiresource.md
+++ b/versioned_docs/version-3.13/oauth2-examples-multiresource.md
@@ -1,5 +1,5 @@
 ---
-title: Use multiple OAuth 2.0 servers and/or audiences
+title: Using Multiple OAuth 2.0 Servers and/or Audiences
 displayed_sidebar: docsSidebar
 ---
 <!--
@@ -19,34 +19,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Use multiple OAuth 2.0 servers and/or audiences
+# Using Multiple OAuth 2.0 Servers and/or Audiences
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and several OAuth resources using the following flows:
 
-* Access AMQP protocol
-* Access Management UI
+* Application authentication and authorization
+* Access [management UI](./management/)
 
 ## Prerequisites
 
 * Docker
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
 All the examples demonstrated so far, except for this one, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
 
-You could encounter scenarios where some management users and/or applications are registered in
-different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers.
+In some scenarios some management users and/or applications are registered in
+different OAuth 2 servers or they could be registered on the same OAuth 2 server but refer to RabbitMQ using different audience values. To support this scenario, as many OAuth 2 resources must be declared as audiences and/or authorization servers.
 
 The following three scenarios demonstrate various configurations you may encounter:
 
-* [Scenario 1](oauth2-examples-multiresource#scenario1) - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
-* [Scenario 2](./oauth2-examples-multiresource#scenario2) - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
-* [Scenario 3](./oauth2-examples-multiresource#scenario3) - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
+* [Scenario 1](oauth2-examples-multiresource#scenario1): messaging (AMQP) clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
+* [Scenario 2](./oauth2-examples-multiresource#scenario2): each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) that all use the same OAuth 2 (IDP) server, in this example accessible at `keycloak`.
+* [Scenario 3](./oauth2-examples-multiresource#scenario3): each resource is managed on a dedicated OAuth 2 (IDP) server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
 
-## Scenario 1 - AMQP clients and management users registered in same OAuth 2.0 server but with different audience {#scenario1}
+## Scenario 1: Messaging (AMQP) Clients and Management Users Registered in the Same OAuth 2.0 Server but with Different Audiences {#scenario1}
 
 RabbitMQ is configured with two OAuth2 resources one called `rabbit_prod` and another `rabbit_dev`. For example purposes, let's say, the production team refer to RabbitMQ with the `rabbit_prod` audience. And the development team with the `rabbit_dev` audience.
 As both teams are registered in the same OAuth2 server you are going to configure its settings such as `issuer` at the root level so that both resources share the same configuration.
@@ -55,8 +54,8 @@ As both teams are registered in the same OAuth2 server you are going to configur
 
 This is a summary of the configuration, found in [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
-- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
-- RabbitMQ OAuth2 plugin is configured:
+There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in Keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
+The RabbitMQ OAuth 2 plugin is configured like so:
     * With two resources: `rabbit_prod` and `rabbit_dev`:
     ```ini
     auth_oauth2.resource_servers.1.id = rabbit_prod
@@ -88,7 +87,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 
     :::tip
     It is recommended to follow the logs until keycloak is fully initialized: `docker logs keycloak -f`
-    :::    
+    :::
 
 2. Launch RabbitMQ with [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
@@ -109,7 +108,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
       "iat": 1690974539,
       "jti": "c8edec50-5f29-4bd0-b25b-d7a46dc3474e",
       "iss": "http://localhost:8081/realms/test",
-      "aud": "rabbit_prod",            
+      "aud": "rabbit_prod",
       "sub": "826065e7-bb58-4b65-bbf7-8982d6cca6c8",
       "typ": "Bearer",
       "azp": "prod_producer",
@@ -150,7 +149,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
 * There are two users declared in Keycloak: `prod_user` and `dev_user`.
-* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
+* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ management plugin with each with their own OAuth 2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
     ```ini
     management.oauth_resource_servers.1.id = rabbit_prod
     management.oauth_resource_servers.1.client_id = rabbit_prod_mgt_ui
@@ -186,7 +185,7 @@ The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the 
 :::
 
 
-## Scenario 2 - Two OAuth 2.0 resources on dedicated realm under the same many OAuth providers {#scenario2}
+## Scenario 2: Two OAuth 2 Resources on Dedicated Realm Under as Many OAuth Providers {#scenario2}
 
 This scenario uses the same OAuth 2.0 provider called **keycloak**, however, this time there are two realms, `dev` and `prod`:
 - Under Realm `dev` there are users and clients with granted access to the `rabbit_dev` resource:
@@ -222,8 +221,10 @@ make start-keycloak
 ```
 
 :::tip
+
 Run `docker ps | grep keycloak` to check when the instance has started.
 It is recommended to follow the logs until both instances are fully initialized: `docker logs keycloak -f`
+
 :::
 
 2. Launch RabbitMQ.
@@ -281,7 +282,7 @@ make stop-keycloak
 make stop-rabbitmq
 ```
 
-## Scenario 3 - Two OAuth 2.0 resources on dedicated OAuth provider {#scenario3}
+## Scenario 3: Two OAuth 2 Resources on Dedicated OAuth 2 Providers {#scenario3}
 
 This scenario uses two separate OAuth 2.0 providers called `devkeycloak` and `prodkeycloak`, with the following setup:
 

--- a/versioned_docs/version-3.13/oauth2-examples-multiresource.md
+++ b/versioned_docs/version-3.13/oauth2-examples-multiresource.md
@@ -35,67 +35,75 @@ contains all the configuration files and scripts used on this example.
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
-All the examples demonstrated by this tutorial, except for this use case, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
+All the examples demonstrated so far, except for this one, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
 
 You could encounter scenarios where some management users and/or applications are registered in
-different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers. The following section demonstrates a scenario where users are declared in **Keycloak** however they refer to RabbitMQ with two distinct **audience**, one `rabbit_prod` and the other `rabbit_dev`.
+different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers.
 
-## AMQP clients and management users registered in same OAuth 2.0 server but with different audience
+The following three scenarios demonstrate various configurations you may encounter:
+
+* [Scenario 1](oauth2-examples-multiresource#scenario1) - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
+* [Scenario 2](./oauth2-examples-multiresource#scenario2) - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
+* [Scenario 3](./oauth2-examples-multiresource#scenario3) - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
+
+## Scenario 1 - AMQP clients and management users registered in same OAuth 2.0 server but with different audience {#scenario1}
 
 RabbitMQ is configured with two OAuth2 resources one called `rabbit_prod` and another `rabbit_dev`. For example purposes, let's say, the production team refer to RabbitMQ with the `rabbit_prod` audience. And the development team with the `rabbit_dev` audience.
-As both teams are registered in the same OAuth2 server you are going to configure its settings such as `jwks_url` at the
-root level so that both resources share the same configuration.
-
-In the past, RabbitMQ imposed a restriction where the scopes had to be prefixed with the name of the resource/audience. For instance, if `resource_server_id` was `rabbitmq1`, all scopes had to be prefixed with the value `rabbitmq1`, for example `rabbitmq1.tag:administrator`.
-
-Since RabbitMQ 3.11, you can configure the scope's prefix independent from the resource_id/audience. This is exactly what this scenario uses which configures the scope prefix with the value `rabbitmq.` so that all scopes, regardless of the resource, have the same prefix.
-
+As both teams are registered in the same OAuth2 server you are going to configure its settings such as `issuer` at the root level so that both resources share the same configuration.
 
 ### Test applications accessing AMQP protocol with their own audience
 
-This is a summary of the configuration, found in [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/support-multiple-resource-server-ids/conf/multi-keycloak/rabbitmq.conf):
+This is a summary of the configuration, found in [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
-- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`
-- RabbitMQ OAuth2 plugin is configured with two resources: `rabbit_prod` and `rabbit_dev`
+- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
+- RabbitMQ OAuth2 plugin is configured:
+    * With two resources: `rabbit_prod` and `rabbit_dev`:
     ```ini
     auth_oauth2.resource_servers.1.id = rabbit_prod
     auth_oauth2.resource_servers.2.id = rabbit_dev
     ```
-- Also RabbitMQ OAuth2 plugin is configured with common settings for the two resources declared above
-    ```
+    * With common settings for the previous two resources:
+    ```ini
     auth_oauth2.preferred_username_claims.1 = preferred_username
     auth_oauth2.preferred_username_claims.2 = user_name
     auth_oauth2.preferred_username_claims.3 = email
-    auth_oauth2.jwks_url = https://keycloak:8443/realms/test/protocol/openid-connect/certs
     auth_oauth2.scope_prefix = rabbitmq.
-    auth_oauth2.https.peer_verification = verify_peer
-    auth_oauth2.https.cacertfile = /etc/rabbitmq/keycloak-cacert.pem
+    ```
+    * With one oauth provider:
+    ```ini
+    auth_oauth2.oauth_providers.keycloak.issuer = https://keycloak:8443/realms/test
+    auth_oauth2.oauth_providers.keycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+    auth_oauth2.oauth_providers.keycloak.https.verify = verify_peer
+    auth_oauth2.oauth_providers.keycloak.https.hostname_verification = wildcard
+    auth_oauth2.default_oauth_provider = keycloak
     ```
 
 Follow these steps to deploy Keycloak and RabbitMQ:
 
+1. Launch Keycloak. Check out [Admin page](http://localhost:8081/admin/master/console/#/test) with the credentials `admin:admin`:
 
-1. Launch Keycloak. Check out [Admin page](http://localhost:8081/admin/master/console/#/test) with the credentials `admin:admin`
-
-    ```
+    ```bash
     make start-keycloak
     ```
 
-2. Launch RabbitMQ
+    :::tip
+    It is recommended to follow the logs until keycloak is fully initialized: `docker logs keycloak -f`
+    :::    
 
-    ```
-    export MODE="multi-keycloak"
-    make start-rabbitmq
+2. Launch RabbitMQ with [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
+
+    ```bash
+    MODE="multi-keycloak" CONF="rabbitmq.scenario1.conf" make start-rabbitmq
     ```
 
-3. Launch the AMQP producer registered in Keycloak with the **client_id** `prod_producer`s and with the permission to access the `rabbit_prod` resource, and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`
+3. Launch the AMQP producer registered in Keycloak with the **client_id** `prod_producer`s and with the permission to access the `rabbit_prod` resource, and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
 
-    ```
+    ```bash
     make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/keycloak/token prod_producer PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9)
     ```
 
     This is an access token generated for `prod_producer`.
-    ```
+    ```json
     {
       "exp": 1690974839,
       "iat": 1690974539,
@@ -133,17 +141,17 @@ Follow these steps to deploy Keycloak and RabbitMQ:
     ```
 
 4. Similarly, launch AMQP producer `dev_producer`, registered in Keycloak too but with the permission to access `rabbit_dev` resource:
-    ```sh
+    ```bash
     make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/keycloak/token dev_producer z1PNm47wfWyulTnAaDOf1AggTy3MxX2H)
     ```
 
 ### Test Management UI accessed via two separate resources
 
-This is a summary of the configuration, found in [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/support-multiple-resource-server-ids/conf/multi-keycloak/rabbitmq.conf):
+This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
-* There are two users declared in Keycloak: `prod_user` and `dev_user`
-* The two resources: `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource.
-    ```
+* There are two users declared in Keycloak: `prod_user` and `dev_user`.
+* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
+    ```ini
     management.oauth_resource_servers.1.id = rabbit_prod
     management.oauth_resource_servers.1.client_id = rabbit_prod_mgt_ui
     management.oauth_resource_servers.1.label = RabbitMQ Production
@@ -154,20 +162,218 @@ This is a summary of the configuration, found in [rabbitmq.conf](https://github.
     management.oauth_resource_servers.2.label = RabbitMQ Development
     management.oauth_resource_servers.2.scopes = openid profile rabbitmq.tag:management
     ```
-* As there is only one OAuth2 server, both resources share the same `provider_url`:
-    ```ini
-    management.oauth_provider_url = http://0.0.0.0:8081/realms/test
-    ```
+
+    :::note
+    As there is only one OAuth2 server, both resources share the oauth provider called **keycloak**.
+    :::
+
 * Each OAuth2 client, `rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`, is declared in Keycloak so that they can only emit tokens for their respective audience, be it `rabbit_prod` and `rabbit_dev` respectively.
 
-Follow the steps:
+Follow the steps to the management UI flows with two OAuth resources:
 
-1. Go to the [RabbitMQ Management UI](http://localhost:15672)
-2. Select `RabbitMQ Production` resource
-3. Login as `prod_user`:`prod_user`
-4. Keycloak prompts you to authorize various scopes for `prod_user`
-5. You should now get redirected to the Management UI as `prod_user` user
+1. Go to the [RabbitMQ Management UI](http://localhost:15672).
+2. Select `RabbitMQ Production` resource.
+3. Login as `prod_user`:`prod_user`.
+4. Keycloak prompts you to authorize various scopes for `prod_user`.
+5. You should now get redirected to the Management UI as `prod_user` user.
 
 Now, logout and repeat the same steps for `dev_user` user. For this user, RabbitMQ is configured to request the `rabbitmq.tag:management` scope only.
 
-**Note**: In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_user` because RabbitMQ is configured to request the scope: `rabbitmq.tag:administrator` for `RabbitMQ Production`. The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
+:::warning
+In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_user` because RabbitMQ is configured to request the scope: `rabbitmq.tag:administrator` for `RabbitMQ Production`.
+
+The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
+:::
+
+
+## Scenario 2 - Two OAuth 2.0 resources on dedicated realm under the same many OAuth providers {#scenario2}
+
+This scenario uses the same OAuth 2.0 provider called **keycloak**, however, this time there are two realms, `dev` and `prod`:
+- Under Realm `dev` there are users and clients with granted access to the `rabbit_dev` resource:
+	- `dev_producer` (password: `SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8`).
+	- `rabbit_dev_admin` (password: `rabbit_dev_admin`).
+	- `rabbit_dev_mgt_api`.
+- Under Realm `prod` there are users and clients with granted access to the `rabbit_prod` resource:
+	- `prod_producer` with the audience `rabbit_prod` (password: `PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9`).
+	- `rabbit_prod_admin` (password: `rabbit_prod_admin`).
+
+Despite there is only one physical OAuth provider, you need to configure RabbitMQ with two OAuth 2.0 providers. Each tenant has its own `issuer` url. This is the configuration file used for this scenario is  [rabbitmq.scenario2.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario2.conf). For convenience here is the relevant part:
+```ini
+...
+## Oauth providers
+auth_oauth2.oauth_providers.devkeycloak.issuer = https://keycloak:8443/realms/dev
+auth_oauth2.oauth_providers.devkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.devkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.devkeycloak.https.hostname_verification = wildcard
+
+auth_oauth2.oauth_providers.prodkeycloak.issuer = https://keycloak:8443/realms/prod
+auth_oauth2.oauth_providers.prodkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.prodkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.prodkeycloak.https.hostname_verification = wildcard
+
+...
+```
+
+Follow these steps to deploy Keycloak and RabbitMQ:
+
+1. Launch Keycloak.
+```bash
+make start-keycloak
+```
+
+:::tip
+Run `docker ps | grep keycloak` to check when the instance has started.
+It is recommended to follow the logs until both instances are fully initialized: `docker logs keycloak -f`
+:::
+
+2. Launch RabbitMQ.
+```bash
+MODE=multi-keycloak OAUTH_PROVIDER=keycloak CONF=rabbitmq.scenario2.conf make start-rabbitmq
+```
+
+3. Launch AMQP producer registered in Keycloak with the **client_id** `prod_producer` and with the permission to access `rabbit_prod` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/keycloak/token prod_producer sIqZ5flmSz3r6uKXMSz8CWGeScdTpqq0 prod)
+```
+
+4. Launch AMQP producer registered in Keycloak with the **client_id** `dev_producer` and with the permission to access `rabbit_dev` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/keycloak/token dev_producer SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8 dev)
+```
+
+5. Stop both producers:
+```bash
+make stop-perftest-producer PRODUCER=dev_producer
+make stop-perftest-producer PRODUCER=prod_producer
+```
+
+6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=dev
+```
+
+You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
+
+8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+```
+
+You should see in the standard output the following:
+```json
+{"error":"not_authorized","reason":"Not_Authorized"}
+```
+
+9. Verify Management UI access:
+
+	- Go to http://localhost:15672.
+	- Select *RabbitMQ Development* OAuth 2.0 resource.
+	- Click on "Click here to login".
+	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
+	- Verify that user is redirected by to Management UI.
+	- Click on Logout.
+	- Repeat with *RabbitMQ Production* and user `rabbit_prod_admin` / `rabbit_prod_admin`.
+
+10. Shutdown RabbitMQ and Keycloak
+
+```bash
+make stop-keycloak
+make stop-rabbitmq
+```
+
+## Scenario 3 - Two OAuth 2.0 resources on dedicated OAuth provider {#scenario3}
+
+This scenario uses two separate OAuth 2.0 providers called `devkeycloak` and `prodkeycloak`, with the following setup:
+
+- `devkeycloak` has the following setup under the `dev` Realm and grants access to `rabbit_dev` resource:
+	- `dev_producer` with the audience `rabbit_dev` (password: `SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8`).
+	- `rabbit_dev_admin` (password: `rabbit_dev_admin`).
+	- `rabbit_dev_mgt_api`.
+- `prodkeycloak` has the following setup under the `prod` Realm and grants access to `rabbit_prod` resource:
+	- `prod_producer` with the audience `rabbit_prod` (password: `PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9`).
+	- `rabbit_prod_admin` (password: `rabbit_prod_admin`).
+
+Check out the section `oauth_providers` in the configuration file [rabbitmq.scenario3.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario3.conf) used by this scenario. Like in the scenario 2, there are two OAuth providers however this time the URL refers to two different hostnames. For convenience here is the relevant part:
+
+```ini
+...
+
+## Oauth providers
+auth_oauth2.oauth_providers.devkeycloak.issuer = https://devkeycloak:8443/realms/dev
+auth_oauth2.oauth_providers.devkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.devkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.devkeycloak.https.hostname_verification = wildcard
+
+auth_oauth2.oauth_providers.prodkeycloak.issuer = https://prodkeycloak:8442/realms/prod
+auth_oauth2.oauth_providers.prodkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.prodkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.prodkeycloak.https.hostname_verification = wildcard
+
+...
+```
+
+Follow these steps to deploy two Keycloaks and RabbitMQ:
+
+1. Launch Keycloak.
+```bash
+make start-dev-keycloak
+make start-prod-keycloak
+```
+:::tip
+Run `docker ps | grep keycloak` to see two instances have started.
+:::
+
+2. Launch RabbitMQ.
+```bash
+MODE=multi-keycloak CONF=rabbitmq.scenario3.conf make start-rabbitmq
+```
+
+3. Launch AMQP producer registered in Keycloak with the **client_id** `prod_producer` and with the permission to access `rabbit_prod` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/prodkeycloak/token prod_producer PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9)
+```
+
+4. Launch AMQP producer registered in Keycloak with the **client_id** `dev_producer` and with the permission to access `rabbit_dev` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/devkeycloak/token dev_producer z1PNm47wfWyulTnAaDOf1AggTy3MxX2H)
+```
+
+5. Stop both producers:
+```bash
+make stop-perftest-producer PRODUCER=dev_producer
+make stop-perftest-producer PRODUCER=prod_producer
+```
+
+6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
+```bash
+make curl-dev-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=p7v6DksWkcb6TUYK6payswovC0LqhU6A
+```
+
+You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
+
+8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+```
+
+You should see in the standard output the following:
+```json
+{"error":"not_authorized","reason":"Not_Authorized"}
+```
+
+9. Verify Management UI access:
+
+	- Go to http://localhost:15672.
+	- Select *RabbitMQ Development* OAuth 2.0 resource.
+	- Click on "Click here to login".
+	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
+	- Verify that user is redirected by to Management UI.
+	- Click on Logout.
+	- Repeat with *RabbitMQ Production* and user `rabbit_prod_admin` / `rabbit_prod_admin`.
+
+10. Shutdown RabbitMQ and the two Keycloaks:
+```bash
+make stop-dev-keycloak
+make stop-prod-keycloak
+make stop-rabbitmq
+```

--- a/versioned_docs/version-3.13/oauth2-examples-okta.md
+++ b/versioned_docs/version-3.13/oauth2-examples-okta.md
@@ -24,7 +24,7 @@ limitations under the License.
 Demonstrate how to authenticate using OAuth 2.0 protocol
 and Okta as Authorization Server using the following flows:
 
-1. Access management UI via a browser
+1. Access [management UI](./management/) via a browser
 
 ## Prerequisites to follow this guide
 
@@ -63,9 +63,9 @@ In Trusted Origins (for Web and Native app integrations), choose **keep the defa
 
 In Assignments, choose **Allow everyone in your organization to access**.
 
-Finally, click on **Save** and write down the following values, as you will need them later to configure RabbitMQ:  
+Finally, click on **Save** and write down the following values, as you will need them later to configure RabbitMQ:
 
-  * **ClientID**  
+  * **ClientID**
   * **Okta domain name**
 
 
@@ -101,7 +101,7 @@ And below are the steps to create a claim for **role** to distinguish `admin` an
 
 6. Choose **Expression** as Value type
 
-7. In **Value** field enter the following expression:  
+7. In **Value** field enter the following expression:
   `isMemberOfGroupName("admin") ? "admin" : isMemberOfGroupName("monitoring") ? "monitoring" : ""`
 
 8. Click on create.
@@ -152,7 +152,7 @@ Once you've added the user to the appropriate groups and apps, they should have 
 
 The configuration on Okta side is done. You now have to configure RabbitMQ to use the resources you just created.
 
-[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta. 
+[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
 
 Update it with the following values (you should have noted these in the previous steps):
 

--- a/versioned_docs/version-3.13/oauth2-examples-proxy.md
+++ b/versioned_docs/version-3.13/oauth2-examples-proxy.md
@@ -43,8 +43,7 @@ Let's test the following flow:
 
 * Docker
 * make
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Deploy Keycloak
 
@@ -94,7 +93,7 @@ make start-oauth2-proxy
 Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
-## Access Management UI
+## Access [management UI](./management/)
 
 Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
 `rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/versioned_docs/version-3.13/oauth2-examples/index.md
+++ b/versioned_docs/version-3.13/oauth2-examples/index.md
@@ -40,7 +40,7 @@ which hosts all the scripts required to deploy the examples demonstrated on the 
 
 ### Management UI Access
 
-* [Access Management UI using OAuth 2.0 tokens](#access-management-ui)
+* [Access [management UI](./management/) using OAuth 2.0 tokens](#access-management-ui)
 * [Service-Provider initiated logon](#service-provider-initiated-logon)
 * [Identity-Provider initiated logon](#identity-provider-initiated-logon)
 
@@ -92,7 +92,7 @@ Run the following two commands to start UAA and RabbitMQ configured for UAA:
 
 The last command starts a RabbitMQ with a specific configuration file, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/uaa/rabbitmq.conf).
 
-## Access Management UI using OAuth 2.0 tokens {#access-management-ui}
+## Access [management UI](./management/) using OAuth 2.0 tokens {#access-management-ui}
 
 The RabbitMQ Management UI can be configured with one of these two login modes:
 
@@ -802,7 +802,7 @@ make curl-with-token URL=http://localhost:15672/api/overview TOKEN=$(bin/jwt_tok
 
 Note: You are using curl to go to the URL using a TOKEN which you have built using the command bin/jwt_token which takes the JWT payload, the name of the signing key and the private and public certificates to sign the token
 
-*Use a Rich Authorization Token to access AMQP protocol*
+*Use a Rich Authorization Token to Application authentication and authorization*
 
 This time, You are going to use the same token you used in the previous section to access the AMQP protocol via the PerfTest tool which acts as a AMQP producer application:
 

--- a/versioned_docs/version-3.13/oauth2.md
+++ b/versioned_docs/version-3.13/oauth2.md
@@ -404,7 +404,7 @@ or
 [
   {rabbitmq_auth_backend_oauth2, [
     {resource_server_id, <<"my_rabbit_server">>},
-    {issuer, <<"https://my-idp-provider/somerealm">>}    
+    {issuer, <<"https://my-idp-provider/somerealm">>}
   ]},
 ].
 ```
@@ -544,7 +544,7 @@ By default the plugin looks for the `scope` key in the token, you can configure 
     {resource_server_id, <<"my_rabbit_server">>},
     {extra_scopes_source, <<"my_custom_scope_key">>},
     ...
-    ]}  
+    ]}
 ].
 ```
 
@@ -773,7 +773,9 @@ All resource servers share the variables you set so far under `auth_oauth2.` suc
 The list of supported resource servers is the combination of `auth_oauth2.resource_servers` and `auth_oauth2.resource_server_id`. You can use both or only one of them.
 
 :::info
-There is an [example](./oauth2-examples-multiresource) that demonstrate multiple OAuth 2 resources.
+
+There is an [example](./oauth2-examples-multiresource) that demonstrate how to use multiple OAuth 2 resources.
+
 :::
 
 ### Configure OAuth 2.0 provider's end_session_endpoint {#configure-end-session-endpoint}

--- a/versioned_docs/version-4.0/oauth2-examples-auth0.md
+++ b/versioned_docs/version-4.0/oauth2-examples-auth0.md
@@ -21,19 +21,18 @@ limitations under the License.
 
 # Use https://auth0.com/ as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Auth0 as Authorization Server using the following flows:
 
-* Access management UI via a browser
+* Access [management UI](./management/) via a browser
 * Access management rest api
-* Access AMQP protocol
+* Application authentication and authorization
 
 ## Prerequisites to follow this guide
 
 * Have an account in https://auth0.com/.
 * Docker
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Create RabbitMQ API
 

--- a/versioned_docs/version-4.0/oauth2-examples-entra-id/index.md
+++ b/versioned_docs/version-4.0/oauth2-examples-entra-id/index.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 # Use Microsoft Entra ID (formerly known as Microsoft Azure AD) as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Microsoft Entra ID as Authorization Server using the following flows:
 
 * Access the management UI via a browser
@@ -31,8 +31,7 @@ and Microsoft Entra ID as Authorization Server using the following flows:
 * Have an account in https://portal.azure.com.
 * Docker
 * Openssl
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Register your app
 
@@ -214,7 +213,7 @@ on port `15671`, see the management UI guide.
 
 :::
 
-When you run `make start-rabbitmq` for the first time with `MODE=entra`, before RabbitMQ is deployed, a TLS certificate is generated for RabbitMQ so that it listens on HTTPS port 15671.  
+When you run `make start-rabbitmq` for the first time with `MODE=entra`, before RabbitMQ is deployed, a TLS certificate is generated for RabbitMQ so that it listens on HTTPS port 15671.
 
 The script generates the following files in `conf/entra/certs`:
 * **cacert.pem**: a custom certificate authority that is used to generate and sign a self signed certificate for RabbitMQ

--- a/versioned_docs/version-4.0/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-4.0/oauth2-examples-keycloak.md
@@ -21,19 +21,18 @@ limitations under the License.
 
 # Use Keycloak as OAuth 2.0 server
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and Keycloak as Authorization Server using the following flows:
 
-* Access management UI via a browser
+* Access [management UI](./management/) via a browser
 * Access management rest api
-* Access AMQP protocol
+* Application authentication and authorization
 
 ## Prerequisites to follow this guide
 
 * Docker
 * make
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Deploy Keycloak
 
@@ -69,7 +68,7 @@ To access the management api run the following command. It uses the client [mgt_
 make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=LWOuYqJ8gjKg3D2U8CJZDuID3KiRZVDa
 ```
 
-## Access AMQP protocol with PerfTest
+## Application authentication and authorization with PerfTest
 
 To test OAuth 2.0 authentication with AMQP protocol you are going to use RabbitMQ PerfTest tool which uses RabbitMQ Java Client.
 
@@ -81,7 +80,7 @@ make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/t
 
 **NOTE**: Initializing an application with a token has one drawback: the application cannot use the connection beyond the lifespan of the token. See the next section where you demonstrate how to refresh the token.
 
-## Access AMQP protocol with Pika
+## Application authentication and authorization with Pika
 
 In the following information, OAuth 2.0 authentication is tested with the AMQP protocol and the Pika library. These tests specifically demonstrate how to refresh a token on a live AMQP connection.
 
@@ -97,7 +96,7 @@ python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 
 Note: Ensure you install pika 1.3
 
-## Access Management UI
+## Access [management UI](./management/)
 
 1. Go to http://localhost:15672.
 2. Click on the single button on the page which redirects to **Keycloak** to authenticate.

--- a/versioned_docs/version-4.0/oauth2-examples-multiresource.md
+++ b/versioned_docs/version-4.0/oauth2-examples-multiresource.md
@@ -1,5 +1,5 @@
 ---
-title: Use multiple OAuth 2.0 servers and/or audiences
+title: Using Multiple OAuth 2.0 Servers and/or Audiences
 displayed_sidebar: docsSidebar
 ---
 <!--
@@ -19,34 +19,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Use multiple OAuth 2.0 servers and/or audiences
+# Using Multiple OAuth 2.0 Servers and/or Audiences
 
-Demonstrate how to authenticate using the OAuth 2.0 protocol
+This guide explains how to set up OAuth 2.0 for RabbitMQ
 and several OAuth resources using the following flows:
 
-* Access AMQP protocol
-* Access Management UI
+* Application authentication and authorization
+* Access [management UI](./management/)
 
 ## Prerequisites
 
 * Docker
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
 All the examples demonstrated so far, except for this one, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
 
-You could encounter scenarios where some management users and/or applications are registered in
-different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers.
+In some scenarios some management users and/or applications are registered in
+different OAuth 2 servers or they could be registered on the same OAuth 2 server but refer to RabbitMQ using different audience values. To support this scenario, as many OAuth 2 resources must be declared as audiences and/or authorization servers.
 
 The following three scenarios demonstrate various configurations you may encounter:
 
-* [Scenario 1](oauth2-examples-multiresource#scenario1) - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
-* [Scenario 2](./oauth2-examples-multiresource#scenario2) - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
-* [Scenario 3](./oauth2-examples-multiresource#scenario3) - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
+* [Scenario 1](oauth2-examples-multiresource#scenario1): messaging (AMQP) clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
+* [Scenario 2](./oauth2-examples-multiresource#scenario2): each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) that all use the same OAuth 2 (IDP) server, in this example accessible at `keycloak`.
+* [Scenario 3](./oauth2-examples-multiresource#scenario3): each resource is managed on a dedicated OAuth 2 (IDP) server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
 
-## Scenario 1 - AMQP clients and management users registered in same OAuth 2.0 server but with different audience {#scenario1}
+## Scenario 1: Messaging (AMQP) Clients and Management Users Registered in the Same OAuth 2.0 Server but with Different Audiences {#scenario1}
 
 RabbitMQ is configured with two OAuth2 resources one called `rabbit_prod` and another `rabbit_dev`. For example purposes, let's say, the production team refer to RabbitMQ with the `rabbit_prod` audience. And the development team with the `rabbit_dev` audience.
 As both teams are registered in the same OAuth2 server you are going to configure its settings such as `issuer` at the root level so that both resources share the same configuration.
@@ -55,8 +54,8 @@ As both teams are registered in the same OAuth2 server you are going to configur
 
 This is a summary of the configuration, found in [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
-- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
-- RabbitMQ OAuth2 plugin is configured:
+There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in Keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
+The RabbitMQ OAuth 2 plugin is configured like so:
     * With two resources: `rabbit_prod` and `rabbit_dev`:
     ```ini
     auth_oauth2.resource_servers.1.id = rabbit_prod
@@ -88,7 +87,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 
     :::tip
     It is recommended to follow the logs until keycloak is fully initialized: `docker logs keycloak -f`
-    :::    
+    :::
 
 2. Launch RabbitMQ with [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
@@ -109,7 +108,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
       "iat": 1690974539,
       "jti": "c8edec50-5f29-4bd0-b25b-d7a46dc3474e",
       "iss": "http://localhost:8081/realms/test",
-      "aud": "rabbit_prod",            
+      "aud": "rabbit_prod",
       "sub": "826065e7-bb58-4b65-bbf7-8982d6cca6c8",
       "typ": "Bearer",
       "azp": "prod_producer",
@@ -150,7 +149,7 @@ Follow these steps to deploy Keycloak and RabbitMQ:
 This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
 * There are two users declared in Keycloak: `prod_user` and `dev_user`.
-* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
+* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ management plugin with each with their own OAuth 2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
     ```ini
     management.oauth_resource_servers.1.id = rabbit_prod
     management.oauth_resource_servers.1.client_id = rabbit_prod_mgt_ui
@@ -186,7 +185,7 @@ The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the 
 :::
 
 
-## Scenario 2 - Two OAuth 2.0 resources on dedicated realm under the same many OAuth providers {#scenario2}
+## Scenario 2: Two OAuth 2 Resources on Dedicated Realm Under as Many OAuth Providers {#scenario2}
 
 This scenario uses the same OAuth 2.0 provider called **keycloak**, however, this time there are two realms, `dev` and `prod`:
 - Under Realm `dev` there are users and clients with granted access to the `rabbit_dev` resource:
@@ -222,8 +221,10 @@ make start-keycloak
 ```
 
 :::tip
+
 Run `docker ps | grep keycloak` to check when the instance has started.
 It is recommended to follow the logs until both instances are fully initialized: `docker logs keycloak -f`
+
 :::
 
 2. Launch RabbitMQ.
@@ -281,7 +282,7 @@ make stop-keycloak
 make stop-rabbitmq
 ```
 
-## Scenario 3 - Two OAuth 2.0 resources on dedicated OAuth provider {#scenario3}
+## Scenario 3: Two OAuth 2 Resources on Dedicated OAuth 2 Providers {#scenario3}
 
 This scenario uses two separate OAuth 2.0 providers called `devkeycloak` and `prodkeycloak`, with the following setup:
 

--- a/versioned_docs/version-4.0/oauth2-examples-multiresource.md
+++ b/versioned_docs/version-4.0/oauth2-examples-multiresource.md
@@ -35,67 +35,75 @@ contains all the configuration files and scripts used on this example.
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
-All the examples demonstrated by this tutorial, except for this use case, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
+All the examples demonstrated so far, except for this one, configure a single **resource_server_id** and therefore a single **OAuth 2.0 server**.
 
 You could encounter scenarios where some management users and/or applications are registered in
-different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers. The following section demonstrates a scenario where users are declared in **Keycloak** however they refer to RabbitMQ with two distinct **audience**, one `rabbit_prod` and the other `rabbit_dev`.
+different OAuth2 servers or they could be registered on the same OAuth2 server however they could refer to RabbitMQ with different audience values. When this happens, you have to declare as many OAuth2 resources as audiences and/or authorization servers.
 
-## AMQP clients and management users registered in same OAuth 2.0 server but with different audience
+The following three scenarios demonstrate various configurations you may encounter:
+
+* [Scenario 1](oauth2-examples-multiresource#scenario1) - AMQP clients and management users are registered in same OAuth 2.0 server, **keycloak**, but with different audience, e.g. `rabbit_prod` and `rabbit_dev` respectively.
+* [Scenario 2](./oauth2-examples-multiresource#scenario2) - Each resource is managed on a dedicated realm (i.e. `rabbit_prod` resource -> https://keycloak:8443/realms/prod realm, `rabbit_dev` resource -> https://keycloak:8443/realms/dev) but under the same physical server, **keycloak**.
+* [Scenario 3](./oauth2-examples-multiresource#scenario3) - Each resource is managed on a dedicated OAuth server and realm (i.e. `rabbit_dev` -> https://devkeycloak:8443/realms/dev, `rabbit_dev` -> https://prodkeycloak:8442/realms/prod).
+
+## Scenario 1 - AMQP clients and management users registered in same OAuth 2.0 server but with different audience {#scenario1}
 
 RabbitMQ is configured with two OAuth2 resources one called `rabbit_prod` and another `rabbit_dev`. For example purposes, let's say, the production team refer to RabbitMQ with the `rabbit_prod` audience. And the development team with the `rabbit_dev` audience.
-As both teams are registered in the same OAuth2 server you are going to configure its settings such as `jwks_url` at the
-root level so that both resources share the same configuration.
-
-In the past, RabbitMQ imposed a restriction where the scopes had to be prefixed with the name of the resource/audience. For instance, if `resource_server_id` was `rabbitmq1`, all scopes had to be prefixed with the value `rabbitmq1`, for example `rabbitmq1.tag:administrator`.
-
-Since RabbitMQ 3.11, you can configure the scope's prefix independent from the resource_id/audience. This is exactly what this scenario uses which configures the scope prefix with the value `rabbitmq.` so that all scopes, regardless of the resource, have the same prefix.
-
+As both teams are registered in the same OAuth2 server you are going to configure its settings such as `issuer` at the root level so that both resources share the same configuration.
 
 ### Test applications accessing AMQP protocol with their own audience
 
-This is a summary of the configuration, found in [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/support-multiple-resource-server-ids/conf/multi-keycloak/rabbitmq.conf):
+This is a summary of the configuration, found in [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
 
-- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`
-- RabbitMQ OAuth2 plugin is configured with two resources: `rabbit_prod` and `rabbit_dev`
+- There are two OAuth2 clients (`prod_producer` and `dev_producer`) declared in keycloak and configured to access their respective audience: `rabbit_prod` and `rabbit_dev`.
+- RabbitMQ OAuth2 plugin is configured:
+    * With two resources: `rabbit_prod` and `rabbit_dev`:
     ```ini
     auth_oauth2.resource_servers.1.id = rabbit_prod
     auth_oauth2.resource_servers.2.id = rabbit_dev
     ```
-- Also RabbitMQ OAuth2 plugin is configured with common settings for the two resources declared above
-    ```
+    * With common settings for the previous two resources:
+    ```ini
     auth_oauth2.preferred_username_claims.1 = preferred_username
     auth_oauth2.preferred_username_claims.2 = user_name
     auth_oauth2.preferred_username_claims.3 = email
-    auth_oauth2.jwks_url = https://keycloak:8443/realms/test/protocol/openid-connect/certs
     auth_oauth2.scope_prefix = rabbitmq.
-    auth_oauth2.https.peer_verification = verify_peer
-    auth_oauth2.https.cacertfile = /etc/rabbitmq/keycloak-cacert.pem
+    ```
+    * With one oauth provider:
+    ```ini
+    auth_oauth2.oauth_providers.keycloak.issuer = https://keycloak:8443/realms/test
+    auth_oauth2.oauth_providers.keycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+    auth_oauth2.oauth_providers.keycloak.https.verify = verify_peer
+    auth_oauth2.oauth_providers.keycloak.https.hostname_verification = wildcard
+    auth_oauth2.default_oauth_provider = keycloak
     ```
 
 Follow these steps to deploy Keycloak and RabbitMQ:
 
+1. Launch Keycloak. Check out [Admin page](http://localhost:8081/admin/master/console/#/test) with the credentials `admin:admin`:
 
-1. Launch Keycloak. Check out [Admin page](http://localhost:8081/admin/master/console/#/test) with the credentials `admin:admin`
-
-    ```
+    ```bash
     make start-keycloak
     ```
 
-2. Launch RabbitMQ
+    :::tip
+    It is recommended to follow the logs until keycloak is fully initialized: `docker logs keycloak -f`
+    :::    
 
-    ```
-    export MODE="multi-keycloak"
-    make start-rabbitmq
+2. Launch RabbitMQ with [rabbitmq.scenario1.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario1.conf):
+
+    ```bash
+    MODE="multi-keycloak" CONF="rabbitmq.scenario1.conf" make start-rabbitmq
     ```
 
-3. Launch the AMQP producer registered in Keycloak with the **client_id** `prod_producer`s and with the permission to access the `rabbit_prod` resource, and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`
+3. Launch the AMQP producer registered in Keycloak with the **client_id** `prod_producer`s and with the permission to access the `rabbit_prod` resource, and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
 
-    ```
+    ```bash
     make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/keycloak/token prod_producer PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9)
     ```
 
     This is an access token generated for `prod_producer`.
-    ```
+    ```json
     {
       "exp": 1690974839,
       "iat": 1690974539,
@@ -133,17 +141,17 @@ Follow these steps to deploy Keycloak and RabbitMQ:
     ```
 
 4. Similarly, launch AMQP producer `dev_producer`, registered in Keycloak too but with the permission to access `rabbit_dev` resource:
-    ```sh
+    ```bash
     make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/keycloak/token dev_producer z1PNm47wfWyulTnAaDOf1AggTy3MxX2H)
     ```
 
 ### Test Management UI accessed via two separate resources
 
-This is a summary of the configuration, found in [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/support-multiple-resource-server-ids/conf/multi-keycloak/rabbitmq.conf):
+This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
-* There are two users declared in Keycloak: `prod_user` and `dev_user`
-* The two resources: `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource.
-    ```
+* There are two users declared in Keycloak: `prod_user` and `dev_user`.
+* The two resources, `rabbit_prod` and `rabbit_dev` are declared in the RabbitMQ Management Plugin with their own OAuth2 client (`rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`) scopes, and the label associated with each resource:
+    ```ini
     management.oauth_resource_servers.1.id = rabbit_prod
     management.oauth_resource_servers.1.client_id = rabbit_prod_mgt_ui
     management.oauth_resource_servers.1.label = RabbitMQ Production
@@ -154,20 +162,218 @@ This is a summary of the configuration, found in [rabbitmq.conf](https://github.
     management.oauth_resource_servers.2.label = RabbitMQ Development
     management.oauth_resource_servers.2.scopes = openid profile rabbitmq.tag:management
     ```
-* As there is only one OAuth2 server, both resources share the same `provider_url`:
-    ```ini
-    management.oauth_provider_url = http://0.0.0.0:8081/realms/test
-    ```
+
+    :::note
+    As there is only one OAuth2 server, both resources share the oauth provider called **keycloak**.
+    :::
+
 * Each OAuth2 client, `rabbit_prod_mgt_ui` and `rabbit_dev_mgt_ui`, is declared in Keycloak so that they can only emit tokens for their respective audience, be it `rabbit_prod` and `rabbit_dev` respectively.
 
-Follow the steps:
+Follow the steps to the management UI flows with two OAuth resources:
 
-1. Go to the [RabbitMQ Management UI](http://localhost:15672)
-2. Select `RabbitMQ Production` resource
-3. Login as `prod_user`:`prod_user`
-4. Keycloak prompts you to authorize various scopes for `prod_user`
-5. You should now get redirected to the Management UI as `prod_user` user
+1. Go to the [RabbitMQ Management UI](http://localhost:15672).
+2. Select `RabbitMQ Production` resource.
+3. Login as `prod_user`:`prod_user`.
+4. Keycloak prompts you to authorize various scopes for `prod_user`.
+5. You should now get redirected to the Management UI as `prod_user` user.
 
 Now, logout and repeat the same steps for `dev_user` user. For this user, RabbitMQ is configured to request the `rabbitmq.tag:management` scope only.
 
-**Note**: In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_user` because RabbitMQ is configured to request the scope: `rabbitmq.tag:administrator` for `RabbitMQ Production`. The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
+:::warning
+In step 3, if you login as the `dev_user`, RabbitMQ will not authorize the `dev_user` because RabbitMQ is configured to request the scope: `rabbitmq.tag:administrator` for `RabbitMQ Production`.
+
+The `dev_user` does not have the `rabbitmq.tag:administrator` scope, it has the `rabbitmq.tag:management` scope. In this scenario, the `dev_user` gets a token which has none of the scopes RabbitMQ supports.
+:::
+
+
+## Scenario 2 - Two OAuth 2.0 resources on dedicated realm under the same many OAuth providers {#scenario2}
+
+This scenario uses the same OAuth 2.0 provider called **keycloak**, however, this time there are two realms, `dev` and `prod`:
+- Under Realm `dev` there are users and clients with granted access to the `rabbit_dev` resource:
+	- `dev_producer` (password: `SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8`).
+	- `rabbit_dev_admin` (password: `rabbit_dev_admin`).
+	- `rabbit_dev_mgt_api`.
+- Under Realm `prod` there are users and clients with granted access to the `rabbit_prod` resource:
+	- `prod_producer` with the audience `rabbit_prod` (password: `PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9`).
+	- `rabbit_prod_admin` (password: `rabbit_prod_admin`).
+
+Despite there is only one physical OAuth provider, you need to configure RabbitMQ with two OAuth 2.0 providers. Each tenant has its own `issuer` url. This is the configuration file used for this scenario is  [rabbitmq.scenario2.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario2.conf). For convenience here is the relevant part:
+```ini
+...
+## Oauth providers
+auth_oauth2.oauth_providers.devkeycloak.issuer = https://keycloak:8443/realms/dev
+auth_oauth2.oauth_providers.devkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.devkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.devkeycloak.https.hostname_verification = wildcard
+
+auth_oauth2.oauth_providers.prodkeycloak.issuer = https://keycloak:8443/realms/prod
+auth_oauth2.oauth_providers.prodkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.prodkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.prodkeycloak.https.hostname_verification = wildcard
+
+...
+```
+
+Follow these steps to deploy Keycloak and RabbitMQ:
+
+1. Launch Keycloak.
+```bash
+make start-keycloak
+```
+
+:::tip
+Run `docker ps | grep keycloak` to check when the instance has started.
+It is recommended to follow the logs until both instances are fully initialized: `docker logs keycloak -f`
+:::
+
+2. Launch RabbitMQ.
+```bash
+MODE=multi-keycloak OAUTH_PROVIDER=keycloak CONF=rabbitmq.scenario2.conf make start-rabbitmq
+```
+
+3. Launch AMQP producer registered in Keycloak with the **client_id** `prod_producer` and with the permission to access `rabbit_prod` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/keycloak/token prod_producer sIqZ5flmSz3r6uKXMSz8CWGeScdTpqq0 prod)
+```
+
+4. Launch AMQP producer registered in Keycloak with the **client_id** `dev_producer` and with the permission to access `rabbit_dev` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/keycloak/token dev_producer SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8 dev)
+```
+
+5. Stop both producers:
+```bash
+make stop-perftest-producer PRODUCER=dev_producer
+make stop-perftest-producer PRODUCER=prod_producer
+```
+
+6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=dev
+```
+
+You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
+
+8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+```
+
+You should see in the standard output the following:
+```json
+{"error":"not_authorized","reason":"Not_Authorized"}
+```
+
+9. Verify Management UI access:
+
+	- Go to http://localhost:15672.
+	- Select *RabbitMQ Development* OAuth 2.0 resource.
+	- Click on "Click here to login".
+	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
+	- Verify that user is redirected by to Management UI.
+	- Click on Logout.
+	- Repeat with *RabbitMQ Production* and user `rabbit_prod_admin` / `rabbit_prod_admin`.
+
+10. Shutdown RabbitMQ and Keycloak
+
+```bash
+make stop-keycloak
+make stop-rabbitmq
+```
+
+## Scenario 3 - Two OAuth 2.0 resources on dedicated OAuth provider {#scenario3}
+
+This scenario uses two separate OAuth 2.0 providers called `devkeycloak` and `prodkeycloak`, with the following setup:
+
+- `devkeycloak` has the following setup under the `dev` Realm and grants access to `rabbit_dev` resource:
+	- `dev_producer` with the audience `rabbit_dev` (password: `SBuw1L5a7Y2aQfWfbsgXlEKGTNaEHxO8`).
+	- `rabbit_dev_admin` (password: `rabbit_dev_admin`).
+	- `rabbit_dev_mgt_api`.
+- `prodkeycloak` has the following setup under the `prod` Realm and grants access to `rabbit_prod` resource:
+	- `prod_producer` with the audience `rabbit_prod` (password: `PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9`).
+	- `rabbit_prod_admin` (password: `rabbit_prod_admin`).
+
+Check out the section `oauth_providers` in the configuration file [rabbitmq.scenario3.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/multi-keycloak/rabbitmq.scenario3.conf) used by this scenario. Like in the scenario 2, there are two OAuth providers however this time the URL refers to two different hostnames. For convenience here is the relevant part:
+
+```ini
+...
+
+## Oauth providers
+auth_oauth2.oauth_providers.devkeycloak.issuer = https://devkeycloak:8443/realms/dev
+auth_oauth2.oauth_providers.devkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.devkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.devkeycloak.https.hostname_verification = wildcard
+
+auth_oauth2.oauth_providers.prodkeycloak.issuer = https://prodkeycloak:8442/realms/prod
+auth_oauth2.oauth_providers.prodkeycloak.https.cacertfile = /etc/rabbitmq/keycloak-ca_certificate.pem
+auth_oauth2.oauth_providers.prodkeycloak.https.verify = verify_peer
+auth_oauth2.oauth_providers.prodkeycloak.https.hostname_verification = wildcard
+
+...
+```
+
+Follow these steps to deploy two Keycloaks and RabbitMQ:
+
+1. Launch Keycloak.
+```bash
+make start-dev-keycloak
+make start-prod-keycloak
+```
+:::tip
+Run `docker ps | grep keycloak` to see two instances have started.
+:::
+
+2. Launch RabbitMQ.
+```bash
+MODE=multi-keycloak CONF=rabbitmq.scenario3.conf make start-rabbitmq
+```
+
+3. Launch AMQP producer registered in Keycloak with the **client_id** `prod_producer` and with the permission to access `rabbit_prod` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=prod_producer TOKEN=$(bin/prodkeycloak/token prod_producer PdLHb1w8RH1oD5bpppgy8OF9G6QeRpL9)
+```
+
+4. Launch AMQP producer registered in Keycloak with the **client_id** `dev_producer` and with the permission to access `rabbit_dev` resource and with the scopes `rabbitmq.read:*/* rabbitmq.write:*/* rabbitmq.configure:*/*`:
+```bash
+make start-perftest-producer-with-token PRODUCER=dev_producer TOKEN=$(bin/devkeycloak/token dev_producer z1PNm47wfWyulTnAaDOf1AggTy3MxX2H)
+```
+
+5. Stop both producers:
+```bash
+make stop-perftest-producer PRODUCER=dev_producer
+make stop-perftest-producer PRODUCER=prod_producer
+```
+
+6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
+```bash
+make curl-dev-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=p7v6DksWkcb6TUYK6payswovC0LqhU6A
+```
+
+You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
+
+8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
+```bash
+make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+```
+
+You should see in the standard output the following:
+```json
+{"error":"not_authorized","reason":"Not_Authorized"}
+```
+
+9. Verify Management UI access:
+
+	- Go to http://localhost:15672.
+	- Select *RabbitMQ Development* OAuth 2.0 resource.
+	- Click on "Click here to login".
+	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
+	- Verify that user is redirected by to Management UI.
+	- Click on Logout.
+	- Repeat with *RabbitMQ Production* and user `rabbit_prod_admin` / `rabbit_prod_admin`.
+
+10. Shutdown RabbitMQ and the two Keycloaks:
+```bash
+make stop-dev-keycloak
+make stop-prod-keycloak
+make stop-rabbitmq
+```

--- a/versioned_docs/version-4.0/oauth2-examples-okta.md
+++ b/versioned_docs/version-4.0/oauth2-examples-okta.md
@@ -24,7 +24,7 @@ limitations under the License.
 Demonstrate how to authenticate using OAuth 2.0 protocol
 and Okta as Authorization Server using the following flows:
 
-1. Access management UI via a browser
+1. Access [management UI](./management/) via a browser
 
 ## Prerequisites to follow this guide
 
@@ -63,9 +63,9 @@ In Trusted Origins (for Web and Native app integrations), choose **keep the defa
 
 In Assignments, choose **Allow everyone in your organization to access**.
 
-Finally, click on **Save** and write down the following values, as you will need them later to configure RabbitMQ:  
+Finally, click on **Save** and write down the following values, as you will need them later to configure RabbitMQ:
 
-  * **ClientID**  
+  * **ClientID**
   * **Okta domain name**
 
 
@@ -101,7 +101,7 @@ And below are the steps to create a claim for **role** to distinguish `admin` an
 
 6. Choose **Expression** as Value type
 
-7. In **Value** field enter the following expression:  
+7. In **Value** field enter the following expression:
   `isMemberOfGroupName("admin") ? "admin" : isMemberOfGroupName("monitoring") ? "monitoring" : ""`
 
 8. Click on create.
@@ -152,7 +152,7 @@ Once you've added the user to the appropriate groups and apps, they should have 
 
 The configuration on Okta side is done. You now have to configure RabbitMQ to use the resources you just created.
 
-[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta. 
+[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
 
 Update it with the following values (you should have noted these in the previous steps):
 

--- a/versioned_docs/version-4.0/oauth2-examples-proxy.md
+++ b/versioned_docs/version-4.0/oauth2-examples-proxy.md
@@ -43,8 +43,7 @@ Let's test the following flow:
 
 * Docker
 * make
-* `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
-contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
 
 ## Deploy Keycloak
 
@@ -94,7 +93,7 @@ make start-oauth2-proxy
 Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
-## Access Management UI
+## Access [management UI](./management/)
 
 Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
 `rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/versioned_docs/version-4.0/oauth2-examples/index.md
+++ b/versioned_docs/version-4.0/oauth2-examples/index.md
@@ -40,7 +40,7 @@ which hosts all the scripts required to deploy the examples demonstrated on the 
 
 ### Management UI Access
 
-* [Access Management UI using OAuth 2.0 tokens](#access-management-ui)
+* [Access [management UI](./management/) using OAuth 2.0 tokens](#access-management-ui)
 * [Service-Provider initiated logon](#service-provider-initiated-logon)
 * [Identity-Provider initiated logon](#identity-provider-initiated-logon)
 
@@ -92,7 +92,7 @@ Run the following two commands to start UAA and RabbitMQ configured for UAA:
 
 The last command starts a RabbitMQ with a specific configuration file, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/blob/main/conf/uaa/rabbitmq.conf).
 
-## Access Management UI using OAuth 2.0 tokens {#access-management-ui}
+## Access [management UI](./management/) using OAuth 2.0 tokens {#access-management-ui}
 
 The RabbitMQ Management UI can be configured with one of these two login modes:
 
@@ -802,7 +802,7 @@ make curl-with-token URL=http://localhost:15672/api/overview TOKEN=$(bin/jwt_tok
 
 Note: You are using curl to go to the URL using a TOKEN which you have built using the command bin/jwt_token which takes the JWT payload, the name of the signing key and the private and public certificates to sign the token
 
-*Use a Rich Authorization Token to access AMQP protocol*
+*Use a Rich Authorization Token to Application authentication and authorization*
 
 This time, You are going to use the same token you used in the previous section to access the AMQP protocol via the PerfTest tool which acts as a AMQP producer application:
 

--- a/versioned_docs/version-4.0/oauth2.md
+++ b/versioned_docs/version-4.0/oauth2.md
@@ -758,7 +758,9 @@ All resource servers share the variables you set so far under `auth_oauth2.` suc
 The list of supported resource servers is the combination of `auth_oauth2.resource_servers` and `auth_oauth2.resource_server_id`. You can use both or only one of them.
 
 :::info
-There is an [example](./oauth2-examples-multiresource) that demonstrate multiple OAuth 2 resources.
+
+There is an [example](./oauth2-examples-multiresource) that demonstrate how to use multiple OAuth 2 resources.
+
 :::
 
 A list of [all the configurable variables](#multiple-resource-servers-configuration) for


### PR DESCRIPTION
Update multi-resource example 

This PR required another [PR](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/pull/28) in the rabbitmq-oauth2-tutorial which is now merged.

Tasks: 
- [x] Correct the link to the configuration files in rabbitmq-oauth2-tutorial repo. 
- [x] Include 2 more scenarios which were not included on the initial commit

This change applies to all versions: 3.13.x , 4.0.x and main.