### PR TITLE
Add note about poison messages with prefetch_count > 1

### DIFF
--- a/versioned_docs/version-4.0/quorum-queues/index.md
+++ b/versioned_docs/version-4.0/quorum-queues/index.md
@@ -369,6 +369,12 @@ using an [optional queue argument](./queues#optional-arguments) at declaration t
 
 See [repeated requeues](#repeated-requeues) for more details.
 
+:::important
+
+Note that with `prefetch_count` > 1, if a consumer crashes due to a single "poison message" while other prefetched messages are not yet acknowledged, those other messages will also be redelivered and have their delivery counts incremented. This may force messages that could otherwise be processed normally (i.e. not "poison") to be dropped or dead-lettered.
+
+:::
+
 ### Configuring the Limit {#position-message-handling-configuring-limit}
 
 It is possible to set a delivery limit for a queue using a [policy](./parameters#policies) argument, `delivery-limit`.


### PR DESCRIPTION
This adds a warning that a single "poison message" may force other messages to be dropped or dead-lettered with `prefetch_count` > 1. This behavior follows straightforwardly from how prefetch counts and delivery counts work, but it is not immediately obvious to users and could lead to unexpected message loss.