### PR TITLE
Fix typo in exchanges.md 4.0

### DIFF
--- a/versioned_docs/version-4.0/exchanges.md
+++ b/versioned_docs/version-4.0/exchanges.md
@@ -88,7 +88,7 @@ Topic exchanges use pattern matching of the [message's routing key](./publishers
 to the routing (binding) key pattern used at binding time.
 
 For the purpose of routing, the keys are separated into segments by `.`. Some segments are populated by specific values,
-while others are populated by wildcards: `*` for exactly one segment and `#` for zero or more (including multiple) srgments
+while others are populated by wildcards: `*` for exactly one segment and `#` for zero or more (including multiple) segments
 
 For example,
 


### PR DESCRIPTION
I beleave there is still typo in 4.0 version.  Also I have checked version 3.13 and did not find such typo there