### PR TITLE
Add a stream client for C++ in stream.md

### DIFF
--- a/docs/stream.md
+++ b/docs/stream.md
@@ -52,6 +52,7 @@ Client libraries for the stream protocol are available on several platforms.
 * [RabbitMQ Erlang Stream Client (lake)](https://gitlab.com/evnu/lake)
 * [RabbitMQ Elixir Stream Client ](https://github.com/VictorGaiva/rabbitmq-stream)
 * [RabbitMQ C Stream Client ](https://github.com/GianfrancoGGL/rabbitmq-stream-c-client)
+* [RabbitMQ C++ Stream Client](https://github.com/coveooss/hareflow)
 
 Use [Stream PerfTest](https://github.com/rabbitmq/rabbitmq-stream-perf-test) to simulate workloads and measure the performance of your RabbitMQ stream system.
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/stream.md` file. The change adds a new RabbitMQ stream client for C++.