### PR TITLE
Add docs for cache auth backend

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -531,7 +531,7 @@ server-generated names and the default exchange.  The empty
 string, <code>''</code> is a synonym for <code>'^$'</code>
 and restricts permissions in the exact same way.
 
-RabbitMQ may cache the results of access control checks on a
+RabbitMQ may [cache](./auth-cache-backend) the results of access control checks on a
 per-connection or per-channel basis. Hence changes to user
 permissions may only take effect when the user reconnects.
 
@@ -665,7 +665,7 @@ also only provide an authorisation backend.
 
 Authentication is supposed to be handled by the internal database, LDAP, etc.
 
-A special [cache backend](https://github.com/rabbitmq/rabbitmq-server/tree/v3.13.x/deps/rabbitmq_auth_backend_cache)
+A special [cache backend](./auth-cache-backend) 
 can be used in [combination](#combined-backends) with other backends to significantly
 reduce the load they generate on external services, such as LDAP or HTTP servers.
 

--- a/docs/auth-cache-backend.md
+++ b/docs/auth-cache-backend.md
@@ -63,7 +63,6 @@ auth_backends.1 = cache
 auth_cache.cached_backend = http
 
 auth_http.http_method = post
-....
 ```
 
 It is possible to use different backends for authorization and authentication.

--- a/docs/auth-cache-backend.md
+++ b/docs/auth-cache-backend.md
@@ -23,7 +23,7 @@ limitations under the License.
 ## Overview {#overview}
 
 This plugin provides a way to cache authentication and authorization backend 
-results for a configurable amount of time. It's not an independent auth backend
+results for a configurable amount of time. It's not an independent auth backend,
  but a caching layer for existing backends such as the built-in, [LDAP](./ldap),
  or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
 Although It is not very useful with the 

--- a/docs/auth-cache-backend.md
+++ b/docs/auth-cache-backend.md
@@ -1,0 +1,150 @@
+---
+title: RabbitMQ Access Control Cache Plugin
+---
+<!--
+Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Authentication/Authorization Cache Backend
+
+## Overview {#overview}
+
+This plugin provides a way to cache authentication and authorization backend 
+results for a configurable amount of time. It's not an independent auth backend
+ but a caching layer for existing backends such as the built-in, [LDAP](./ldap),
+ or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
+Although It is not very useful with the 
+built-in (internal) [authn/authz backends](./access-control) but can be other 
+backends that use network requests like LDAP or HTTP.
+
+Cache expiration is currently time-based. 
+
+## Table of Contents
+
+### [Installation](#installation)
+### [Authorization and Authentication Backend Configuration](#configuration)
+### [Basic Cache configuration](#basic-configuration)
+### [Advanced Cache configuration](#advanced-configuration)
+
+## Installation {#installation}
+
+To enable this plugin use the following command or check out [other mechanisms](./plugins)
+to enable it. 
+
+```bash
+rabbitmq-plugins enable rabbitmq_auth_backend_cache
+```
+
+## Authorization and Authentication Backend Configuration {#configuration}
+
+To configure this plugin so that it caches all the authorization and authentication
+decisions, you first of all set this cache backend as the `auth_backends` or one
+of them and then you configure which authentication backend is actually cached.
+
+For instance, lets say you are caching the `http` backend:
+
+```ini
+auth_backends.1 = cache
+auth_cache.cached_backend = http
+
+auth_http.http_method = post
+....
+```
+
+It is possible to use different backends for authorization and authentication.
+
+The following example configures the plugin to use LDAP backend for 
+authentication but internal backend for authorization:
+
+```ini 
+auth_backends.1 = cache
+
+auth_cache.cached_backend.authn = ldap
+auth_cache.cached_backend.authz = internal
+```
+
+## Basic Cache configuration {#basic-configuration}
+
+You can configure TTL for cache items, by using `cache_ttl` configuration variable, 
+specified in milliseconds. The default value is `15000` milliseconds:
+
+```ini 
+auth_cache.cached_backend = ldap
+auth_cache.cache_ttl = 5000
+```
+
+By default, negative authentication and/o authorization decisions are not cached, 
+only positive ones. However you can change this behaviour by setting `cache_refusals` to `true` 
+as shown below: 
+
+```ini
+auth_cache.cache_refusals = true
+```
+
+## Advanced Cache configuration {#advanced-configuration}
+
+You can also use a custom cache module to store cached requests. This module 
+should be an erlang module implementing `rabbit_auth_cache` behaviour and 
+(optionally) define `start_link` function to start the cache process.
+
+This repository provides several implementations:
+
+* `rabbit_auth_cache_dict` stores cache entries in the internal process dictionary. 
+This module is for demonstration only and should not be used in production.
+* `rabbit_auth_cache_ets` stores cache entries in an [ETS](https://learnyousomeerlang.com/ets) 
+table and uses timers for cache invalidation. **This is the default implementation**.
+* `rabbit_auth_cache_ets_segmented` stores cache entries in multiple ETS tables 
+and does not delete individual cache items but rather uses a separate process for garbage collection.
+* `rabbit_auth_cache_ets_segmented_stateless` same as previous, but with minimal
+ use of gen_server state, using ets tables to store information about segments.
+
+To specify the module for caching you should use `cache_module` configuration variable. 
+This example configuration configures the `rabbit_auth_backend_ets_segmented` 
+cache_module.
+
+```ini 
+auth_cache.cache_module = rabbit_auth_backend_ets_segmented
+```
+
+:::info
+For custom implementation of a cache_module, you can specify `start args` 
+with `cache_module_args`. `Start args` should be list of arguments passed to 
+module `start_link` function.
+
+However, additional cache module arguments can only be defined via the 
+[advanced.config](./configure#advanced-config-file).
+
+```erlang 
+[
+ {rabbit, [
+   %% ...
+ ]},
+
+ {rabbitmq_auth_backend_cache, [{cache_module, rabbit_auth_backend_ets_segmented},
+                                {cache_module_args, [10000]}]}
+].
+```
+:::
+
+
+## Clear Cache command 
+
+There is a [`rabbitmqctl`](./man/rabbitmqctl.8) command `clear_auth_backend_cache`
+to clear the cache in all the nodes of the RabbitMQ cluster. 
+
+```bash 
+$ rabbitmqctl clear_auth_backend_cache
+```

--- a/docs/auth-cache-backend.md
+++ b/docs/auth-cache-backend.md
@@ -25,7 +25,7 @@ limitations under the License.
 This plugin provides a way to cache authentication and authorization backend 
 results for a configurable amount of time. It's not an independent auth backend,
  but a caching layer for existing backends such as the built-in, [LDAP](./ldap),
- or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
+or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
 Although It is not very useful with the 
 built-in (internal) [authn/authz backends](./access-control) but can be other 
 backends that use network requests like LDAP or HTTP.

--- a/docs/auth-cache-backend.md
+++ b/docs/auth-cache-backend.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 This plugin provides a way to cache authentication and authorization backend 
 results for a configurable amount of time. It's not an independent auth backend,
- but a caching layer for existing backends such as the built-in, [LDAP](./ldap),
+but a caching layer for existing backends, such as the built-in, [LDAP](./ldap),
 or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
 Although It is not very useful with the 
 built-in (internal) [authn/authz backends](./access-control) but can be other 

--- a/docs/auth-cache-backend.md
+++ b/docs/auth-cache-backend.md
@@ -26,7 +26,7 @@ This plugin provides a way to cache authentication and authorization backend
 results for a configurable amount of time. It's not an independent auth backend,
 but a caching layer for existing backends, such as the built-in, [LDAP](./ldap),
 or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
-Although It is not very useful with the 
+Although it is not very useful with the 
 built-in (internal) [authn/authz backends](./access-control) but can be other 
 backends that use network requests like LDAP or HTTP.
 

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -459,6 +459,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'auth-cache-backend',
+              label: 'Cache',
+            },
+            {
+              type: 'doc',
               id: 'auth-notification',
               label: 'Authentication Failure Notifications',
             },

--- a/versioned_docs/version-4.0/access-control.md
+++ b/versioned_docs/version-4.0/access-control.md
@@ -531,7 +531,7 @@ server-generated names and the default exchange.  The empty
 string, <code>''</code> is a synonym for <code>'^$'</code>
 and restricts permissions in the exact same way.
 
-RabbitMQ may cache the results of access control checks on a
+RabbitMQ may [cache](./auth-cache-backend) the results of access control checks on a
 per-connection or per-channel basis. Hence changes to user
 permissions may only take effect when the user reconnects.
 
@@ -665,7 +665,7 @@ also only provide an authorisation backend.
 
 Authentication is supposed to be handled by the internal database, LDAP, etc.
 
-A special [cache backend](https://github.com/rabbitmq/rabbitmq-server/tree/v3.13.x/deps/rabbitmq_auth_backend_cache)
+A special [cache backend](./auth-cache-backend) 
 can be used in [combination](#combined-backends) with other backends to significantly
 reduce the load they generate on external services, such as LDAP or HTTP servers.
 

--- a/versioned_docs/version-4.0/auth-cache-backend.md
+++ b/versioned_docs/version-4.0/auth-cache-backend.md
@@ -63,7 +63,6 @@ auth_backends.1 = cache
 auth_cache.cached_backend = http
 
 auth_http.http_method = post
-....
 ```
 
 It is possible to use different backends for authorization and authentication.

--- a/versioned_docs/version-4.0/auth-cache-backend.md
+++ b/versioned_docs/version-4.0/auth-cache-backend.md
@@ -1,0 +1,150 @@
+---
+title: RabbitMQ Access Control Cache Plugin
+---
+<!--
+Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Authentication/Authorization Cache Backend
+
+## Overview {#overview}
+
+This plugin provides a way to cache authentication and authorization backend 
+results for a configurable amount of time. It's not an independent auth backend
+ but a caching layer for existing backends such as the built-in, [LDAP](./ldap),
+ or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
+Although It is not very useful with the 
+built-in (internal) [authn/authz backends](./access-control) but can be other 
+backends that use network requests like LDAP or HTTP.
+
+Cache expiration is currently time-based. 
+
+## Table of Contents
+
+### [Installation](#installation)
+### [Authorization and Authentication Backend Configuration](#configuration)
+### [Basic Cache configuration](#basic-configuration)
+### [Advanced Cache configuration](#advanced-configuration)
+
+## Installation {#installation}
+
+To enable this plugin use the following command or check out [other mechanisms](./plugins)
+to enable it. 
+
+```bash
+rabbitmq-plugins enable rabbitmq_auth_backend_cache
+```
+
+## Authorization and Authentication Backend Configuration {#configuration}
+
+To configure this plugin so that it caches all the authorization and authentication
+decisions, you first of all set this cache backend as the `auth_backends` or one
+of them and then you configure which authentication backend is actually cached.
+
+For instance, lets say you are caching the `http` backend:
+
+```ini
+auth_backends.1 = cache
+auth_cache.cached_backend = http
+
+auth_http.http_method = post
+....
+```
+
+It is possible to use different backends for authorization and authentication.
+
+The following example configures the plugin to use LDAP backend for 
+authentication but internal backend for authorization:
+
+```ini 
+auth_backends.1 = cache
+
+auth_cache.cached_backend.authn = ldap
+auth_cache.cached_backend.authz = internal
+```
+
+## Basic Cache configuration {#basic-configuration}
+
+You can configure TTL for cache items, by using `cache_ttl` configuration variable, 
+specified in milliseconds. The default value is `15000` milliseconds:
+
+```ini 
+auth_cache.cached_backend = ldap
+auth_cache.cache_ttl = 5000
+```
+
+By default, negative authentication and/o authorization decisions are not cached, 
+only positive ones. However you can change this behaviour by setting `cache_refusals` to `true` 
+as shown below: 
+
+```ini
+auth_cache.cache_refusals = true
+```
+
+## Advanced Cache configuration {#advanced-configuration}
+
+You can also use a custom cache module to store cached requests. This module 
+should be an erlang module implementing `rabbit_auth_cache` behaviour and 
+(optionally) define `start_link` function to start the cache process.
+
+This repository provides several implementations:
+
+* `rabbit_auth_cache_dict` stores cache entries in the internal process dictionary. 
+This module is for demonstration only and should not be used in production.
+* `rabbit_auth_cache_ets` stores cache entries in an [ETS](https://learnyousomeerlang.com/ets) 
+table and uses timers for cache invalidation. **This is the default implementation**.
+* `rabbit_auth_cache_ets_segmented` stores cache entries in multiple ETS tables 
+and does not delete individual cache items but rather uses a separate process for garbage collection.
+* `rabbit_auth_cache_ets_segmented_stateless` same as previous, but with minimal
+ use of gen_server state, using ets tables to store information about segments.
+
+To specify the module for caching you should use `cache_module` configuration variable. 
+This example configuration configures the `rabbit_auth_backend_ets_segmented` 
+cache_module.
+
+```ini 
+auth_cache.cache_module = rabbit_auth_backend_ets_segmented
+```
+
+:::info
+For custom implementation of a cache_module, you can specify `start args` 
+with `cache_module_args`. `Start args` should be list of arguments passed to 
+module `start_link` function.
+
+However, additional cache module arguments can only be defined via the 
+[advanced.config](./configure#advanced-config-file).
+
+```erlang 
+[
+ {rabbit, [
+   %% ...
+ ]},
+
+ {rabbitmq_auth_backend_cache, [{cache_module, rabbit_auth_backend_ets_segmented},
+                                {cache_module_args, [10000]}]}
+].
+```
+:::
+
+
+## Clear Cache command 
+
+There is a [`rabbitmqctl`](./man/rabbitmqctl.8) command `clear_auth_backend_cache`
+to clear the cache in all the nodes of the RabbitMQ cluster. 
+
+```bash 
+$ rabbitmqctl clear_auth_backend_cache
+```

--- a/versioned_docs/version-4.0/auth-cache-backend.md
+++ b/versioned_docs/version-4.0/auth-cache-backend.md
@@ -23,26 +23,28 @@ limitations under the License.
 ## Overview {#overview}
 
 This plugin provides a way to cache authentication and authorization backend 
-results for a configurable amount of time. It's not an independent auth backend
- but a caching layer for existing backends such as the built-in, [LDAP](./ldap),
- or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
-Although It is not very useful with the 
-built-in (internal) [authn/authz backends](./access-control) but can be other 
-backends that use network requests like LDAP or HTTP.
+results for a configurable amount of time. It's not an independent auth backend,
+but a caching layer for existing backends, such as the built-in, [LDAP](./ldap),
+or [HTTP](https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_auth_backend_http) ones.
+Although it is not very useful with the
+built-in (internal) [authentication and authorization backends](./access-control) but can be other
+backends that use network requests, such as LDAP or HTTP.
 
 Cache expiration is currently time-based. 
 
 ## Table of Contents
 
-### [Installation](#installation)
-### [Authorization and Authentication Backend Configuration](#configuration)
-### [Basic Cache configuration](#basic-configuration)
-### [Advanced Cache configuration](#advanced-configuration)
+ * [Installation](#installation)
+ * Authorization and Authentication [Backend Configuration](#configuration)
+ * [Plugin configuration](#basic-configuration)
+ * [Advanced plugin configuration](#advanced-configuration)
 
 ## Installation {#installation}
 
-To enable this plugin use the following command or check out [other mechanisms](./plugins)
-to enable it. 
+The `rabbitmq_auth_backend_cache` plugin ships with RabbitMQ.
+
+Like all plugins, it [must be enabled](./plugins) before it can be used, for example,
+use [`rabbitmqctl`](./cli):
 
 ```bash
 rabbitmq-plugins enable rabbitmq_auth_backend_cache
@@ -51,10 +53,10 @@ rabbitmq-plugins enable rabbitmq_auth_backend_cache
 ## Authorization and Authentication Backend Configuration {#configuration}
 
 To configure this plugin so that it caches all the authorization and authentication
-decisions, you first of all set this cache backend as the `auth_backends` or one
+decisions, first set this cache backend as the `auth_backends` or one
 of them and then you configure which authentication backend is actually cached.
 
-For instance, lets say you are caching the `http` backend:
+For example, to cache requests to the `http` backend:
 
 ```ini
 auth_backends.1 = cache
@@ -67,7 +69,7 @@ auth_http.http_method = post
 It is possible to use different backends for authorization and authentication.
 
 The following example configures the plugin to use LDAP backend for 
-authentication but internal backend for authorization:
+authentication, but internal backend for authorization:
 
 ```ini 
 auth_backends.1 = cache
@@ -86,8 +88,8 @@ auth_cache.cached_backend = ldap
 auth_cache.cache_ttl = 5000
 ```
 
-By default, negative authentication and/o authorization decisions are not cached, 
-only positive ones. However you can change this behaviour by setting `cache_refusals` to `true` 
+By default, negative authentication and/or authorization decisions are not cached,
+only positive ones are. However, this behaviour can be changed by setting `cache_refusals` to `true`
 as shown below: 
 
 ```ini
@@ -97,30 +99,28 @@ auth_cache.cache_refusals = true
 ## Advanced Cache configuration {#advanced-configuration}
 
 You can also use a custom cache module to store cached requests. This module 
-should be an erlang module implementing `rabbit_auth_cache` behaviour and 
+should be an Erlang module implementing the `rabbit_auth_cache` behavior and
 (optionally) define `start_link` function to start the cache process.
 
 This repository provides several implementations:
 
-* `rabbit_auth_cache_dict` stores cache entries in the internal process dictionary. 
-This module is for demonstration only and should not be used in production.
+* `rabbit_auth_cache_dict` stores cache entries in the internal process dictionary.
+  This module is for demonstration only and should not be used in production.
 * `rabbit_auth_cache_ets` stores cache entries in an [ETS](https://learnyousomeerlang.com/ets) 
-table and uses timers for cache invalidation. **This is the default implementation**.
+  table and uses timers for cache invalidation. **This is the default implementation**.
 * `rabbit_auth_cache_ets_segmented` stores cache entries in multiple ETS tables 
-and does not delete individual cache items but rather uses a separate process for garbage collection.
+  and does not delete individual cache items but rather uses a separate process for garbage collection.
 * `rabbit_auth_cache_ets_segmented_stateless` same as previous, but with minimal
- use of gen_server state, using ets tables to store information about segments.
+   use of `gen_server` state, using ets tables to store information about segments.
 
-To specify the module for caching you should use `cache_module` configuration variable. 
-This example configuration configures the `rabbit_auth_backend_ets_segmented` 
-cache_module.
+To specify the module for caching, use the `cache_module` configuration key.
+This example configuration configures the `rabbit_auth_backend_ets_segmented` module.
 
 ```ini 
 auth_cache.cache_module = rabbit_auth_backend_ets_segmented
 ```
 
-:::info
-For custom implementation of a cache_module, you can specify `start args` 
+When using a custom implementation of a `cache_module`, you can specify `start args`
 with `cache_module_args`. `Start args` should be list of arguments passed to 
 module `start_link` function.
 
@@ -133,18 +133,9 @@ However, additional cache module arguments can only be defined via the
    %% ...
  ]},
 
- {rabbitmq_auth_backend_cache, [{cache_module, rabbit_auth_backend_ets_segmented},
-                                {cache_module_args, [10000]}]}
+ {rabbitmq_auth_backend_cache, [
+    {cache_module, rabbit_auth_backend_ets_segmented},
+    {cache_module_args, [10000]}
+  ]}
 ].
-```
-:::
-
-
-## Clear Cache command 
-
-There is a [`rabbitmqctl`](./man/rabbitmqctl.8) command `clear_auth_backend_cache`
-to clear the cache in all the nodes of the RabbitMQ cluster. 
-
-```bash 
-$ rabbitmqctl clear_auth_backend_cache
 ```

--- a/versioned_sidebars/version-4.0-sidebars.json
+++ b/versioned_sidebars/version-4.0-sidebars.json
@@ -480,6 +480,11 @@
             },
             {
               "type": "doc",
+              "id": "auth-cache-backend",
+              "label": "Cache"
+            },
+            {
+              "type": "doc",
               "id": "auth-notification",
               "label": "Authentication Failure Notifications"
             },


### PR DESCRIPTION
When the docs wanted to reference the cache authz backend, it used to link to the Readme in the source code. 
Since this plugin now has a rabbitmqctl command and to keep the docs consistent, this PR adds a docs page dedicated to this plugin. 
