### PR TITLE
GO stream client 1.5.8 released with a critical fix

### DIFF
--- a/blog/2025-07-04-go-stream-client-1.5.8-critical-fix/index.md
+++ b/blog/2025-07-04-go-stream-client-1.5.8-critical-fix/index.md
@@ -4,11 +4,18 @@ tags: ["Stream","Stream-clients"]
 authors: [gsantomaggio]
 ---
 
-[RabbitMQ Go Stream client 1.5.8](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.5.8)  is a new minor release that includes a [critical fix](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/411). The fix reverts the [pull request 393](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/393) that introduced a dangerous bug: The client skips the chunk delivery when the channel is full. In short: Messages are not being delivered to the user's callback as expected.  
-The bug happens when the consumer is under pressure or when it is slow to process the messages.
+[RabbitMQ Go Stream client 1.5.8](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.5.8)  is a newbug fix release that includes
+a [critical fix](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/411).
+
+The fix reverts the [pull request 393](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/393) that introduced a dangerous bug where the library skipped chunk delivery when the channel's maximum
+capacity was reached. In practical terms, message dispatch to the application would stop.
+
+The bug was triggered when the consumer was experiencing a near peak delivery pressure for some time,
+or when the consumer was consistently slow to process the deliveries.
 
 
 ## Affected versions
 
-The bug affects the following versions: `1.5.5`, `1.5.6` and `1.5.7`. We suggest updating the client as soon as possible
+The bug affects the following versions: `1.5.5`, `1.5.6` and `1.5.7`.
 
+We strongly recommend updating the client to `1.5.8` as soon as possible.

--- a/blog/2025-07-04-go-stream-client-1.5.8-critical-fix/index.md
+++ b/blog/2025-07-04-go-stream-client-1.5.8-critical-fix/index.md
@@ -1,0 +1,13 @@
+---
+title: "Go Stream client 1.5.8 is released with a critical fix"
+tags: ["Stream","Stream-clients"]
+authors: [gsantomaggio]
+---
+
+[RabbitMQ Go Stream client 1.5.8](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.5.8)  is a new minor release that includes a [critical fix](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/411). The fix reverts the [pull request 393](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/393) that introduced a dangerous bug: The client skips the chunk delivery when the channel is full. The bug happens under pressure or when the consumer is slow to process the messages.
+
+
+## Affected versions
+
+The bug affects the following versions: `1.5.5`, `1.5.6` and `1.5.7`. We suggest updating the client as soon as possible
+

--- a/blog/2025-07-04-go-stream-client-1.5.8-critical-fix/index.md
+++ b/blog/2025-07-04-go-stream-client-1.5.8-critical-fix/index.md
@@ -4,7 +4,8 @@ tags: ["Stream","Stream-clients"]
 authors: [gsantomaggio]
 ---
 
-[RabbitMQ Go Stream client 1.5.8](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.5.8)  is a new minor release that includes a [critical fix](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/411). The fix reverts the [pull request 393](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/393) that introduced a dangerous bug: The client skips the chunk delivery when the channel is full. The bug happens under pressure or when the consumer is slow to process the messages.
+[RabbitMQ Go Stream client 1.5.8](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.5.8)  is a new minor release that includes a [critical fix](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/411). The fix reverts the [pull request 393](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/393) that introduced a dangerous bug: The client skips the chunk delivery when the channel is full. In short: Messages are not being delivered to the user's callback as expected.  
+The bug happens when the consumer is under pressure or when it is slow to process the messages.
 
 
 ## Affected versions

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -7,6 +7,14 @@ acogoluegnes:
     linkedin: arnaudcogoluegnes
     bluesky: https://bsky.app/profile/acogoluegnes.bsky.social
 
+gsantomaggio:
+  name: "Gabriele gsantomaggio"
+  url: https://github.com/gsantomaggio
+  image_url: https://github.com/gsantomaggio.png
+  socials:
+    github: gsantomaggio
+    linkedin: santomaggio
+
 alebedeff:
   name: "Alexey Lebedeff"
   url: https://github.com/binarin


### PR DESCRIPTION
Blog post about the Go stream [client 1.5.8](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.5.8) released. 

