### PR TITLE
Document exchangeDelete and queueDelete for AMQP Java client

### DIFF
--- a/client-libraries/amqp-client-libraries.md
+++ b/client-libraries/amqp-client-libraries.md
@@ -663,7 +663,7 @@ Here is how to delete an exchange:
 <TabItem value="java" label="Java">
 
 ```java title="Deleting an exchange"
-management.exchangeDeletion().delete("my-exchange");
+management.exchangeDelete("my-exchange");
 ```
 
 </TabItem>
@@ -805,7 +805,7 @@ And here is how to delete a queue:
 <TabItem value="java" label="Java">
 
 ```java title="Deleting a queue"
-management.queueDeletion().delete("my-queue");
+management.queueDelete("my-queue");
 ```
 
 </TabItem>


### PR DESCRIPTION
Instead of exchangeDeletion and queueDeletion, which are deprecated.

References rabbitmq/rabbitmq-amqp-java-client#137

To merge when AMQP Java client 0.4.0 is release.