### PR TITLE
Add oauth2 alias for configuring auth backend in documentation

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -699,6 +699,7 @@ The following aliases are available:
 
  * <code>internal</code> for <code>rabbit_auth_backend_internal</code>
  * <code>ldap</code> for <code>rabbit_auth_backend_ldap</code> (from the [LDAP plugin](./ldap))
+ * <code>oauth</code> or <code>oauth2</code> for <code>rabbit_auth_backend_oauth2</code> (from the [OAuth 2.0 plugin](./oauth2))
  * <code>http</code> for <code>rabbit_auth_backend_http</code> (from the [HTTP auth backend plugin](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http))
  * <code>dummy</code> for <code>rabbit_auth_backend_dummy</code>
 
@@ -708,7 +709,7 @@ be used:
 ```ini
 # note that the module name begins with a "rabbit_", not "rabbitmq_", like in the name
 # of the plugin
-auth_backends.1 = rabbit_auth_backend_oauth2
+auth_backends.1 = rabbit_auth_backend_example
 ```
 
 When using third party plugins, providing a full module name is necessary.

--- a/versioned_docs/version-3.13/access-control.md
+++ b/versioned_docs/version-3.13/access-control.md
@@ -705,6 +705,7 @@ The following aliases are available:
 
  * <code>internal</code> for <code>rabbit_auth_backend_internal</code>
  * <code>ldap</code> for <code>rabbit_auth_backend_ldap</code> (from the [LDAP plugin](./ldap))
+ * <code>oauth</code> or <code>oauth2</code> for <code>rabbit_auth_backend_oauth2</code> (from the [OAuth 2.0 plugin](./oauth2))
  * <code>http</code> for <code>rabbit_auth_backend_http</code> (from the [HTTP auth backend plugin](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http))
  * <code>dummy</code> for <code>rabbit_auth_backend_dummy</code>
 
@@ -714,7 +715,7 @@ be used:
 ```ini
 # note that the module name begins with a "rabbit_", not "rabbitmq_", like in the name
 # of the plugin
-auth_backends.1 = rabbit_auth_backend_oauth2
+auth_backends.1 = rabbit_auth_backend_example
 ```
 
 When using third party plugins, providing a full module name is necessary.

--- a/versioned_docs/version-4.0/access-control.md
+++ b/versioned_docs/version-4.0/access-control.md
@@ -699,6 +699,7 @@ The following aliases are available:
 
  * <code>internal</code> for <code>rabbit_auth_backend_internal</code>
  * <code>ldap</code> for <code>rabbit_auth_backend_ldap</code> (from the [LDAP plugin](./ldap))
+ * <code>oauth</code> or <code>oauth2</code> for <code>rabbit_auth_backend_oauth2</code> (from the [OAuth 2.0 plugin](./oauth2))
  * <code>http</code> for <code>rabbit_auth_backend_http</code> (from the [HTTP auth backend plugin](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http))
  * <code>dummy</code> for <code>rabbit_auth_backend_dummy</code>
 
@@ -708,7 +709,7 @@ be used:
 ```ini
 # note that the module name begins with a "rabbit_", not "rabbitmq_", like in the name
 # of the plugin
-auth_backends.1 = rabbit_auth_backend_oauth2
+auth_backends.1 = rabbit_auth_backend_example
 ```
 
 When using third party plugins, providing a full module name is necessary.


### PR DESCRIPTION
Saw that `oauth` and `oauth2` aliases were added for auth backends configuration since `3.13`. Updating the docs to reflect so.

Relevant commit: https://github.com/rabbitmq/rabbitmq-server/commit/16f49d336f8a3975922ff1b370c10fe9ae1a89e3