### PR TITLE
[docs/configure] rename `management_db_cache_multiplier` option to `management.db_cache_multiplier`

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1115,7 +1115,7 @@ collect_statistics_interval = 5000
     </td>
   </tr>
   <tr>
-    <td>`management_db_cache_multiplier`</td>
+    <td>`management.db_cache_multiplier`</td>
     <td>
       Affects the amount of time the [management plugin](./management#statistics-interval)
       will cache expensive management queries such as
@@ -1125,7 +1125,7 @@ collect_statistics_interval = 5000
       <p>
         Default:
 ```ini
-management_db_cache_multiplier = 5
+management.db_cache_multiplier = 5
 ```
       </p>
     </td>

--- a/versioned_docs/version-3.13/configure.md
+++ b/versioned_docs/version-3.13/configure.md
@@ -1090,7 +1090,7 @@ collect_statistics_interval = 5000
     </td>
   </tr>
   <tr>
-    <td>`management_db_cache_multiplier`</td>
+    <td>`management.db_cache_multiplier`</td>
     <td>
       Affects the amount of time the [management plugin](./management#statistics-interval)
       will cache expensive management queries such as
@@ -1100,7 +1100,7 @@ collect_statistics_interval = 5000
       <p>
         Default:
 ```ini
-management_db_cache_multiplier = 5
+management.db_cache_multiplier = 5
 ```
       </p>
     </td>

--- a/versioned_docs/version-4.0/configure.md
+++ b/versioned_docs/version-4.0/configure.md
@@ -1115,7 +1115,7 @@ collect_statistics_interval = 5000
     </td>
   </tr>
   <tr>
-    <td>`management_db_cache_multiplier`</td>
+    <td>`management.db_cache_multiplier`</td>
     <td>
       Affects the amount of time the [management plugin](./management#statistics-interval)
       will cache expensive management queries such as
@@ -1125,7 +1125,7 @@ collect_statistics_interval = 5000
       <p>
         Default:
 ```ini
-management_db_cache_multiplier = 5
+management.db_cache_multiplier = 5
 ```
       </p>
     </td>


### PR DESCRIPTION
As described in #2114 , the config option has an incorrect name on the website.