### PR TITLE
CONNECT_USING_PLAIN_HTTP Env Variable for the Messaging Topology Operator

### DIFF
--- a/kubernetes/operator/install-topology-operator.md
+++ b/kubernetes/operator/install-topology-operator.md
@@ -264,6 +264,17 @@ The following table listes the Topology Operator environment variables that are 
       Default value is set to 2 seconds.
     </td>
   </tr>
+  <tr>
+    <td>
+      CONNECT_USING_PLAIN_HTTP
+    </td>
+    <td>
+      Communicate with RabbitMQ clusters using plain HTTP, even if a cluster has TLS enabled. Default is `false`.
+    </td>
+    <td>
+      Default value is set to `false` and will communicate via HTTPS.
+    </td>
+  </tr>
 </table>
 
 ### Older Operator Versions

--- a/kubernetes/operator/tls-topology-operator.md
+++ b/kubernetes/operator/tls-topology-operator.md
@@ -56,6 +56,4 @@ Any  communication the Pod performs with the RabbitmqCluster will be done over H
 
 * Messaging Topology Operator will not be able to manage RabbitmqClusters that have not mounted their CA as described above:
   such nodes won't accept client connections over HTTPS
-* Messaging Topology Operator will not attempt to connect to the RabbitmqCluster over HTTP if HTTPS is available (even if the
-certificate is not trusted)
 * RabbitmqClusters with TLS deactivated (that is nothing is configured under .spec.tls) will always be managed over HTTP


### PR DESCRIPTION
Nearly 2 years ago this issue was raised: https://github.com/rabbitmq/messaging-topology-operator/issues/621
With the following PR addressing it: https://github.com/rabbitmq/messaging-topology-operator/pull/622

This enabled the Messaging Topology Operator to communicate to RabbitMQ clusters via HTTP, even if the cluster had TLS enabled. The PR added in a new environment variable called `CONNECT_USING_PLAIN_HTTP`.

I don't believe that this was documented anywhere?

Furthermore, it also [addresses this limitation](https://www.rabbitmq.com/kubernetes/operator/tls-topology-operator#limitations):
> Messaging Topology Operator will not attempt to connect to the RabbitmqCluster over HTTP if HTTPS is available (even if the certificate is not trusted)

The need to remove this was also mentioned in the PR.