### PR TITLE
Fix: Removed duplicate 'Configure Custom Signing Keys' section (#2269)

### DIFF
--- a/docs/oauth2-examples-entra-id/index.md
+++ b/docs/oauth2-examples-entra-id/index.md
@@ -163,24 +163,6 @@ Check out the last section to see how this scope is used to configure RabbitMQ.
 
 ## Configure Custom Signing Keys
 
-There is one last configuration step required. Without this step, the `access_token` returned
-by **Entra ID** won't be useable with RabbitMQ. More specifically, RabbitMQ will not be able to validate its signature because the `access_token` is meant for Microsoft resources
-
-Therefore, create a new scope associated with the application registered above to be used for RabbitMQ management UI.
-To do so:
-
-1. Go to **App registrations**
-2. Click on your application
-3. Go to **Manage** option on the left menu and choose the option **Expose an API**
-4. Click on **Add a scope**
-5. Enter a name, eg. `management-ui`. Enter the same name for **Admin consent display name** and a description and save it
-7. The scope is named `api://{Application (client) ID}/{scope_name}`
-
-This scope will be used further below in this guide.
-
-
-## Configure Custom Signing Keys
-
 Creating a signing key for the application is optional. If a custom key is created, RabbitMQ must be configured accordingly.
 In the following example, replace `{Application(client) ID}` with the actual *Application(client) ID*.
 

--- a/versioned_docs/version-4.1/oauth2-examples-entra-id/index.md
+++ b/versioned_docs/version-4.1/oauth2-examples-entra-id/index.md
@@ -163,24 +163,6 @@ Check out the last section to see how this scope is used to configure RabbitMQ.
 
 ## Configure Custom Signing Keys
 
-There is one last configuration step required. Without this step, the `access_token` returned
-by **Entra ID** won't be useable with RabbitMQ. More specifically, RabbitMQ will not be able to validate its signature because the `access_token` is meant for Microsoft resources
-
-Therefore, create a new scope associated with the application registered above to be used for RabbitMQ management UI.
-To do so:
-
-1. Go to **App registrations**
-2. Click on your application
-3. Go to **Manage** option on the left menu and choose the option **Expose an API**
-4. Click on **Add a scope**
-5. Enter a name, eg. `management-ui`. Enter the same name for **Admin consent display name** and a description and save it
-7. The scope is named `api://{Application (client) ID}/{scope_name}`
-
-This scope will be used further below in this guide.
-
-
-## Configure Custom Signing Keys
-
 Creating a signing key for the application is optional. If a custom key is created, RabbitMQ must be configured accordingly.
 In the following example, replace `{Application(client) ID}` with the actual *Application(client) ID*.
 


### PR DESCRIPTION
This PR removes a duplicate "Configure Custom Signing Keys" section in oauth2-examples-entra-id.md, as reported in #2269. The content was essentially a repeat of "Create a Scope for Management UI Access".