### PR TITLE
Remove space from :::important tag in dynamic shovel 1.0 html section

### DIFF
--- a/docs/shovel-dynamic.md
+++ b/docs/shovel-dynamic.md
@@ -658,7 +658,7 @@ counterparts.
             Only of use when URI scheme is <code>amqps</code>.
 
             <p>
-              ::: important
+              :::important
 
               Note that starting with Erlang 26, peer verification for TLS clients (such as shovels)
               is enabled by default.


### PR DESCRIPTION
::: important had a rogue space causing not to render properly. Copied from same edit earlier in the 0.9.1 table.  I have not tested this change but there is a working version in the same document and confident this is a valid change.