### PR TITLE
Fix typo in ssl example code

### DIFF
--- a/versioned_docs/version-4.0/ssl/index.md
+++ b/versioned_docs/version-4.0/ssl/index.md
@@ -838,7 +838,7 @@ public class Example2 {
       ks.load(new FileInputStream(&quot;/path/to/client_key.p12&quot;), keyPassphrase);
 
       KeyManagerFactory kmf = KeyManagerFactory.getInstance(&quot;SunX509&quot;);
-      kmf.init(ks, passphrase);
+      kmf.init(ks, keyPassphrase);
 
       char[] trustPassphrase = &quot;rabbitstore&quot;.toCharArray();
       KeyStore tks = KeyStore.getInstance(&quot;JKS&quot;);


### PR DESCRIPTION
Small typo fix in versioned_docs/version-4.0/ssl/index.md.
