### PR TITLE
Fix `npm start` on Windows

### DIFF
--- a/src/plugins/configure-svgo.js
+++ b/src/plugins/configure-svgo.js
@@ -10,13 +10,14 @@ function configureSvgo() {
   return {
     name: 'configure-svgo',
     configureWebpack(config) {
+      const path = require('path');
       /** @type {object[]} */
       const rules = config.module.rules;
 
       const rule = rules.find((rule) => {
         /** @type {string|undefined} */
         const loader = rule.oneOf?.[0]?.use?.[0]?.loader;
-        return loader && loader.includes("/@svgr/");
+        return loader && loader.includes(path.sep + "@svgr" + path.sep);
       });
 
       const svgoConfig = rule.oneOf[0].use[0].options.svgoConfig;


### PR DESCRIPTION
The `src/plugins/configure-svgo.js` file has code that depends on the current path separator. This removes the hard-coded `/` separator and uses the `path.sep` value, instead.

Follow-up to acb4b1852ea3fd272f55901202173ba434bc68ea