### PR TITLE
Typo fix  for tutorial-two-python.md

### DIFF
--- a/tutorials/tutorial-two-python.md
+++ b/tutorials/tutorial-two-python.md
@@ -308,7 +308,7 @@ to the n-th consumer.
 
 <T2DiagramPrefetch/>
 
-In order to defeat that we can use the `Channel#basic_qos` channel method with the
+In order to defeat that we can use the `channel.basic_qos` channel method with the
 `prefetch_count=1` setting. This uses the `basic.qos` protocol method to tell RabbitMQ
 not to give more than one message to a worker at a time. Or, in other words, don't dispatch
 a new message to a worker until it has processed and acknowledged the


### PR DESCRIPTION
Just a minor typo fixing for the Python-based tutorial. 