### PR TITLE
Fix undefined method call: replace body() with getBody() in rpc_clien…

### DIFF
--- a/tutorials/tutorial-six-php.md
+++ b/tutorials/tutorial-six-php.md
@@ -296,7 +296,7 @@ class FibonacciRpcClient
     public function onResponse(AMQPMessage $rep)
     {
         if ($rep->get('correlation_id') === $this->corr_id) {
-            $this->response = $rep->body();
+            $this->response = $rep->getBody();
         }
     }
 


### PR DESCRIPTION
…t.php

Replaced the incorrect call to AMQPMessage::body() with the correct method AMQPMessage::getBody() in rpc_client.php.

The 'body()' method does not exist in PhpAmqpLib\Message\AMQPMessage, leading to a fatal error at runtime. According to the PhpAmqpLib documentation, 'getBody()' should be used to retrieve the message content.

This change ensures compatibility with the current version of php-amqplib/php-amqplib and prevents runtime errors during RPC calls.