### PR TITLE
New blog post: RabbitMQ 3.13.8 is released

### DIFF
--- a/blog/2025-02-07-rabbitmq-3.13.8-is-released/index.md
+++ b/blog/2025-02-07-rabbitmq-3.13.8-is-released/index.md
@@ -1,0 +1,20 @@
+---
+title: "RabbitMQ 3.13.8 is released"
+tags: ["Releases", "RabbitMQ 3.13"]
+authors: [mklishin]
+---
+
+# RabbitMQ 3.13.8 is released
+
+RabbitMQ `3.13.8` is a new patch release in the `3.13.x` series.
+This series is currently covered by [commercial support](https://www.rabbitmq.com/release-information) only.
+
+For publicly available open source releases, see the [`4.0.x` series](https://www.rabbitmq.com/blog/tags/rabbit-mq-4-0).
+
+# Release Artifacts
+
+Release artifacts for the `3.13.x` series can be obtained via the [Broadcom customer portal](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/open-source-rabbitmq/3-13/opn-src-rabbitmq/site-install.html).
+
+# Upgrade Guidance
+
+If [upgrading](https://www.rabbitmq.com/docs/upgrade) from a version prior to 3.13.9, please consult the [3.13.0 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.13.0).


### PR DESCRIPTION
for those holding a commercial license.

4.0.x is still distributed via GitHub and
package repositories until the release of 4.1.0.