### PR TITLE
Highlighted the use of the ssl_options.password option.

### DIFF
--- a/docs/ssl/index.md
+++ b/docs/ssl/index.md
@@ -281,7 +281,7 @@ Here are the essential configuration settings related to TLS:
   </tr>
   <tr>
     <td><code>ssl_options.password</code></td>
-    <td>Private keys password. It is usually always required. See example paragraph <a href="#automated-certificate-generation-transcript">Using tls-gen's Basic Profile</a></td>
+    <td>Password for private key file</td>
   </tr>
   <tr>
     <td><code>ssl_options.verify</code></td>
@@ -310,8 +310,8 @@ ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert = true
 
-# If you have set a password for the certificate key, remember to set the property
-# ssl_options.password with the value of the password
+# If the private key file is password protected, set this value:
+# ssl_options.password = PASSWORD
 ```
 
 This configuration will also perform [peer certificate chain verification](#peer-verification)

--- a/docs/ssl/index.md
+++ b/docs/ssl/index.md
@@ -280,6 +280,10 @@ Here are the essential configuration settings related to TLS:
     <td>Server private key file path</td>
   </tr>
   <tr>
+    <td><code>ssl_options.password</code></td>
+    <td>Private keys password. It is usually always required. See example paragraph <a href="#automated-certificate-generation-transcript">Using tls-gen's Basic Profile</a></td>
+  </tr>
+  <tr>
     <td><code>ssl_options.verify</code></td>
     <td>Should <a href="#peer-verification">peer verification</a> be enabled?</td>
   </tr>
@@ -305,6 +309,9 @@ ssl_options.certfile   = /path/to/server_certificate.pem
 ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert = true
+
+# If you have set a password for the certificate key, remember to set the property
+# ssl_options.password with the value of the password
 ```
 
 This configuration will also perform [peer certificate chain verification](#peer-verification)

--- a/versioned_docs/version-4.0/ssl/index.md
+++ b/versioned_docs/version-4.0/ssl/index.md
@@ -281,7 +281,7 @@ Here are the essential configuration settings related to TLS:
   </tr>
   <tr>
     <td><code>ssl_options.password</code></td>
-    <td>Private keys password. It is usually always required. See example paragraph <a href="#automated-certificate-generation-transcript">Using tls-gen's Basic Profile</a></td>
+    <td>Password for private key file</td>
   </tr>
   <tr>
     <td><code>ssl_options.verify</code></td>
@@ -310,8 +310,8 @@ ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert = true
 
-# If you have set a password for the certificate key, remember to set the property
-# ssl_options.password with the value of the password
+# If the private key file is password protected, set this value:
+# ssl_options.password = PASSWORD
 ```
 
 This configuration will also perform [peer certificate chain verification](#peer-verification)

--- a/versioned_docs/version-4.0/ssl/index.md
+++ b/versioned_docs/version-4.0/ssl/index.md
@@ -280,6 +280,10 @@ Here are the essential configuration settings related to TLS:
     <td>Server private key file path</td>
   </tr>
   <tr>
+    <td><code>ssl_options.password</code></td>
+    <td>Private keys password. It is usually always required. See example paragraph <a href="#automated-certificate-generation-transcript">Using tls-gen's Basic Profile</a></td>
+  </tr>
+  <tr>
     <td><code>ssl_options.verify</code></td>
     <td>Should <a href="#peer-verification">peer verification</a> be enabled?</td>
   </tr>
@@ -305,6 +309,9 @@ ssl_options.certfile   = /path/to/server_certificate.pem
 ssl_options.keyfile    = /path/to/server_key.pem
 ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert = true
+
+# If you have set a password for the certificate key, remember to set the property
+# ssl_options.password with the value of the password
 ```
 
 This configuration will also perform [peer certificate chain verification](#peer-verification)


### PR DESCRIPTION
Reading the documentation and following the flow in order, you are led into error by not setting the password for the server certificate key right away, which is set following the example in the Using tls-gen's Basic Profile paragraph.

Usually it is rare to have a server certificate key without a password even for test/development environments.