### PR TITLE
Add idp-initiated login  example

### DIFF
--- a/docs/oauth2-examples-idp-initiated.md
+++ b/docs/oauth2-examples-idp-initiated.md
@@ -1,0 +1,114 @@
+---
+title: Use Identity Provider Initiated Logon
+displayed_sidebar: docsSidebar
+---
+<!--
+Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Use Identity Provider Initiated Logon
+
+This guide explains how to set up Identity Provider Initiated Logon
+using UAA as Authorization Server and a sample Node.js web application as a Web Portal.
+
+The web portal acts as an identity provider, allowing users to access the 
+management UI with a single click using an OAuth 2.0 token previously 
+obtained from the authorization server.
+
+```
+      | Idp (e.g.UAA) |
+            /\
+             | 2. get token
+             |
+     | Web app Portal |  ---------> | RabbitMQ | <---+
+           /\                  |         |           | 4. 302 direct to overview page
+            |                  |         |           |    with cookie
+            |                  |         +-----------+
+            |                  |
+    1. user requests             3. POST https://rabbitmq:15671/login  
+          access                    with access_token 
+       to management ui
+
+```
+
+* Access [management UI](./management/) via a browser
+
+## Prerequisites to follow this guide
+
+* Docker
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/tree/next) for branch `next` that contains all the configuration files and scripts used on this example.
+
+:::info 
+The commands used to start UAA, RabbitMQ and the web portal automatically 
+generate their x.509 certificates required for https.
+
+:::
+
+## Deploy UAA 
+
+Run the following commands to start UAA:
+
+```bash
+make start-uaa
+```
+ 
+To check if UAA is running, run `docker ps | grep uaa`
+
+## Deploy RabbitMQ 
+
+Run the following commands to start RabbitMQ:
+
+```bash
+export MODE=portal
+OAUTH_PROVIDER=uaa make start-rabbitmq
+```
+
+:::tip
+Ensure RabbitMQ is deployed with the version you expect by searching for 
+ `Running RabbitMQ (<image>:<image_tag>) with` in `docker logs rabbitmq`.
+:::
+
+:::info
+To start one specific version of RabbitMQ run the following command instead:
+```bash 
+MODE=portal OAUTH_PROVIDER=uaa IMAGE=rabbitmq IMAGE_TAG=<YourVersion> make start-rabbitmq
+```
+:::
+
+## Deploy Portal 
+
+Run the following commands to start Portal:
+
+```bash
+make start-portal
+```
+
+## Verify Management UI flows
+
+1. Go to the portal `https://localhost:3000`.
+2. Click on the button `https://localhost:15671 for rabbit_idp_user`.
+3. It redirects to RabbitMQ management UI fully authenticated.
+
+:::info 
+`rabbit_idp_user` is the OAuth Client the portal uses to obtain an access token to
+test this flow. This OAuth Client is declared in UAA.
+:::
+
+:::warning
+When you visit https://localhost:3000 you will get a browser warning 
+due to net::ERR_CERT_AUTHORITY_INVALID. This is because the portal 
+is using a self-signed certificate. You accept it by clicking on `Proceed to localhost (unsafe)`.
+:::

--- a/docs/oauth2-examples/index.md
+++ b/docs/oauth2-examples/index.md
@@ -160,6 +160,11 @@ auth_oauth2.issuer = https://uaa:8443
 # ...
 ```
 
+:::tip 
+You only need to set `management.oauth_provider_url` when you have not configured
+`auth_oauth2.issuer` and/or they have different urls. 
+:::
+
 
 ### Identity-Provider initiated logon {#identity-provider-initiated-logon}
 
@@ -179,12 +184,15 @@ by submitting a form with their OAuth token in the `access_token` form field as 
 
 ```plain
     [ Idp | WebPortal ] ----> 2. /login [access_token: TOKEN]----   [ RabbitMQ Cluster ]
-              /|\                                                        |       /|\
-               |                                                         +--------+
-      1. rabbit_admin from a browser                                   3. validate token
+              /|\                                                               |
+               |                                                                |
+     1. rabbit_admin from a browser <-----3. 302 redirect to RabbitMQ w/cookie--+
+                                  
 ```
 
-If the access token is valid, RabbitMQ redirects the user to the **Overview** page.
+If the access token is valid, RabbitMQ redirects the user to the **Overview** page with 
+a cookie which carries the validated token. When RabbitMQ delivers the **Overview** page, 
+it clears the cookie.  
 
 By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required in `rabbitmq.conf`:
 
@@ -196,10 +204,17 @@ management.oauth_provider_url = http://localhost:8080
 # ...
 ```
 
+:::tip 
+You only need to set `management.oauth_provider_url` when you have not configured
+`auth_oauth2.issuer` and/or they have different urls. 
+:::
+
 **Important**: when the user logs out, or its RabbitMQ session expires, or the token expires, the user is directed to the
 RabbitMQ Management landing page which has a **Click here to login** button.
 The user is never automatically redirected back to the url configured in the `auth_oauth2.issuer`.
 It is only when the user clicks **Click here to login** , the user is redirected to the configured url in `auth_oauth2.issuer`.
+
+This scenario is demonstrated [here](./oauth2-examples-idp-initiated).
 
 ## Using JWT tokens in several protocols to access RabbitMQ {#access-other-protocols}
 

--- a/versioned_docs/version-3.13/oauth2-examples-idp-initiated.md
+++ b/versioned_docs/version-3.13/oauth2-examples-idp-initiated.md
@@ -1,0 +1,114 @@
+---
+title: Use Identity Provider Initiated Logon
+displayed_sidebar: docsSidebar
+---
+<!--
+Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Use Identity Provider Initiated Logon
+
+This guide explains how to set up Identity Provider Initiated Logon
+using UAA as Authorization Server and a sample Node.js web application as a Web Portal.
+
+The web portal acts as an identity provider, allowing users to access the 
+management UI with a single click using an OAuth 2.0 token previously 
+obtained from the authorization server.
+
+```
+      | Idp (e.g.UAA) |
+            /\
+             | 2. get token
+             |
+     | Web app Portal |  ---------> | RabbitMQ | <---+
+           /\                  |         |           | 4. 302 direct to overview page
+            |                  |         |           |    with cookie
+            |                  |         +-----------+
+            |                  |
+    1. user requests             3. POST https://rabbitmq:15671/login  
+          access                    with access_token 
+       to management ui
+
+```
+
+* Access [management UI](./management/) via a browser
+
+## Prerequisites to follow this guide
+
+* Docker
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example.
+
+:::info 
+The commands used to start UAA, RabbitMQ and the web portal automatically 
+generate their x.509 certificates required for https.
+
+:::
+
+## Deploy UAA 
+
+Run the following commands to start UAA:
+
+```bash
+make start-uaa
+```
+ 
+To check if UAA is running, run `docker ps | grep uaa`
+
+## Deploy RabbitMQ 
+
+Run the following commands to start RabbitMQ:
+
+```bash
+export MODE=portal
+OAUTH_PROVIDER=uaa make start-rabbitmq
+```
+
+:::tip
+Ensure RabbitMQ is deployed with the version you expect by searching for 
+ `Running RabbitMQ (<image>:<image_tag>) with` in `docker logs rabbitmq`.
+:::
+
+:::info
+To start one specific version of RabbitMQ run the following command instead:
+```bash 
+MODE=portal OAUTH_PROVIDER=uaa IMAGE=rabbitmq IMAGE_TAG=<YourVersion> make start-rabbitmq
+```
+:::
+
+## Deploy Portal 
+
+Run the following commands to start Portal:
+
+```bash
+make start-portal
+```
+
+## Verify Management UI flows
+
+1. Go to the portal `https://localhost:3000`.
+2. Click on the button `https://localhost:15671 for rabbit_idp_user`.
+3. It redirects to RabbitMQ management UI fully authenticated.
+
+:::info 
+`rabbit_idp_user` is the OAuth Client the portal uses to obtain an access token to
+test this flow. This OAuth Client is declared in UAA.
+:::
+
+:::warning
+When you visit https://localhost:3000 you will get a browser warning 
+due to net::ERR_CERT_AUTHORITY_INVALID. This is because the portal 
+is using a self-signed certificate. You accept it by clicking on `Proceed to localhost (unsafe)`.
+:::

--- a/versioned_docs/version-3.13/oauth2-examples/index.md
+++ b/versioned_docs/version-3.13/oauth2-examples/index.md
@@ -156,6 +156,11 @@ management.oauth_provider_url = https://uaa:8443
 # ...
 ```
 
+:::tip 
+You only need to set `management.oauth_provider_url` when you have not configured
+`auth_oauth2.issuer` and/or they have different urls. 
+:::
+
 ### Identity-Provider initiated logon {#identity-provider-initiated-logon}
 
 Like Service-Provider initiated logon, with Idp-initiated logon users get to the RabbitMQ Management UI with a valid token.
@@ -174,28 +179,37 @@ by submitting a form with their OAuth token in the `access_token` form field as 
 
 ```plain
     [ Idp | WebPortal ] ----> 2. /login [access_token: TOKEN]----   [ RabbitMQ Cluster ]
-              /|\                                                        |       /|\
-               |                                                         +--------+
-      1. rabbit_admin from a browser                                   3. validate token
+              /|\                                                               |
+               |                                                                |
+     1. rabbit_admin from a browser <-----3. 302 redirect to RabbitMQ w/cookie--+
+                                  
 ```
 
-If the access token is valid, RabbitMQ redirects the user to the **Overview** page.
+If the access token is valid, RabbitMQ redirects the user to the **Overview** page with 
+a cookie which carries the validated token. When RabbitMQ delivers the **Overview** page, 
+it clears the cookie.  
 
-By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required
-in `rabbitmq.conf`:
+By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required in `rabbitmq.conf`:
 
 ```ini
 # ...
 management.oauth_enabled = true
-management.oauth_provider_url = http://localhost:8080
 management.oauth_initiated_logon_type = idp_initiated
+management.oauth_provider_url = http://localhost:8080
 # ...
 ```
 
-**Important**: when the user logs out, or its RabbitMQ session expired, or the token expired, the user is directed to the
+:::tip 
+You only need to set `management.oauth_provider_url` when you have not configured
+`auth_oauth2.issuer` and/or they have different urls. 
+:::
+
+**Important**: when the user logs out, or its RabbitMQ session expires, or the token expires, the user is directed to the
 RabbitMQ Management landing page which has a **Click here to login** button.
-The user is never automatically redirected back to the url configured in the `oauth_provider_url`.
-It is only when the user clicks **Click here to login** , the user is redirected to the configured url in `oauth_provider_url`.
+The user is never automatically redirected back to the url configured in the `auth_oauth2.issuer`.
+It is only when the user clicks **Click here to login** , the user is redirected to the configured url in `auth_oauth2.issuer`.
+
+This scenario is demonstrated [here](./oauth2-examples-idp-initiated).
 
 ## Access other protocols using OAuth 2.0 tokens {#access-other-protocols}
 

--- a/versioned_docs/version-4.0/oauth2-examples-idp-initiated.md
+++ b/versioned_docs/version-4.0/oauth2-examples-idp-initiated.md
@@ -1,0 +1,114 @@
+---
+title: Use Identity Provider Initiated Logon
+displayed_sidebar: docsSidebar
+---
+<!--
+Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the under the Apache License,
+Version 2.0 (the "License”); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Use Identity Provider Initiated Logon
+
+This guide explains how to set up Identity Provider Initiated Logon
+using UAA as Authorization Server and a sample Node.js web application as a Web Portal.
+
+The web portal acts as an identity provider, allowing users to access the 
+management UI with a single click using an OAuth 2.0 token previously 
+obtained from the authorization server.
+
+```
+      | Idp (e.g.UAA) |
+            /\
+             | 2. get token
+             |
+     | Web app Portal |  ---------> | RabbitMQ | <---+
+           /\                  |         |           | 4. 302 direct to overview page
+            |                  |         |           |    with cookie
+            |                  |         +-----------+
+            |                  |
+    1. user requests             3. POST https://rabbitmq:15671/login  
+          access                    with access_token 
+       to management ui
+
+```
+
+* Access [management UI](./management/) via a browser
+
+## Prerequisites to follow this guide
+
+* Docker
+* A local clone of a [GitHub repository](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial) that contains all the configuration files and scripts used on this example.
+
+:::info 
+The commands used to start UAA, RabbitMQ and the web portal automatically 
+generate their x.509 certificates required for https.
+
+:::
+
+## Deploy UAA 
+
+Run the following commands to start UAA:
+
+```bash
+make start-uaa
+```
+ 
+To check if UAA is running, run `docker ps | grep uaa`
+
+## Deploy RabbitMQ 
+
+Run the following commands to start RabbitMQ:
+
+```bash
+export MODE=portal
+OAUTH_PROVIDER=uaa make start-rabbitmq
+```
+
+:::tip
+Ensure RabbitMQ is deployed with the version you expect by searching for 
+ `Running RabbitMQ (<image>:<image_tag>) with` in `docker logs rabbitmq`.
+:::
+
+:::info
+To start one specific version of RabbitMQ run the following command instead:
+```bash 
+MODE=portal OAUTH_PROVIDER=uaa IMAGE=rabbitmq IMAGE_TAG=<YourVersion> make start-rabbitmq
+```
+:::
+
+## Deploy Portal 
+
+Run the following commands to start Portal:
+
+```bash
+make start-portal
+```
+
+## Verify Management UI flows
+
+1. Go to the portal `https://localhost:3000`.
+2. Click on the button `https://localhost:15671 for rabbit_idp_user`.
+3. It redirects to RabbitMQ management UI fully authenticated.
+
+:::info 
+`rabbit_idp_user` is the OAuth Client the portal uses to obtain an access token to
+test this flow. This OAuth Client is declared in UAA.
+:::
+
+:::warning
+When you visit https://localhost:3000 you will get a browser warning 
+due to net::ERR_CERT_AUTHORITY_INVALID. This is because the portal 
+is using a self-signed certificate. You accept it by clicking on `Proceed to localhost (unsafe)`.
+:::

--- a/versioned_docs/version-4.0/oauth2-examples/index.md
+++ b/versioned_docs/version-4.0/oauth2-examples/index.md
@@ -156,6 +156,11 @@ management.oauth_provider_url = https://uaa:8443
 # ...
 ```
 
+:::tip 
+You only need to set `management.oauth_provider_url` when you have not configured
+`auth_oauth2.issuer` and/or they have different urls. 
+:::
+
 ### Identity-Provider initiated logon {#identity-provider-initiated-logon}
 
 Like Service-Provider initiated logon, with Idp-initiated logon users get to the RabbitMQ Management UI with a valid token.
@@ -174,28 +179,37 @@ by submitting a form with their OAuth token in the `access_token` form field as 
 
 ```plain
     [ Idp | WebPortal ] ----> 2. /login [access_token: TOKEN]----   [ RabbitMQ Cluster ]
-              /|\                                                        |       /|\
-               |                                                         +--------+
-      1. rabbit_admin from a browser                                   3. validate token
+              /|\                                                               |
+               |                                                                |
+     1. rabbit_admin from a browser <-----3. 302 redirect to RabbitMQ w/cookie--+
+                                  
 ```
 
-If the access token is valid, RabbitMQ redirects the user to the **Overview** page.
+If the access token is valid, RabbitMQ redirects the user to the **Overview** page with 
+a cookie which carries the validated token. When RabbitMQ delivers the **Overview** page, 
+it clears the cookie.  
 
-By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required
-in `rabbitmq.conf`:
+By default, the RabbitMQ Management UI is configured with **service-provider initiated logon**, to configure **Identity-Provider initiated logon**, the following configuration entries are required in `rabbitmq.conf`:
 
 ```ini
 # ...
 management.oauth_enabled = true
-management.oauth_provider_url = http://localhost:8080
 management.oauth_initiated_logon_type = idp_initiated
+management.oauth_provider_url = http://localhost:8080
 # ...
 ```
 
-**Important**: when the user logs out, or its RabbitMQ session expired, or the token expired, the user is directed to the
+:::tip 
+You only need to set `management.oauth_provider_url` when you have not configured
+`auth_oauth2.issuer` and/or they have different urls. 
+:::
+
+**Important**: when the user logs out, or its RabbitMQ session expires, or the token expires, the user is directed to the
 RabbitMQ Management landing page which has a **Click here to login** button.
-The user is never automatically redirected back to the url configured in the `oauth_provider_url`.
-It is only when the user clicks **Click here to login** , the user is redirected to the configured url in `oauth_provider_url`.
+The user is never automatically redirected back to the url configured in the `auth_oauth2.issuer`.
+It is only when the user clicks **Click here to login** , the user is redirected to the configured url in `auth_oauth2.issuer`.
+
+This scenario is demonstrated [here](./oauth2-examples-idp-initiated).
 
 ## Access other protocols using OAuth 2.0 tokens {#access-other-protocols}
 


### PR DESCRIPTION
The proposed changes add a new Oauth2 example that demonstrates the Idp-initiated logon via a web portal. 
I have added it to all versions : next, 4.0 and 3.13. This example was mainly added for a customer expecting the next 3.13.x release.

This PR depends on another [PR](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/pull/45) on the rabbitmq-oauth2-tutorial repo for next version (4.1) and [PR](https://github.com/rabbitmq/rabbitmq-oauth2-tutorial/pull/46) for 4.1 and 3.13 versions. These two PRs are now merged.
