### PR TITLE
Add note about interaction of queue mirroring and anonymous queues

### DIFF
--- a/docs/queues.md
+++ b/docs/queues.md
@@ -315,6 +315,7 @@ Use [durable queues](#durability) or [non-durable exclusive queues](#exclusive-q
 When RabbitMQ detects a non-durable and non-exclusive queue, it will display a deprecation
 warning in the management UI.
 
+A queue that is mirrored (a deprecated replication feature) will not be autodeleted. A queue that is exclusive cannot be mirrored.
 :::
 
 
@@ -552,3 +553,4 @@ There are two solutions to this fundamental race condition:
    use a connection recovery delay of 5 seconds by default
 2. Use server-named queues, which side steps the problem entirely since the new client connection
    will use a different queue name from its predecessor
+


### PR DESCRIPTION
We had an interesting incident because our anonymous queues, although declared with 

```
Durable:            false,
AutoDelete:         true,
```

and a message ttl, were not deleted when their consumer was cancelled. Each pod in our kubernetes deployment created an anonymous queue, and then failed to clean it up. As a result we saw disk utilization alarms and had to take emergency action. 

It turns out that a) they were not declared with exlusive (which according to docs would have turned off mirroring) and b) they had mirroring applied with a policy, which apparently turned off auto-deletion.

I know mirroring is deprecated, which I called out in this PR, but I'm sure many deployments, like us, have not yet switched to quorum queues, so I think some documentation support is warranted.