### PR TITLE
Fix the link to rabbitmq.conf link to point to the file the does exist

### DIFF
--- a/versioned_docs/version-3.13/oauth2-examples-okta.md
+++ b/versioned_docs/version-3.13/oauth2-examples-okta.md
@@ -153,7 +153,7 @@ Once you've added the user to the appropriate groups and apps, they should have 
 The configuration on the Okta side is now done. The next step is to configure RabbitMQ
 to use the resources created earlier.
 
-[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
+[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf.tmpl) is an example RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
 
 Update it with the following values from the earlier steps:
 

--- a/versioned_docs/version-4.0/oauth2-examples-okta.md
+++ b/versioned_docs/version-4.0/oauth2-examples-okta.md
@@ -153,7 +153,7 @@ Once you've added the user to the appropriate groups and apps, they should have 
 The configuration on the Okta side is now done. The next step is to configure RabbitMQ
 to use the resources created earlier.
 
-[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf) is a RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
+[rabbitmq.conf](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/rabbitmq.conf.tmpl) is an example RabbitMQ configuration to **enable okta as OAuth 2.0 authentication backend** for the RabbitMQ OAuth2 and Management plugins. And [advanced.config](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/main/conf/okta/advanced.config) is the RabbitMQ advanced configuration that maps RabbitMQ scopes to the permissions previously configured in Okta.
 
 Update it with the following values from the earlier steps:
 


### PR DESCRIPTION
This link to `rabbitmq.conf` at this page is broken:

https://www.rabbitmq.com/docs/oauth2-examples-okta#configure-rabbitmq-to-use-okta-as-oauth-20-authentication-backend

This PR attempts to fix that broken link by point to the rabbitmq.conf.tmpl file that does exist in that location.