### PR TITLE
Update Event Exchange Plugin docs

### DIFF
--- a/docs/event-exchange.md
+++ b/docs/event-exchange.md
@@ -44,36 +44,55 @@ is a plugin that consumes RabbitMQ internal events and re-publishes them to a
 To consume the events, an application needs to declare a queue and bind it to the `amq.rabbitmq.event` exchange.
 
 By default, the plugin declares the topic exchange `amq.rabbitmq.event` in the default virtual host (`/`).
-All events are published to this exchange with routing keys (topics) like `exchange.created`, `binding.deleted`. etc.
-You can subscribe to only the events you're interested in.
-For example, to subscribe to all user events (such as `user.created`, `user.authentication.failure`, etc.) create a binding with binding key `user.#`.
+All events are published to this exchange with routing keys (topics) such as `exchange.created`, `binding.deleted`, etc.
+Applications can therefore consume only the relevant events.
+For example, to subscribe to all user events (such as `user.created`, `user.authentication.failure`, etc.) create a binding with routing (binding) key `user.#`.
 
 The exchange behaves similarly to `amq.rabbitmq.log`: everything gets published there.
-If you don't trust a user with the events that get published, don't allow them `read` access to the `amq.rabbitmq.event` exchange.
+If application's user cannot be trusted with the events that get published, don't [allow](./access-control) them `read` access to the `amq.rabbitmq.event` exchange.
+
+::: important
+
+All messages published by the internal event mechanism will always have a blank body.
+Relevant event attributes are passed in message metadata.
+
+:::
 
 Each event has various event properties associated with it.
 By default, the plugin internally publishes AMQP 0.9.1 messages with event properties translated to AMQP 0.9.1 message headers.
 The plugin can optionally be configured to internally publish AMQP 1.0 messages with event properties translated to AMQP 1.0 [message-annotations](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-message-annotations)
 by setting the following in [rabbitmq.conf](configure#config-file):
+
 ```
 event_exchange.protocol = amqp_1_0
 ```
-The message body is always blank.
+
+All messages published by the internal event mechanism will always have a blank body.
+Relevant event attributes are passed in message metadata.
 
 Because the plugin sets event properties as AMQP 0.9.1 headers or AMQP 1.0 message-annotations, client applications can optionally subscribe to only specific event properties (for example all events emitted for a specific user). This can be achieved by binding a queue to a [headers exchange](/tutorials/amqp-concepts#exchange-headers), and the headers exchange to the `amq.rabbitmq.event` topic exchange.
 
-## Events
+### Events
 
 Events including their routing keys (topics) that this plugin publishes are documented [here](./logging#internal-events).
 
-## Example
+### Example
 
-You can find a usage example using the Java client [here](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_event_exchange/examples/java).
+There's an [example internal event consumer in Java](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_event_exchange/examples/java).
+
 
 ## Plugin Configuration
 
 By default, the `rabbitmq_event_exchange` plugin uses the following configuration:
-```
+
+``` ini
 event_exchange.vhost = /
 event_exchange.protocol = amqp_0_9_1
+```
+
+To switch the plugin to publish events in the AMQP 1.0 format, use
+
+``` ini
+event_exchange.vhost = /
+event_exchange.protocol = amqp_1_0
 ```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -937,7 +937,7 @@ The events can also be exposed to applications for [consumption](./consumers)
 with [a plugin](./event-exchange).
 
 Events are published as messages with blank bodies. All event metadata is stored in
-message metadata (properties, headers).
+message annotations (properties, headers).
 
 Below is a list of published events.
 
@@ -952,7 +952,7 @@ Below is a list of published events.
  * `binding.created`
  * `binding.deleted`
 
-[Connection](./connections) and [Channel](./channels) events:
+[Connection](./connections) and AMQP 0.9.1 [Channel](./channels) events:
 
  * `connection.created`
  * `connection.closed`
@@ -968,6 +968,8 @@ Below is a list of published events.
 
  * `policy.set`
  * `policy.cleared`
+ * `queue.policy.updated`
+ * `queue.policy.cleared`
  * `parameter.set`
  * `parameter.cleared`
 
@@ -980,10 +982,10 @@ Below is a list of published events.
 
 User management events:
 
- * `user.authentication.success`
- * `user.authentication.failure`
  * `user.created`
  * `user.deleted`
+ * `user.authentication.success`
+ * `user.authentication.failure`
  * `user.password.changed`
  * `user.password.cleared`
  * `user.tags.set`


### PR DESCRIPTION
This is the docs PR for
https://github.com/rabbitmq/rabbitmq-server/pull/12714 and applies to RabbitMQ >= 4.1

Note that the internal event types were documented previously at three different places:
1. https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_event_exchange/README.md
2. https://www.rabbitmq.com/docs/event-exchange
3. https://www.rabbitmq.com/docs/logging#internal-events

All of them listed different and/or outdated event types. From now on, we use the 3rd place as only place and single source of truth for documenting internal events.