### PR TITLE
Add editUrl to tutorial, kubernetes and client-libraries

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -224,6 +224,9 @@ const config = {
         path: 'tutorials',
         routeBasePath: 'tutorials',
         sidebarPath: './sidebarsTutorials.js',
+        // Remove this to remove the "edit this page" links.
+        editUrl:
+          'https://github.com/rabbitmq/rabbitmq-website/tree/main/',
       },
     ],
     [
@@ -242,6 +245,9 @@ const config = {
         path: 'kubernetes',
         routeBasePath: 'kubernetes',
         sidebarPath: './sidebarsKubernetes.js',
+        // Remove this to remove the "edit this page" links.
+        editUrl:
+          'https://github.com/rabbitmq/rabbitmq-website/tree/main/',
       },
     ],
     [
@@ -251,6 +257,9 @@ const config = {
         path: 'client-libraries',
         routeBasePath: 'client-libraries',
         sidebarPath: './sidebarsClientLibs.js',
+        // Remove this to remove the "edit this page" links.
+        editUrl:
+          'https://github.com/rabbitmq/rabbitmq-website/tree/main/',
       },
     ],
     "./src/plugins/configure-svgo.js",


### PR DESCRIPTION
Fixes #2222 

Apparently it was defined through presets for the docs/blog but not through the plugins section for tutorial, kubernetes and client-libraries.

I have not added it to "release-information" as that seemed to not per-se apply