### PR TITLE
Fix confusing grammar around long-lived channels

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -115,8 +115,7 @@ ch.close();
 The same example using the .NET client:
 
 ```csharp
-// the .NET client calls channels "models"
-var ch = conn.CreateModel();
+var ch = await conn.CreateChannelAsync();
 
 // do some work
 
@@ -137,8 +136,9 @@ In this case the messages with a pending acknowledgement on the channel will be 
 following the channel closure.
 
 This scenario usually applies to workloads with short lived channels. Using long lived channels and
-designing consumers in a way that they can handle redeliveries potential surprises may be
-associated with this edge case behavior. Note that redelivered messages will be [explicitly marked as such](./consumers#message-properties).
+designing consumers in a way that they can handle redeliveries will mitigate the above behavior.
+Long lived channels are usually associated with better performance, as well. Note that redelivered
+messages will be [explicitly marked as such](./consumers#message-properties).
 
 
 ### Channels and Error Handling {#error-handling}

--- a/versioned_docs/version-3.13/channels/index.md
+++ b/versioned_docs/version-3.13/channels/index.md
@@ -137,8 +137,9 @@ In this case the messages with a pending acknowledgement on the channel will be 
 following the channel closure.
 
 This scenario usually applies to workloads with short lived channels. Using long lived channels and
-designing consumers in a way that they can handle redeliveries potential surprises may be
-associated with this edge case behavior. Note that redelivered messages will be [explicitly marked as such](./consumers#message-properties).
+designing consumers in a way that they can handle redeliveries will mitigate the above behavior.
+Long lived channels are usually associated with better performance, as well. Note that redelivered
+messages will be [explicitly marked as such](./consumers#message-properties).
 
 
 ### Channels and Error Handling {#error-handling}

--- a/versioned_docs/version-4.0/channels/index.md
+++ b/versioned_docs/version-4.0/channels/index.md
@@ -137,8 +137,9 @@ In this case the messages with a pending acknowledgement on the channel will be 
 following the channel closure.
 
 This scenario usually applies to workloads with short lived channels. Using long lived channels and
-designing consumers in a way that they can handle redeliveries potential surprises may be
-associated with this edge case behavior. Note that redelivered messages will be [explicitly marked as such](./consumers#message-properties).
+designing consumers in a way that they can handle redeliveries will mitigate the above behavior.
+Long lived channels are usually associated with better performance, as well. Note that redelivered
+messages will be [explicitly marked as such](./consumers#message-properties).
 
 
 ### Channels and Error Handling {#error-handling}


### PR DESCRIPTION
References #2228