### PR TITLE
fix:  resolved confusion with attaching log file

### DIFF
--- a/tutorials/tutorial-four-python.md
+++ b/tutorials/tutorial-four-python.md
@@ -236,6 +236,14 @@ messages to a file, just open a console and type:
 python receive_logs_direct.py warning error > logs_from_rabbit.log
 ```
 
+> 🚨 Warning:
+> 
+> The above command will not update the log file immediately; rather, it will update each message after closing the execution by interruption.
+> To see the result immediately in the *.log file, use the command `-u`, which stands for `unbuffered`
+> ```bash
+> python -u receive_logs_direct.py warning error > logs_from_rabbit.log
+> ```
+
 If you'd like to see all the log messages on your screen, open a new
 terminal and do:
 

--- a/tutorials/tutorial-three-python.md
+++ b/tutorials/tutorial-three-python.md
@@ -268,6 +268,14 @@ We're done. If you want to save logs to a file, just open a console and type:
 python receive_logs.py > logs_from_rabbit.log
 ```
 
+> 🚨 Warning:
+> 
+> The above command will not update the log file immediately; rather, it will update each message after closing the execution by interruption.
+> To see the result immediately in the *.log file, use the command `-u`, which stands for `unbuffered`
+> ```bash
+> python -u receive_logs.py > logs_from_rabbit.log
+> ```
+
 If you wish to see the logs on your screen, spawn a new terminal and run:
 
 ```bash


### PR DESCRIPTION
Currently if we run the receive_*.py file to dump logs in a log file, it does not reflect the message in the file immediately. Which creates confusion for a new practionner. added the warning and corrent command to show the reflection immediately in the file to resolve confusion.