### PR TITLE
Remove fail_if_no_peer_cert from LDAP documentation

### DIFF
--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -363,11 +363,6 @@ auth_ldap.ssl_options.verify = verify_peer
 auth_ldap.ssl_options.verify = verify_none
 ```
 
-```ini
-# if target LDAP server does not present a certificate, should the connection be aborted?
-auth_ldap.ssl_options.fail_if_no_peer_cert = true
-```
-
 #### Peer Chain Verification Depth
 
 [Certificate chain verification depth](./ssl#peer-verification-depth) can be increased
@@ -397,8 +392,7 @@ The below example uses an [`advanced.config` format](./configure#advanced-config
      {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
                     {certfile,   "/path/to/server_certificate.pem"},
                     {keyfile,    "/path/to/server_key.pem"},
-                    {verify,               verify_peer},
-                    {fail_if_no_peer_cert, true}]},
+                    {verify, verify_peer},
                     {server_name_indication, "ldap.identity.eng.megacorp.local"},
                     {ssl_hostname_verification, wildcard}
    ]}

--- a/versioned_docs/version-3.13/ldap.md
+++ b/versioned_docs/version-3.13/ldap.md
@@ -359,11 +359,6 @@ auth_ldap.ssl_options.verify = verify_peer
 auth_ldap.ssl_options.verify = verify_none
 ```
 
-```ini
-# if target LDAP server does not present a certificate, should the connection be aborted?
-auth_ldap.ssl_options.fail_if_no_peer_cert = true
-```
-
 #### Peer Chain Verification Depth
 
 [Certificate chain verification depth](./ssl#peer-verification-depth) can be increased
@@ -393,8 +388,7 @@ The below example uses an [`advanced.config` format](./configure#advanced-config
      {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
                     {certfile,   "/path/to/server_certificate.pem"},
                     {keyfile,    "/path/to/server_key.pem"},
-                    {verify,               verify_peer},
-                    {fail_if_no_peer_cert, true}]},
+                    {verify, verify_peer},
                     {server_name_indication, "ldap.identity.eng.megacorp.local"},
                     {ssl_hostname_verification, wildcard}
    ]}

--- a/versioned_docs/version-4.0/ldap.md
+++ b/versioned_docs/version-4.0/ldap.md
@@ -363,11 +363,6 @@ auth_ldap.ssl_options.verify = verify_peer
 auth_ldap.ssl_options.verify = verify_none
 ```
 
-```ini
-# if target LDAP server does not present a certificate, should the connection be aborted?
-auth_ldap.ssl_options.fail_if_no_peer_cert = true
-```
-
 #### Peer Chain Verification Depth
 
 [Certificate chain verification depth](./ssl#peer-verification-depth) can be increased
@@ -397,8 +392,7 @@ The below example uses an [`advanced.config` format](./configure#advanced-config
      {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
                     {certfile,   "/path/to/server_certificate.pem"},
                     {keyfile,    "/path/to/server_key.pem"},
-                    {verify,               verify_peer},
-                    {fail_if_no_peer_cert, true}]},
+                    {verify, verify_peer},
                     {server_name_indication, "ldap.identity.eng.megacorp.local"},
                     {ssl_hostname_verification, wildcard}
    ]}

--- a/versioned_docs/version-4.1/ldap.md
+++ b/versioned_docs/version-4.1/ldap.md
@@ -363,11 +363,6 @@ auth_ldap.ssl_options.verify = verify_peer
 auth_ldap.ssl_options.verify = verify_none
 ```
 
-```ini
-# if target LDAP server does not present a certificate, should the connection be aborted?
-auth_ldap.ssl_options.fail_if_no_peer_cert = true
-```
-
 #### Peer Chain Verification Depth
 
 [Certificate chain verification depth](./ssl#peer-verification-depth) can be increased
@@ -397,8 +392,7 @@ The below example uses an [`advanced.config` format](./configure#advanced-config
      {ssl_options, [{cacertfile, "/path/to/ca_certificate.pem"},
                     {certfile,   "/path/to/server_certificate.pem"},
                     {keyfile,    "/path/to/server_key.pem"},
-                    {verify,               verify_peer},
-                    {fail_if_no_peer_cert, true}]},
+                    {verify, verify_peer},
                     {server_name_indication, "ldap.identity.eng.megacorp.local"},
                     {ssl_hostname_verification, wildcard}
    ]}


### PR DESCRIPTION
Removed option `fail_if_no_peer_cert` from LDAP documentation because it is not a valid client option. 
https://www.erlang.org/doc/apps/ssl/ssl.html#t:client_option_cert/0

Removed option from all previous versioned docs and not just 3.13 since option has never worked.

Similar to:
- https://github.com/rabbitmq/rabbitmq-website/pull/1933
- https://github.com/rabbitmq/rabbitmq-website/commit/2ac6c0f96b0a3fa23a37b202c255f29e9bdd9f17
