### PR TITLE
Add a hint on Debian package conflicts for 3.13

### DIFF
--- a/versioned_docs/version-3.13/install-debian.md
+++ b/versioned_docs/version-3.13/install-debian.md
@@ -154,6 +154,8 @@ and <a href="#apt-cloudsmith-erlang">on Cloudsmith.io</a>.
 
 Below is a shell snippet that performs those steps.
 
+Note: by default, the snippet installs the latest version of Erlang available in the apt repository. If you face vesion conflicts, note the section on [package pinning](#apt-pinning).
+
 <Tabs groupId="distribution-specific">
 <TabItem value="ubuntu-noble" label="Ubuntu 24.04" default>
 ```bash


### PR DESCRIPTION
To the `3.13.x` version of the site add a hint for the case of conflicts with Erlang versions, so that fellow users do not add new issues or questions facing problems with the installation instruction.

I have not run tests, and also hope the change is trivial enough to not sign the contributor agreement.