### PR TITLE
Update using-topology-operator.md to have a real SHA-512 hash in the user example

### DIFF
--- a/kubernetes/operator/using-topology-operator.md
+++ b/kubernetes/operator/using-topology-operator.md
@@ -367,7 +367,7 @@ metadata:
 type: Opaque
 stringData:
   username: my-user
-  passwordHash: tLXSw48rCJO5gc8zu2UJRxR+RfbmNIJMWA6udRQlb6zVWwZg # SHA-512 hash of "foobarbaz"
+  passwordHash: tLXSw/gQg2QVPehN+O5wpRx6o22OKMX2OuO5nb0mrametb29utktQXy6caRkxk9QwNxxwgPC7qZ2psKy48GPI0sC6TQ= # SHA-512 hash of "foobarbaz"
 ---
 apiVersion: rabbitmq.com/v1beta1
 kind: User


### PR DESCRIPTION
The existing docs has a SHA-256 hash of "foobarbaz" in the example, even though the text says SHA-512