### PR TITLE
Configure keycloak, uaa and oauth2-proxy with TLS

### DIFF
--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -33,6 +33,10 @@ and Keycloak as Authorization Server using the following flows:
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example
+* Add the following entry to your /etc/hosts:
+```
+localhost keycloak rabbitmq
+```
 
 ## Deploy Keycloak
 
@@ -46,8 +50,9 @@ and Keycloak as Authorization Server using the following flows:
 
 There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
-* A [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
-* A [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
+* A [rsa](https://keycloak:8443/admin/master/console/#/test/realm-settings/keys) signing key. Use `admin`:`admin`
+ when prompted for credentials to access the Keycloak Administration page
+* A [rsa provider](https://keycloak:8443/admin/master/console/#/test/realm-settings/keys/providers)
 * Three clients: `rabbitmq-client-code` for the rabbitmq management UI, `mgt_api_client` to access via the
 management api and `producer` to access via AMQP protocol.
 
@@ -60,12 +65,16 @@ export MODE=keycloak
 make start-rabbitmq
 ```
 
+:::info
+RabbitMQ is deployed with TLS enabled and Keycloak is configured with the corresponding `redirect_url` which uses https.
+:::
+
 ## Access Management api
 
-To access the management api run the following command. It uses the client [mgt_api_client](http://0.0.0.0:8080/admin/master/console/#/realms/test/clients/c5be3c24-0c88-4672-a77a-79002fcc9a9d) which has the scope [rabbitmq.tag:administrator](http://0.0.0.0:8080/admin/master/console/#/realms/test/client-scopes/f6e6dd62-22bf-4421-910e-e6070908764c).
+To access the management api run the following command. It uses the client [mgt_api_client](https://keycloak:8443/admin/master/console/#/test/clients/c5be3c24-0c88-4672-a77a-79002fcc9a9d/settings) which has the scope [rabbitmq.tag:administrator](https://keycloak:8443/admin/master/console/#/test/client-scopes/f6e6dd62-22bf-4421-910e-e6070908764c/settings).
 
 ```bash
-make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=LWOuYqJ8gjKg3D2U8CJZDuID3KiRZVDa
+make curl-keycloak url=https://localhost:15671/api/overview client_id=mgt_api_client secret=LWOuYqJ8gjKg3D2U8CJZDuID3KiRZVDa
 ```
 
 ## Application authentication and authorization with PerfTest
@@ -98,7 +107,7 @@ Note: Ensure you install pika 1.3
 
 ## Access [management UI](./management/)
 
-1. Go to http://localhost:15672.
+1. Go to https://localhost:15671.
 2. Click on the single button on the page which redirects to **Keycloak** to authenticate.
 3. Enter `rabbit_admin` and `rabbit_admin` and you should be redirected back to RabbitMQ Management fully logged in.
 

--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -84,7 +84,7 @@ To test OAuth 2.0 authentication with AMQP protocol you are going to use RabbitM
 First you obtain the token and pass it as a parameter to the make target `start-perftest-producer-with-token`.
 
 ```bash
-make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/token producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn)
+make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/token producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn test)
 ```
 
 **NOTE**: Initializing an application with a token has one drawback: the application cannot use the connection beyond the lifespan of the token. See the next section where you demonstrate how to refresh the token.

--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -33,7 +33,7 @@ and Keycloak as Authorization Server using the following flows:
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example
-* Add the following entry to your /etc/hosts:
+* Add the following entry to `/etc/hosts`:
 ```
 localhost keycloak rabbitmq
 ```
@@ -103,9 +103,9 @@ pip install requests
 python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 ```
 
-:::tip 
-If `pip` is not available try instead the following two commands to installing it: 
-```bash 
+:::tip
+If `pip` is not available try instead the following two commands to installing it:
+```bash
 python3 -m venv venv
 source venv/bin/activate
 ```

--- a/docs/oauth2-examples-keycloak.md
+++ b/docs/oauth2-examples-keycloak.md
@@ -103,6 +103,14 @@ pip install requests
 python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 ```
 
+:::tip 
+If `pip` is not available try instead the following two commands to installing it: 
+```bash 
+python3 -m venv venv
+source venv/bin/activate
+```
+:::
+
 Note: Ensure you install pika 1.3
 
 ## Access [management UI](./management/)

--- a/docs/oauth2-examples-multiresource.md
+++ b/docs/oauth2-examples-multiresource.md
@@ -31,7 +31,7 @@ and several OAuth resources using the following flows:
 
 * Docker
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example
-* Add the following entry to your /etc/hosts:
+* Add the following entry to `/etc/hosts`:
 ```
 localhost keycloak devkeycloak prodkeycloak rabbitmq
 ```

--- a/docs/oauth2-examples-multiresource.md
+++ b/docs/oauth2-examples-multiresource.md
@@ -31,6 +31,10 @@ and several OAuth resources using the following flows:
 
 * Docker
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example
+* Add the following entry to your /etc/hosts:
+```
+localhost keycloak devkeycloak prodkeycloak rabbitmq
+```
 
 ## Single OAuth 2.0 vs Multiple OAuth 2.0 resources
 
@@ -81,7 +85,7 @@ The RabbitMQ OAuth 2 plugin is configured like so:
 
 Follow these steps to deploy Keycloak and RabbitMQ:
 
-1. Launch Keycloak. Check out [Admin page](http://localhost:8081/admin/master/console/#/test) with the credentials `admin:admin`:
+1. Launch Keycloak. Check out [Admin page](https://localhost:8443/admin/master/console/#/test) with the credentials `admin:admin`:
 
     ```bash
     make start-keycloak
@@ -109,7 +113,6 @@ Follow these steps to deploy Keycloak and RabbitMQ:
       "exp": 1690974839,
       "iat": 1690974539,
       "jti": "c8edec50-5f29-4bd0-b25b-d7a46dc3474e",
-      "iss": "http://localhost:8081/realms/test",
       "aud": "rabbit_prod",
       "sub": "826065e7-bb58-4b65-bbf7-8982d6cca6c8",
       "typ": "Bearer",
@@ -172,7 +175,7 @@ This is a summary of the configuration to enable OAuth 2.0 in the management UI:
 
 Follow the steps to the management UI flows with two OAuth resources:
 
-1. Go to the [RabbitMQ Management UI](http://localhost:15672).
+1. Go to the [RabbitMQ Management UI](https://localhost:15671).
 2. Select `RabbitMQ Production` resource.
 3. Login as `prod_user`:`prod_user`.
 4. Keycloak prompts you to authorize various scopes for `prod_user`.
@@ -252,14 +255,14 @@ make stop-perftest-producer PRODUCER=prod_producer
 
 6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
 ```bash
-make curl-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=dev
+make curl-keycloak url=https://localhost:15671/api/overview client_id=rabbit_dev_mgt_api secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=dev
 ```
 
 You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
 
 8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
 ```bash
-make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+make curl-keycloak url=https://localhost:15671/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
 ```
 
 You should see in the standard output the following:
@@ -269,7 +272,7 @@ You should see in the standard output the following:
 
 9. Verify Management UI access:
 
-	- Go to http://localhost:15672.
+	- Go to https://localhost:15671.
 	- Select *RabbitMQ Development* OAuth 2.0 resource.
 	- Click on "Click here to login".
 	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.
@@ -349,14 +352,14 @@ make stop-perftest-producer PRODUCER=prod_producer
 
 6. Verify `rabbit_dev_mgt_api` can access Management API because its token grants access to `rabbit_dev`:
 ```bash
-make curl-dev-keycloak url=http://localhost:15672/api/overview client_id=rabbit_dev_mgt_api secret=p7v6DksWkcb6TUYK6payswovC0LqhU6A
+make curl-dev-keycloak url=https://localhost:15671/api/overview client_id=rabbit_dev_mgt_api secret=p7v6DksWkcb6TUYK6payswovC0LqhU6A
 ```
 
 You should see in the standard output the json blob corresponding to the endpoint `/overview` in RabbitMQ's management api.
 
 8. Verify `mgt_api_client` cannot access Management API because its token does not grant access to `rabbit_dev` or `rabbit_prod`:
 ```bash
-make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
+make curl-keycloak url=https://localhost:15671/api/overview client_id=mgt_api_client secret=La1Mvj7Qvt8iAqHisZyAguEE8rUpg014 realm=test
 ```
 
 You should see in the standard output the following:
@@ -366,7 +369,7 @@ You should see in the standard output the following:
 
 9. Verify Management UI access:
 
-	- Go to http://localhost:15672.
+	- Go to https://localhost:15671.
 	- Select *RabbitMQ Development* OAuth 2.0 resource.
 	- Click on "Click here to login".
 	- Authenticate with Keycloak using `rabbit_dev_admin` / `rabbit_dev_admin`.

--- a/docs/oauth2-examples-proxy.md
+++ b/docs/oauth2-examples-proxy.md
@@ -21,10 +21,8 @@ limitations under the License.
 
 # Use OAuth2 Proxy and Keycloak as OAuth 2.0 server
 
-Demonstrate how to authenticate using OAuth 2.0 protocol
-and OAuth2 Proxy as Authorization Server using the following flows:
-
-Let's test the following flow:
+This guide explains how to set up OAuth 2.0 for RabbitMQ
+and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorization Server using the following flows:
 
 * Access the RabbitMQ Management UI using a browser through OAuth2 Proxy
 
@@ -51,8 +49,6 @@ Deploy Keycloak by running the following command:
 ```bash
 make start-keycloak
 ```
-
-Note: Keycloak is preconfigured with the required scopes, users, and clients. It is configured with its own signing key and the [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) file is also configured with the same signing key.
 
 To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
@@ -90,7 +86,7 @@ To start OAuth2 Proxy, run the following command:
 make start-oauth2-proxy
 ```
 
-Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
+Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
 ## Access [management UI](./management/)

--- a/docs/oauth2-examples-proxy.md
+++ b/docs/oauth2-examples-proxy.md
@@ -42,6 +42,11 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+* The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
+```
+localhost keycloak rabbitmq oauth2-proxy
+```
+
 
 ## Deploy Keycloak
 

--- a/docs/oauth2-examples-proxy.md
+++ b/docs/oauth2-examples-proxy.md
@@ -47,6 +47,13 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 localhost keycloak rabbitmq oauth2-proxy
 ```
 
+:::warning
+The first time you run `make start-keycloak` or `make start-oauth2-proxy` it 
+generates their corresponding TLS certificates. These certificates expire. 
+If you run into any issues with expired or invalid certificates, stop keycloak 
+and oauth-proxy and run `make clean-certs` command. The next time you deploy 
+keycloak and oauth2-proxy, they start with a newly generated certificate.
+:::
 
 ## Deploy Keycloak
 
@@ -55,33 +62,13 @@ Deploy Keycloak by running the following command:
 make start-keycloak
 ```
 
-To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+To access Keycloak Management UI, go to https://keycloak:8443/ and enter `admin` as username and password.
 
 There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
-* [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
-* [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
+* [rsa](https://keycloak:8443/admin/master/console/#/realms/test/keys) signing key
+* [rsa provider]https://keycloak:8443/admin/master/console/#/realms/test/keys/providers)
 * `rabbitmq-proxy-client` client
-
-## Start RabbitMQ
-
-To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf)
-
-```
-export MODE=oauth2-proxy
-make start-rabbitmq
-```
-
-**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
-`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
-impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) has
-the setting below which disables validation of the audience claim.
-
-```ini
-auth_oauth2.verify_aud = false
-```
-
 
 ## Start OAuth2 Proxy
 
@@ -94,7 +81,25 @@ make start-oauth2-proxy
 Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
+## Start RabbitMQ
+
+To start RabbitMQ run the following command:
+
+```
+MODE=oauth2-proxy make start-rabbitmq
+```
+
+**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
+`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
+impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) has
+the setting below which disables validation of the audience claim.
+
+```ini
+auth_oauth2.verify_aud = false
+```
+
+
 ## Access [management UI](./management/)
 
-Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
+Go to https://oauth2-proxy:8442/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
 `rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/docs/oauth2-examples-proxy.md
+++ b/docs/oauth2-examples-proxy.md
@@ -47,12 +47,13 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 localhost keycloak rabbitmq oauth2-proxy
 ```
 
-:::warning
-The first time you run `make start-keycloak` or `make start-oauth2-proxy` it 
-generates their corresponding TLS certificates. These certificates expire. 
-If you run into any issues with expired or invalid certificates, stop keycloak 
-and oauth-proxy and run `make clean-certs` command. The next time you deploy 
-keycloak and oauth2-proxy, they start with a newly generated certificate.
+:::info
+`make start-keycloak` or `make start-oauth2-proxy` will
+generate the TLS certificate and private keys necessary. These certificates have an expiration date.
+
+In case of any error messages that hint at expired or invalid certificates, stop Keycloak
+and `oauth-proxy` and run `make clean-certs` to regenerate the certificates and private keys,
+then restart Keycloak and the proxy
 :::
 
 ## Deploy Keycloak

--- a/docs/oauth2-examples/index.md
+++ b/docs/oauth2-examples/index.md
@@ -76,6 +76,12 @@ The guide is accompanied by [a public GitHub repository](https://github.com/rabb
  * Ruby must be installed
  * make
  * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+ * The following entries must be in your `/etc/hosts` file:
+ 
+  ```
+  127.0.0.1 localhost uaa rabbitmq
+  ```
+
 
 ## Getting started with UAA and RabbitMQ {#getting-started-with-uaa-and-rabbitmq}
 
@@ -121,10 +127,16 @@ authorize RabbitMQ application as shown on the screenshot below.
 
 ![authorize application](./authorize-app.png)
 
-UAA has previously been configured and seeded with two users:
+UAA has previously been configured with two users:
 
 * `rabbit_admin:rabbit_admin`
 * and `rabbit_monitor:rabbit_monitor`
+
+:::tip
+First visit https://uaa:8443 so that your browser can trust the self-signed 
+certificate `uua` has. Otherwise, the management UI will fail to connect to 
+`uaa`. 
+:::
 
 Now navigating to the [local node's management UI](http://localhost:15672) and login using any of those two users.
 
@@ -140,9 +152,10 @@ in `rabbitmq.conf`:
 # ...
 management.oauth_enabled = true
 management.oauth_client_id = rabbit_client_code
-auth_oauth2.issuer = http://localhost:8080
+auth_oauth2.issuer = https://uaa:8443
 # ...
 ```
+
 
 ### Identity-Provider initiated logon {#identity-provider-initiated-logon}
 
@@ -169,15 +182,13 @@ by submitting a form with their OAuth token in the `access_token` form field as 
 
 If the access token is valid, RabbitMQ redirects the user to the **Overview** page.
 
-By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required
-in `rabbitmq.conf`:
+By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required in `rabbitmq.conf`:
 
 ```ini
 # ...
 management.oauth_enabled = true
-management.oauth_client_id = rabbit_client_code
 management.oauth_initiated_logon_type = idp_initiated
-auth_oauth2.issuer = http://localhost:8080
+management.oauth_provider_url = http://localhost:8080
 # ...
 ```
 

--- a/versioned_docs/version-3.13/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-3.13/oauth2-examples-keycloak.md
@@ -75,7 +75,7 @@ To test OAuth 2.0 authentication with AMQP protocol you are going to use RabbitM
 First you obtain the token and pass it as a parameter to the make target `start-perftest-producer-with-token`.
 
 ```bash
-make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/token producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn)
+make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/token producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn test)
 ```
 
 **NOTE**: Initializing an application with a token has one drawback: the application cannot use the connection beyond the lifespan of the token. See the next section where you demonstrate how to refresh the token.

--- a/versioned_docs/version-3.13/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-3.13/oauth2-examples-keycloak.md
@@ -94,6 +94,14 @@ pip install requests
 python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 ```
 
+:::tip 
+If `pip` is not available try instead the following two commands to installing it: 
+```bash 
+python3 -m venv venv
+source venv/bin/activate
+```
+:::
+
 Note: Ensure you install pika 1.3
 
 ## Access [management UI](./management/)

--- a/versioned_docs/version-3.13/oauth2-examples-proxy.md
+++ b/versioned_docs/version-3.13/oauth2-examples-proxy.md
@@ -42,6 +42,10 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+* The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
+```
+localhost keycloak rabbitmq oauth2-proxy
+```
 
 ## Deploy Keycloak
 

--- a/versioned_docs/version-3.13/oauth2-examples-proxy.md
+++ b/versioned_docs/version-3.13/oauth2-examples-proxy.md
@@ -41,11 +41,19 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 
 * Docker
 * make
-* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/) that contains all the configuration files and scripts used on this example.
 * The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
 ```
 127.0.0.1  localhost keycloak rabbitmq oauth2-proxy
 ```
+
+:::warning
+The first time you run `make start-keycloak` or `make start-oauth2-proxy` it 
+generates their corresponding TLS certificates. These certificates expire. 
+If you run into any issues with expired or invalid certificates, stop keycloak 
+and oauth-proxy and run `make clean-certs` command. The next time you deploy 
+keycloak and oauth2-proxy, they start with a newly generated certificate.
+:::
 
 ## Deploy Keycloak
 
@@ -54,32 +62,13 @@ Deploy Keycloak by running the following command:
 make start-keycloak
 ```
 
-To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+To access Keycloak Management UI, go to https://keycloak:8443/ and enter `admin` as username and password.
 
 There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
-* [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
-* [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
+* [rsa](https://keycloak:8443/admin/master/console/#/realms/test/keys) signing key
+* [rsa provider](https://keycloak:8443/admin/master/console/#/realms/test/keys/providers)
 * `rabbitmq-proxy-client` client
-
-## Start RabbitMQ
-
-To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf)
-
-```
-export MODE=oauth2-proxy
-make start-rabbitmq
-```
-
-**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
-`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
-impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) has
-the setting below which disables validation of the audience claim.
-
-```ini
-auth_oauth2.verify_aud = false
-```
 
 
 ## Start OAuth2 Proxy
@@ -90,10 +79,25 @@ To start OAuth2 Proxy, run the following command:
 make start-oauth2-proxy
 ```
 
-Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
+Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
+**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
+`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
+impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) has
+the setting below which disables validation of the audience claim.
+
+```ini
+auth_oauth2.verify_aud = false
+```
+
+## Start RabbitMQ
+
+To start RabbitMQ run the following command:
+```
+MODE=oauth2-proxy make start-rabbitmq
+```
 
 ## Access [management UI](./management/)
 
-Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
+Go to https://oauth2-proxy:8442/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
 `rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/versioned_docs/version-3.13/oauth2-examples-proxy.md
+++ b/versioned_docs/version-3.13/oauth2-examples-proxy.md
@@ -47,12 +47,15 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 127.0.0.1  localhost keycloak rabbitmq oauth2-proxy
 ```
 
-:::warning
-The first time you run `make start-keycloak` or `make start-oauth2-proxy` it 
-generates their corresponding TLS certificates. These certificates expire. 
-If you run into any issues with expired or invalid certificates, stop keycloak 
-and oauth-proxy and run `make clean-certs` command. The next time you deploy 
-keycloak and oauth2-proxy, they start with a newly generated certificate.
+:::info
+
+`make start-keycloak` or `make start-oauth2-proxy` will
+generate the TLS certificate and private keys necessary. These certificates have an expiration date.
+
+In case of any error messages that hint at expired or invalid certificates, stop Keycloak
+and `oauth-proxy` and run `make clean-certs` to regenerate the certificates and private keys,
+then restart Keycloak and the proxy
+
 :::
 
 ## Deploy Keycloak

--- a/versioned_docs/version-3.13/oauth2-examples-proxy.md
+++ b/versioned_docs/version-3.13/oauth2-examples-proxy.md
@@ -21,10 +21,8 @@ limitations under the License.
 
 # Use OAuth2 Proxy and Keycloak as OAuth 2.0 server
 
-Demonstrate how to authenticate using OAuth 2.0 protocol
-and OAuth2 Proxy as Authorization Server using the following flows:
-
-Let's test the following flow:
+This guide explains how to set up OAuth 2.0 for RabbitMQ
+and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorization Server using the following flows:
 
 * Access the RabbitMQ Management UI using a browser through OAuth2 Proxy
 
@@ -43,7 +41,7 @@ Let's test the following flow:
 
 * Docker
 * make
-* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
 
 ## Deploy Keycloak
 
@@ -51,8 +49,6 @@ Deploy Keycloak by running the following command:
 ```bash
 make start-keycloak
 ```
-
-Note: Keycloak is preconfigured with the required scopes, users, and clients. It is configured with its own signing key and the [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) file is also configured with the same signing key.
 
 To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
@@ -65,7 +61,7 @@ There is a dedicated **Keycloak realm** called `Test` configured as follows:
 ## Start RabbitMQ
 
 To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
+rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf)
 
 ```
 export MODE=oauth2-proxy
@@ -74,7 +70,7 @@ make start-rabbitmq
 
 **NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
 `aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
-impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) has
+impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) has
 the setting below which disables validation of the audience claim.
 
 ```ini
@@ -90,7 +86,7 @@ To start OAuth2 Proxy, run the following command:
 make start-oauth2-proxy
 ```
 
-Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
+Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
 ## Access [management UI](./management/)

--- a/versioned_docs/version-3.13/oauth2-examples-proxy.md
+++ b/versioned_docs/version-3.13/oauth2-examples-proxy.md
@@ -44,7 +44,7 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
 * The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
 ```
-localhost keycloak rabbitmq oauth2-proxy
+127.0.0.1  localhost keycloak rabbitmq oauth2-proxy
 ```
 
 ## Deploy Keycloak

--- a/versioned_docs/version-3.13/oauth2-examples/index.md
+++ b/versioned_docs/version-3.13/oauth2-examples/index.md
@@ -128,6 +128,12 @@ UAA has previously been configured and seeded with two users:
 * `rabbit_admin:rabbit_admin`
 * and `rabbit_monitor:rabbit_monitor`
 
+:::tip
+First visit https://uaa:8443 so that your browser can trust the self-signed 
+certificate `uua` has. Otherwise, the management UI will fail to connect to 
+`uaa`. 
+:::
+
 Now navigating to the [local node's management UI](http://localhost:15672) and login using any of those two users.
 
 This is a token issued by UAA for the `rabbit_admin` user thru the redirect flow you just saw above.
@@ -142,7 +148,7 @@ in `rabbitmq.conf`:
 # ...
 management.oauth_enabled = true
 management.oauth_client_id = rabbit_client_code
-management.oauth_provider_url = http://localhost:8080
+management.oauth_provider_url = https://uaa:8443
 # ...
 ```
 
@@ -177,7 +183,6 @@ in `rabbitmq.conf`:
 ```ini
 # ...
 management.oauth_enabled = true
-management.oauth_client_id = rabbit_client_code
 management.oauth_provider_url = http://localhost:8080
 management.oauth_initiated_logon_type = idp_initiated
 # ...

--- a/versioned_docs/version-3.13/oauth2-examples/index.md
+++ b/versioned_docs/version-3.13/oauth2-examples/index.md
@@ -78,6 +78,10 @@ which hosts all the scripts required to deploy the examples demonstrated on the 
  * make
  * `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
 contains all the configuration files and scripts used on all the examples.
+ * The following entries in the `/etc/hosts` file:
+ ```
+ 127.0.0.1  localhost uaa rabbitmq
+ ```
 
 ## Getting started with UAA and RabbitMQ {#getting-started-with-uaa-and-rabbitmq}
 

--- a/versioned_docs/version-4.0/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-4.0/oauth2-examples-keycloak.md
@@ -33,7 +33,7 @@ and Keycloak as Authorization Server using the following flows:
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
-* Add the following entry to your /etc/hosts:
+    * Add the following entry to `/etc/hosts`:
 ```
 localhost keycloak rabbitmq
 ```
@@ -97,9 +97,9 @@ pip install requests
 python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 ```
 
-:::tip 
-If `pip` is not available try instead the following two commands to installing it: 
-```bash 
+:::tip
+If `pip` is not available try instead the following two commands to installing it:
+```bash
 python3 -m venv venv
 source venv/bin/activate
 ```

--- a/versioned_docs/version-4.0/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-4.0/oauth2-examples-keycloak.md
@@ -97,6 +97,14 @@ pip install requests
 python3 pika-client/producer.py producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn
 ```
 
+:::tip 
+If `pip` is not available try instead the following two commands to installing it: 
+```bash 
+python3 -m venv venv
+source venv/bin/activate
+```
+:::
+
 Note: Ensure you install pika 1.3
 
 ## Access [management UI](./management/)

--- a/versioned_docs/version-4.0/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-4.0/oauth2-examples-keycloak.md
@@ -33,6 +33,10 @@ and Keycloak as Authorization Server using the following flows:
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
+* Add the following entry to your /etc/hosts:
+```
+localhost keycloak rabbitmq
+```
 
 ## Deploy Keycloak
 
@@ -46,10 +50,9 @@ and Keycloak as Authorization Server using the following flows:
 
 There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
-* A [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
-* A [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
-* Three clients: `rabbitmq-client-code` for the rabbitmq management UI, `mgt_api_client` to access via the
-management api and `producer` to access via AMQP protocol.
+* A [rsa](https://keycloak:8443/admin/master/console/#/test/realm-settings/keys) signing key
+* A [rsa provider](https://keycloak:8443/admin/master/console/#/test/realm-settings/keys/providers)
+* Three clients: `rabbitmq-client-code` for the rabbitmq management UI, `mgt_api_client` to access via the management api and `producer` to access via AMQP protocol.
 
 
 ## Start RabbitMQ
@@ -62,7 +65,7 @@ make start-rabbitmq
 
 ## Access Management api
 
-To access the management api run the following command. It uses the client [mgt_api_client](http://0.0.0.0:8080/admin/master/console/#/realms/test/clients/c5be3c24-0c88-4672-a77a-79002fcc9a9d) which has the scope [rabbitmq.tag:administrator](http://0.0.0.0:8080/admin/master/console/#/realms/test/client-scopes/f6e6dd62-22bf-4421-910e-e6070908764c).
+To access the management api run the following command. It uses the client [mgt_api_client](https://keycloak:8443/admin/master/console/#/test/clients/c5be3c24-0c88-4672-a77a-79002fcc9a9d/settings) which has the scope [rabbitmq.tag:administrator](https://keycloak:8443/admin/master/console/#/test/client-scopes/f6e6dd62-22bf-4421-910e-e6070908764c/settings).
 
 ```bash
 make curl-keycloak url=http://localhost:15672/api/overview client_id=mgt_api_client secret=LWOuYqJ8gjKg3D2U8CJZDuID3KiRZVDa

--- a/versioned_docs/version-4.0/oauth2-examples-keycloak.md
+++ b/versioned_docs/version-4.0/oauth2-examples-keycloak.md
@@ -78,7 +78,7 @@ To test OAuth 2.0 authentication with AMQP protocol you are going to use RabbitM
 First you obtain the token and pass it as a parameter to the make target `start-perftest-producer-with-token`.
 
 ```bash
-make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/token producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn)
+make start-perftest-producer-with-token PRODUCER=producer TOKEN=$(bin/keycloak/token producer kbOFBXI9tANgKUq8vXHLhT6YhbivgXxn test)
 ```
 
 **NOTE**: Initializing an application with a token has one drawback: the application cannot use the connection beyond the lifespan of the token. See the next section where you demonstrate how to refresh the token.

--- a/versioned_docs/version-4.0/oauth2-examples-proxy.md
+++ b/versioned_docs/version-4.0/oauth2-examples-proxy.md
@@ -42,6 +42,10 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 * Docker
 * make
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+* The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
+```
+localhost keycloak rabbitmq oauth2-proxy
+```
 
 ## Deploy Keycloak
 

--- a/versioned_docs/version-4.0/oauth2-examples-proxy.md
+++ b/versioned_docs/version-4.0/oauth2-examples-proxy.md
@@ -41,11 +41,19 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 
 * Docker
 * make
-* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/) that contains all the configuration files and scripts used on this example.
 * The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
 ```
 127.0.0.1  localhost keycloak rabbitmq oauth2-proxy
 ```
+
+:::warning
+The first time you run `make start-keycloak` or `make start-oauth2-proxy` it 
+generates their corresponding TLS certificates. These certificates expire. 
+If you run into any issues with expired or invalid certificates, stop keycloak 
+and oauth-proxy and run `make clean-certs` command. The next time you deploy 
+keycloak and oauth2-proxy, they start with a newly generated certificate.
+:::
 
 ## Deploy Keycloak
 
@@ -54,32 +62,13 @@ Deploy Keycloak by running the following command:
 make start-keycloak
 ```
 
-To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
+To access Keycloak Management UI, go to https://keycloak:8443/ and enter `admin` as username and password.
 
 There is a dedicated **Keycloak realm** called `Test` configured as follows:
 
-* [rsa](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys) signing key
-* [rsa provider](http://0.0.0.0:8080/admin/master/console/#/realms/test/keys/providers)
+* [rsa](https://keycloak:8443/admin/master/console/#/realms/test/keys) signing key
+* [rsa provider](https://keycloak:8443/admin/master/console/#/realms/test/keys/providers)
 * `rabbitmq-proxy-client` client
-
-## Start RabbitMQ
-
-To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf)
-
-```
-export MODE=oauth2-proxy
-make start-rabbitmq
-```
-
-**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
-`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
-impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) has
-the setting below which disables validation of the audience claim.
-
-```ini
-auth_oauth2.verify_aud = false
-```
 
 
 ## Start OAuth2 Proxy
@@ -90,10 +79,25 @@ To start OAuth2 Proxy, run the following command:
 make start-oauth2-proxy
 ```
 
-Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
+Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
+**NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
+`aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
+impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) has
+the setting below which disables validation of the audience claim.
+
+```ini
+auth_oauth2.verify_aud = false
+```
+
+## Start RabbitMQ
+
+To start RabbitMQ run the following command:
+```
+MODE=oauth2-proxy make start-rabbitmq
+```
 
 ## Access [management UI](./management/)
 
-Go to http://0.0.0.0:4180/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
+Go to https://oauth2-proxy:8442/, click on the **Sign in with Keycloak OIDC** link, and enter the credentials
 `rabbit_admin` as username and `rabbit_admin` as password. You should be redirected to RabbitMQ management UI.

--- a/versioned_docs/version-4.0/oauth2-examples-proxy.md
+++ b/versioned_docs/version-4.0/oauth2-examples-proxy.md
@@ -47,12 +47,15 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 127.0.0.1  localhost keycloak rabbitmq oauth2-proxy
 ```
 
-:::warning
-The first time you run `make start-keycloak` or `make start-oauth2-proxy` it 
-generates their corresponding TLS certificates. These certificates expire. 
-If you run into any issues with expired or invalid certificates, stop keycloak 
-and oauth-proxy and run `make clean-certs` command. The next time you deploy 
-keycloak and oauth2-proxy, they start with a newly generated certificate.
+:::info
+
+`make start-keycloak` or `make start-oauth2-proxy` will
+generate the TLS certificate and private keys necessary. These certificates have an expiration date.
+
+In case of any error messages that hint at expired or invalid certificates, stop Keycloak
+and `oauth-proxy` and run `make clean-certs` to regenerate the certificates and private keys,
+then restart Keycloak and the proxy
+
 :::
 
 ## Deploy Keycloak

--- a/versioned_docs/version-4.0/oauth2-examples-proxy.md
+++ b/versioned_docs/version-4.0/oauth2-examples-proxy.md
@@ -21,10 +21,8 @@ limitations under the License.
 
 # Use OAuth2 Proxy and Keycloak as OAuth 2.0 server
 
-Demonstrate how to authenticate using OAuth 2.0 protocol
-and OAuth2 Proxy as Authorization Server using the following flows:
-
-Let's test the following flow:
+This guide explains how to set up OAuth 2.0 for RabbitMQ
+and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorization Server using the following flows:
 
 * Access the RabbitMQ Management UI using a browser through OAuth2 Proxy
 
@@ -43,7 +41,7 @@ Let's test the following flow:
 
 * Docker
 * make
-* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
 
 ## Deploy Keycloak
 
@@ -51,8 +49,6 @@ Deploy Keycloak by running the following command:
 ```bash
 make start-keycloak
 ```
-
-Note: Keycloak is preconfigured with the required scopes, users, and clients. It is configured with its own signing key and the [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) file is also configured with the same signing key.
 
 To access Keycloak Management UI, go to http://0.0.0.0:8080/ and enter `admin` as username and password.
 
@@ -65,7 +61,7 @@ There is a dedicated **Keycloak realm** called `Test` configured as follows:
 ## Start RabbitMQ
 
 To start RabbitMQ run the following two commands. The first one tells RabbitMQ to pick up the
-rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf)
+rabbitmq.conf found under [conf/oauth2-proxy/rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf)
 
 ```
 export MODE=oauth2-proxy
@@ -74,7 +70,7 @@ make start-rabbitmq
 
 **NOTE**: Oauth2 Proxy requires that the `aud` claim matches the client's id. However, RabbitMQ requires the
 `aud` field to match `rabbitmq` which is the designated `resource_server_id`. Given that it has been
-impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/rabbitmq.conf) has
+impossible to configure keycloak with both values, [rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/rabbitmq.conf) has
 the setting below which disables validation of the audience claim.
 
 ```ini
@@ -90,7 +86,7 @@ To start OAuth2 Proxy, run the following command:
 make start-oauth2-proxy
 ```
 
-Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/oauth2-proxy/alpha-config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
+Oauth2 Proxy is configured using [Alpha configuration](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next/conf/oauth2-proxy/config.yaml). This type of configuration inserts the access token into the HTTP **Authorization** header.
 
 
 ## Access [management UI](./management/)

--- a/versioned_docs/version-4.0/oauth2-examples-proxy.md
+++ b/versioned_docs/version-4.0/oauth2-examples-proxy.md
@@ -44,7 +44,7 @@ and [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as Authorizatio
 * A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
 * The following entries in your /etc/hosts file. Without these entries you will get DNS errors in the browser. 
 ```
-localhost keycloak rabbitmq oauth2-proxy
+127.0.0.1  localhost keycloak rabbitmq oauth2-proxy
 ```
 
 ## Deploy Keycloak

--- a/versioned_docs/version-4.0/oauth2-examples/index.md
+++ b/versioned_docs/version-4.0/oauth2-examples/index.md
@@ -78,7 +78,11 @@ which hosts all the scripts required to deploy the examples demonstrated on the 
  * make
  * `git clone https://github.com/rabbitmq/rabbitmq-oauth2-tutorial`. This github repository
 contains all the configuration files and scripts used on all the examples.
-
+ * The following entries in the `/etc/hosts` file:
+ ```
+ 127.0.0.1  localhost uaa rabbitmq
+ ```
+ 
 ## Getting started with UAA and RabbitMQ {#getting-started-with-uaa-and-rabbitmq}
 
 To demonstrate OAuth 2.0 you need, at least, an OAuth 2.0 authorization server and RabbitMQ appropriately configured for the chosen authorization server. This guide uses [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) as authorization server to demonstrate basic and advanced configuration to access to the Management UI and various messaging protocols.

--- a/versioned_docs/version-4.0/oauth2-examples/index.md
+++ b/versioned_docs/version-4.0/oauth2-examples/index.md
@@ -123,10 +123,16 @@ authorize RabbitMQ application as shown on the screenshot below.
 
 ![authorize application](./authorize-app.png)
 
-UAA has previously been configured and seeded with two users:
+UAA has previously been configured with two users:
 
 * `rabbit_admin:rabbit_admin`
 * and `rabbit_monitor:rabbit_monitor`
+
+:::tip
+First visit https://uaa:8443 so that your browser can trust the self-signed 
+certificate `uua` has. Otherwise, the management UI will fail to connect to 
+`uaa`. 
+:::
 
 Now navigating to the [local node's management UI](http://localhost:15672) and login using any of those two users.
 
@@ -142,7 +148,7 @@ in `rabbitmq.conf`:
 # ...
 management.oauth_enabled = true
 management.oauth_client_id = rabbit_client_code
-management.oauth_provider_url = http://localhost:8080
+management.oauth_provider_url = https://uaa:8443
 # ...
 ```
 
@@ -177,7 +183,6 @@ in `rabbitmq.conf`:
 ```ini
 # ...
 management.oauth_enabled = true
-management.oauth_client_id = rabbit_client_code
 management.oauth_provider_url = http://localhost:8080
 management.oauth_initiated_logon_type = idp_initiated
 # ...


### PR DESCRIPTION
All the examples that affected uaa or keycloak or oauth2-proxy did not use tls. 
The scripts and configuration files referenced by the examples are already in the main branch of the rabbitmq-oauth2-tutorial.