### PR TITLE
Fix incorrect QQ CMR documentation

### DIFF
--- a/docs/quorum-queues/index.md
+++ b/docs/quorum-queues/index.md
@@ -61,9 +61,9 @@ Topics covered in this document include:
  * [How are they different](#feature-comparison) from classic queues
  * Primary [use cases](#use-cases) of quorum queues and when not to use them
  * How to [declare a quorum queue](#usage)
- * [Replication](#replication)-related topics: [replica management](#replica-management), [replica leader rebalancing](#replica-rebalancing), optimal number of replicas, etc
+ * [Replication](#replication)-related topics: [member management](#member-management), [leader rebalancing](#leader-rebalancing), optimal number of members, etc
  * What guarantees quorum queues offer in terms of [leader failure handling](#leader-election), [data safety](#data-safety) and [availability](#availability)
- * Continuous [Membership Reconciliation](#replica-reconciliation)
+ * Continuous [Membership Reconciliation](#member-reconciliation)
  * [Performance](#performance) characteristics of quorum queues and [performance tuning](#performance-tuning) relevant to them
  * [Poison message handling](#poison-message-handling) (failure-redelivery loop protection)
  * [Configurable settings](#configuration) of quorum queues
@@ -90,7 +90,7 @@ be defined as an agreement between the majority of nodes (`(N/2)+1` where `N` is
 system participants).
 
 When applied to queue mirroring in RabbitMQ [clusters](./clustering)
-this means that the majority of replicas (including the currently elected queue leader)
+this means that the majority of members (including the currently elected queue leader)
 agree on the state of the queue and its contents.
 
 
@@ -109,7 +109,7 @@ not at all from use of quorum queues.
 
 Publishers should [use publisher confirms](./publishers#data-safety) as this is how clients can interact with
 the quorum queue consensus system. Publisher confirms will [only be issued](./confirms#when-publishes-are-confirmed) once
-a published message has been successfully replicated to a quorum of replicas
+a published message has been successfully replicated to a quorum of members
 and is considered "safe" within the context of the queue.
 
 Consumers should use [manual acknowledgements](./confirms) to ensure messages that aren't
@@ -155,7 +155,7 @@ With some queue operations there are minor differences:
 | Message replication | no | yes |
 | [Exclusivity](./queues) | yes | no |
 | Per message persistence | per message | always |
-| Membership changes | no | [semi-automatic](#replica-reconciliation)   |
+| Membership changes | no | [semi-automatic](#member-reconciliation)   |
 | [Message TTL (Time-To-Live)](./ttl) | yes | yes |
 | [Queue TTL](./ttl#queue-ttl) | yes | partially (lease is not renewed on queue re-declaration) |
 | [Queue length limits](./maxlength) | yes | yes (except `x-overflow`: `reject-publish-dlx`) |
@@ -547,11 +547,11 @@ This is because policy definition or applicable policy can be changed dynamicall
 queue type cannot. It must be specified at the time of declaration.
 
 Declaring a queue with an `x-queue-type` argument set to `quorum` will declare a quorum queue with
-up to three replicas (default [replication factor](#replication-factor)),
+up to three members (default [replication factor](#replication-factor)),
 one per each [cluster node](./clustering).
 
-For example, a cluster of three nodes will have three replicas, one on each node.
-In a cluster of five nodes, three nodes will have one replica each but two nodes won't host any replicas.
+For example, a cluster of three nodes will have three members, one on each node.
+In a cluster of five nodes, three nodes will have one member each but two nodes won't host any members.
 
 After declaration a quorum queue can be bound to any exchange just as any other
 RabbitMQ queue.
@@ -577,29 +577,29 @@ With some queue operations there are minor differences:
 
 ## Replication Factor and Membership Management {#replication}
 
-When a quorum queue is declared, an initial number of replicas for it must be started in the cluster.
-By default the number of replicas to be started is up to three, one per RabbitMQ node in the cluster.
+When a quorum queue is declared, an initial number of members for it must be started in the cluster.
+By default the number of members to be started is up to three, one per RabbitMQ node in the cluster.
 
-Three nodes is the **practical minimum** of replicas for a quorum queue. In RabbitMQ clusters with a larger
-number of nodes, adding more replicas than a [quorum](#what-is-quorum) (majority) will not provide
+Three nodes is the **practical minimum** of members for a quorum queue. In RabbitMQ clusters with a larger
+number of nodes, adding more members than a [quorum](#what-is-quorum) (majority) will not provide
 any improvements in terms of [quorum queue availability](#quorum-requirements) but it will consume
 more cluster resources.
 
-Therefore the **recommended number of replicas** for a quorum queue is the quorum of cluster nodes
+Therefore the **recommended number of members** for a quorum queue is the quorum of cluster nodes
 (but no fewer than three). This assumes a [fully formed](./cluster-formation) cluster of at least three nodes.
 
-### Controlling the Initial Replication Factor {#replication-factor}
+### Controlling the Initial Group Size {#replication-factor}
 
-For example, a cluster of three nodes will have three replicas, one on each node.
-In a cluster of seven nodes, three nodes will have one replica each but four more nodes won't host any replicas
+For example, a cluster of three nodes will have three members, one on each node.
+In a cluster of seven nodes, three nodes will have one member each but four more nodes won't host any members
 of the newly declared queue.
 
-The replication factor (number of replicas a queue has) can be configured for quorum queues.
+The group size (number of members a queue has) can be configured for quorum queues.
 
 The minimum factor value that makes practical sense is three.
 It is highly recommended for the factor to be an odd number.
 This way a clear quorum (majority) of nodes can be computed. For example, there is no "majority" of
-nodes in a two node cluster. This is covered with more examples below in the [Fault Tolerance and Minimum Number of Replicas Online](#quorum-requirements)
+nodes in a two node cluster. This is covered with more examples below in the [Fault Tolerance and Minimum Number of Members Online](#quorum-requirements)
 section.
 
 This may not be desirable for larger clusters or for cluster with an even number of
@@ -609,23 +609,23 @@ group size argument provided should be an integer that is greater than zero and 
 equal to the current RabbitMQ cluster size. The quorum queue will be
 launched to run on a random subset of RabbitMQ nodes present in the cluster at declaration time.
 
-In case a quorum queue is declared before all cluster nodes have joined the cluster, and the initial replica
+In case a quorum queue is declared before all cluster nodes have joined the cluster, and the initial member
 count is greater than the total number of cluster members, the effective value used will
-be equal to the total number of cluster nodes. When more nodes join the cluster, the replica count
-will not be automatically increased but it can be [increased by the operator](#replica-management).
+be equal to the total number of cluster nodes. When more nodes join the cluster, the member count
+will not be automatically increased but it can be [increased by the operator](#member-management).
 
-### Managing Replicas {#replica-management}
+### Managing Members {#member-management}
 
-Replicas of a quorum queue are explicitly managed by the operator. When a new node is added
-to the cluster, it will host no quorum queue replicas unless the operator explicitly adds it
-to a member (replica) list of a quorum queue or a set of quorum queues.
+Members of a quorum queue are explicitly managed by the operator. When a new node is added
+to the cluster, it will host no quorum queue members unless the operator explicitly adds it
+to a member list of a quorum queue or a set of quorum queues.
 
 When a node has to be decommissioned (permanently removed from the cluster), the
 [`forget_cluster_node`](./cli) command will automatically attempt to remove all quorum queue
 members on the decommissioned node. Alternatively the `shrink` command below can be used ahead of
-node removal to move any replicas to a new node.
+node removal to move any members to a new node.
 
-Also see [Continuous Membership Reconciliation](#replica-reconciliation) for a
+Also see [Continuous Membership Reconciliation](#member-reconciliation) for a
 more automated way to grow quorum queues.
 
 Several [CLI commands](./cli) are provided to perform the above operations:
@@ -646,8 +646,9 @@ rabbitmq-queues grow <node> <all | even> [--vhost-pattern <pattern>] [--queue-pa
 rabbitmq-queues shrink <node> [--errors-only]
 ```
 
-To successfully add and remove members a quorum of replicas in the queue must be available
-because membership changes are treated as queue state changes.
+To successfully add and remove members a quorum needs to already be available
+because membership changes are treated as queue state changes and require
+consensus.
 
 Care needs to be taken not to accidentally make a queue unavailable by losing
 the quorum whilst performing maintenance operations that involve membership changes.
@@ -657,20 +658,20 @@ that need a member on the new node and then decommission the node it replaces.
 
 ### Queue Leader Location {#leader-placement}
 
-Every quorum queue has a primary replica. That replica is called
+Every quorum queue has a primary member. That member is referred to as the
 _queue leader_. All queue operations go through the leader
 first and then are replicated to followers. This is necessary to
 guarantee FIFO ordering of messages.
 
-To avoid some nodes in a cluster hosting the majority of queue leader
-replicas and thus handling most of the load, queue leaders should
+To avoid some nodes in a cluster hosting the majority of queue leaders
+and thus handling most of the load, queue leaders should
 be reasonably evenly distributed across cluster nodes.
 
 When a new quorum queue is declared, the set of nodes that will host its
-replicas is randomly picked, but will always include the node the client that
+members is randomly picked, but will always include the node the client that
 declares the queue is connected to.
 
-Which replica becomes the initial leader can controlled using three options:
+Which members is selected as the initial leader can controlled using three options:
 
 1. Setting the `queue-leader-locator` [policy](./parameters#policies) key (recommended)
 2. By defining the `queue_leader_locator` key in [the configuration file](./configure#configuration-files) (recommended)
@@ -679,17 +680,17 @@ Which replica becomes the initial leader can controlled using three options:
 Supported queue leader locator values are
 
  * `client-local`: Pick the node the client that declares the queue is connected to. This is the default value.
- * `balanced`: If there are overall less than 1000 queues (classic queues, quorum queues, and streams),
+ * `balanced`: If there are fewer than 1000 queues overall (classic queues, quorum queues, and streams),
    pick the node hosting the minimum number of quorum queue leaders.
    If there are overall more than 1000 queues, pick a random node.
 
-### Rebalancing Replicas {#replica-rebalancing}
+### Rebalancing Leaders {#leader-rebalancing}
 
 Once declared, the RabbitMQ quorum queue leaders may be unevenly
 distributed across the RabbitMQ cluster.
 To re-balance use the `rabbitmq-queues rebalance` command.
 It is important to know that this does not change the nodes which the quorum queues span.
-To modify the membership instead see [managing replicas](#replica-management).
+To modify the membership instead see [managing members](#member-management).
 
 ```bash
 # rebalances all quorum queues
@@ -710,23 +711,24 @@ or quorum queues in a particular set of virtual hosts:
 rabbitmq-queues rebalance quorum --vhost-pattern "production.*"
 ```
 
-### Continuous Membership Reconciliation (CMR) {#replica-reconciliation}
+### Continuous Membership Reconciliation (CMR) {#member-reconciliation}
 
 :::important
 The continuous membership reconciliation (CMR) feature exists in addition to, and not as a replacement for,
-[explicit replica management](#replica-management). In certain cases where nodes are permanently removed
-from the cluster, explicitly removing quorum queue replicas may still be necessary.
+[explicit member management](#member-management). In certain cases where nodes are permanently removed
+from the cluster, explicitly removing quorum queue members may still be necessary.
 :::
 
-In addition to controlling quorum queue replica membership by using the initial target size and [explicit replica management](#replica-management),
-nodes can be configured to automatically try to grow the quorum queue replica membership
-to a configured target group size by enabling the continuous membership reconciliation feature.
+In addition to controlling quorum queue member membership by using the initial target size
+and [explicit member management](#member-management), nodes can be configured to
+automatically try to grow the quorum queue member membership to a configured
+target group size by enabling the continuous membership reconciliation feature.
 
-When activated, every quorum queue leader replica will periodically check its current membership group size
-(the number of replicas online), and compare it with the target value.
+When activated, every quorum queue leader member will periodically check its current membership group size
+(the number of members that are currently configured), and compare it with the target value.
 
-If a queue is below the target value, RabbitMQ will attempt to grow the queue onto the availible nodes that
-do not currently host replicas of said queue, if any, up to the target value.
+If a queue is below the target value, RabbitMQ will attempt to grow the queue onto the available nodes that
+do not currently host members of said queue, if any, up to the target value.
 
 #### When is Continuous Membership Reconciliation Triggered?
 
@@ -735,7 +737,7 @@ certain events in the cluster, such as an addition of a new node, or permanent n
 or a quorum queue-related policy change.
 
 :::warning
-Note that a node or quorum queue replica failure does not trigger automatic membership reconciliation.
+Note that a node or quorum queue member failure does not trigger automatic membership reconciliation.
 
 If a node is failed in an unrecoverable way and cannot be brought back, it must be explicitly removed from the cluster
 or the operator must opt-in and enable the `quorum_queue.continuous_membership_reconciliation.auto_remove` setting.
@@ -775,7 +777,7 @@ are expected to come back and only a minority (often just one) node is stopped f
     `quorum_queue.continuous_membership_reconciliation.target_group_size`
     </td>
     <td>
-      The target replica count (group size) for queue members.
+      The target member count (group size) for queue members.
 
       <p>
         <ul>
@@ -850,7 +852,7 @@ are expected to come back and only a minority (often just one) node is stopped f
     `target-group-size`
     </td>
     <td>
-      Defines the target replica count (group size) for matching queues. This policy can be set by users and operators.
+      Defines the target member count (group size) for matching queues. This policy can be set by users and operators.
       <p>
         <ul>
           <li>Data type: positive integer</li>
@@ -873,7 +875,7 @@ are expected to come back and only a minority (often just one) node is stopped f
     `x-quorum-target-group-size`
     </td>
     <td>
-      Defines the target replica count (group size) for matching queues. This key can be overridden by operator policies.
+      Defines the target member count (group size) for matching queues. This key can be overridden by operator policies.
       <p>
         <ul>
           <li>Data type: positive integer</li>
@@ -888,8 +890,8 @@ are expected to come back and only a minority (often just one) node is stopped f
 
 A quorum queue relies on a consensus protocol called Raft to ensure data consistency and safety.
 
-Every quorum queue has a primary replica (a *leader* in Raft parlance) and zero or more
-secondary replicas (called *followers*).
+Every quorum queue has a primary member (a *leader* in Raft parlance) and zero or more
+secondary members (called *followers*).
 
 A leader is elected when the cluster is first formed and later if the leader
 becomes unavailable.
@@ -899,16 +901,16 @@ becomes unavailable.
 A quorum queue requires a quorum of the declared nodes to be available
 to function. When a RabbitMQ node hosting a quorum queue's
 *leader* fails or is stopped another node hosting one of that
-quorum queue's *follower* will be elected leader and resume
+quorum queue's *followers* will be elected leader and resume
 operations.
 
 Failed and rejoining followers will re-synchronise ("catch up") with the leader.
-With quorum queues, a temporary replica failure
+With quorum queues, a temporary member failure
 does not require a full re-synchronization from the currently elected leader. Only the delta
-will be transferred if a re-joining replica is behind the leader. This "catching up" process
+will be transferred if a re-joining member is behind the leader. This "catching up" process
 does not affect leader availability.
 
-When a new replica is [added](#replica-management), it will synchronise the entire queue state
+When a new member is [added](#member-management), it will synchronise the entire queue state
 from the leader.
 
 ### Fault Tolerance and Minimum Number of Replicas Online {#quorum-requirements}
@@ -969,17 +971,17 @@ Note that depending on the [partition handling strategy](./partitions)
 used RabbitMQ may restart itself during recovery and reset the node but as long as that
 does not happen, this availability guarantee should hold true.
 
-For example, a queue with three replicas can tolerate one node failure without losing availability.
-A queue with five replicas can tolerate two, and so on.
+For example, a queue with three members can tolerate one node failure without losing availability.
+A queue with five members can tolerate two, and so on.
 
 If a quorum of nodes cannot be recovered (say if 2 out of 3 RabbitMQ nodes are
 permanently lost) the queue is permanently unavailable and
 will need to be force deleted and recreated.
 
-Quorum queue follower replicas that are disconnected from the leader or participating in a leader
+Quorum queue follower members that are disconnected from the leader or participating in a leader
 election will ignore queue operations sent to it until they become aware of a newly elected leader.
 There will be warnings in the log (`received unhandled msg` and similar) about such events.
-As soon as the replica discovers a newly elected leader, it will sync the queue operation
+As soon as the member discovers a newly elected leader, it will sync the queue operation
 log entries it does not have from the leader, including the dropped ones. Quorum queue state
 will therefore remain consistent.
 
@@ -1006,9 +1008,9 @@ to be delivered in a timely fashion.
 Due to the disk I/O-heavy nature of quorum queues, their throughput decreases
 as message sizes increase.
 
-Quorum queue throughput is also affected by the number of replicas.
-The more replicas a quorum queue has, the lower its throughput generally will
-be since more work has to be done to replicate data and achieve consensus.
+Quorum queue throughput is also affected by the number of members.
+The more members a quorum queue has, the lower its throughput generally will
+be since more work has to be done to memberte data and achieve consensus.
 
 
 ## Configurable Settings {#configuration}
@@ -1063,7 +1065,7 @@ The following `advanced.config` example modifies all values listed above:
 
 ```erlang
 [
- %% five replicas by default, only makes sense for nine node clusters
+ %% five members by default, only makes sense for nine node clusters
  {rabbit, [{quorum_cluster_size, 5},
            {quorum_commands_soft_limit, 64}]}
 ].


### PR DESCRIPTION
To clarify it operates on the number of _configured_ members _not_ the number of _online_ members.

Also settle the latest QQ doc version to use the word "member" instead of the ambiguous "replica"