### PR TITLE
Add clients compressions implementations

### DIFF
--- a/docs/stream-core-plugin-comparison.md
+++ b/docs/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams)) |[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
+|Sub-entry batching|  Supported (uncompressed)  | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implementations](#stream-clients-sub-entry-batching-compressions)      |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -50,9 +50,32 @@ Streams store messages using the AMQP 1.0 message format.
 
 * RabbitMQ Stream client libraries are expected to support the AMQP 1.0 message format
 * The broker handles the [conversion](./conversions) between AMQP 1.0 and AMQP 0.9.1 for AMQP 0.9.1 clients
-* AMQP 0.9.1 and stream clients can write to and read from the same stream, but [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is not supported.
+* AMQP 0.9.1,AMQP 1.0 and stream clients can write to and read from the same stream. [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is supported without compression.
 * RabbitMQ Stream supports the following section of the AMQP 1.0 message format:
      * properties
      * application properties
      * application data
      * message annotations
+
+### Stream clients sub-entry batching compressions
+
+The compression happens client-side. The available compressions are:
+- No compression
+- Gzip 
+- Snappy
+- LZ4
+- Zstd
+
+See the table below for the clients implementations: 
+
+|Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
+|-| ------------------------ | ------------- |--- | --- | --- |--- |
+|[Java](https://github.com/rabbitmq/rabbitmq-stream-java-client)| ✅| ✅  |✅     |✅    |✅     | ✅  |
+|[.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client)| ✅| ✅   | ✅   |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    | ✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression) |
+|[Go](https://github.com/rabbitmq/rabbitmq-stream-go-client)| ✅| ✅   |✅    |✅   |✅    | ✅ |
+|[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
+|[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
+|[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
+
+
+Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/docs/stream-core-plugin-comparison.md
+++ b/docs/stream-core-plugin-comparison.md
@@ -19,17 +19,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Stream Core vs Stream Plugin
+# RabbitMQ Core vs Stream Plugin
 
 ## Overview {#overview}
 
-This section covers the differences between [stream core](./streams) and the [stream plugin](./stream).
+This section covers the differences between [RabbitMQ core](./streams) and the [stream plugin](./stream).
 Stream core designates stream features in the broker with only default plugins activated and through protocols like AMQP 0.9.1, AMQP 1.0, MQTT, and STOMP.
 
 
 ### Feature Matrix
 
-|Feature | Stream Core              | Stream Plugin    |
+|Feature | RabbitMQ Core              | Stream Plugin    |
 |-| ------------------------ | -------------    |
 |Activation| Built-in                 | [Must be activated](./stream#enabling-plugin)  |
 |Protocol| AMQP 0.9.1 and AMQP 1.0   | [RabbitMQ Stream](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)  |

--- a/docs/stream-core-plugin-comparison.md
+++ b/docs/stream-core-plugin-comparison.md
@@ -76,6 +76,3 @@ See the table below for the clients implementations:
 |[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
 |[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
 |[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
-
-
-Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/docs/stream-core-plugin-comparison.md
+++ b/docs/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams)) |[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Supported (uncompressed)  | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implementations](#stream-clients-sub-entry-batching-compressions)      |
+|Sub-entry batching|  Supported (uncompressed)  | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients Compression Options](#stream-clients-sub-entry-batching-compression-options)      |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -57,16 +57,17 @@ Streams store messages using the AMQP 1.0 message format.
      * application data
      * message annotations
 
-### Stream clients sub-entry batching compressions
+### Stream Clients Sub-entry Batching Compression Options
 
-The compression happens client-side. The available compressions are:
+The compression happens client-side. The available compression implementations:
 - No compression
 - Gzip 
 - Snappy
 - LZ4
 - Zstd
 
-See the table below for the clients implementations: 
+The table below explains what options are supported by a number of RabbitMQ Stream Protocol clients: 
+ 
 
 |Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
 |-| ------------------------ | ------------- |--- | --- | --- |--- |

--- a/docs/stream.md
+++ b/docs/stream.md
@@ -30,7 +30,7 @@ This feature is available in all [currently maintained release series](/release-
 Streams can be used as a regular AMQP 0.9.1 queue or through a
 [dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
 plugin and associated client(s).
-Please see the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+Please see the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 This page covers the Stream plugin, which allows to interact with streams using this
 [new binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc).

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -50,7 +50,7 @@ To answer these questions, streams were not introduced to replace queues but to 
 
 The following information details streams usage, and the administration and maintenance operations for streams.
 
-You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 ### Use Cases for Using Streams {#use-cases}
 

--- a/versioned_docs/version-3.13/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-3.13/stream-core-plugin-comparison.md
@@ -19,17 +19,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Stream Core vs Stream Plugin
+# RabbitMQ Core vs Stream Plugin
 
 ## Overview {#overview}
 
-This section covers the differences between [stream core](./streams) and the [stream plugin](./stream).
+This section covers the differences between [RabbitMQ core](./streams) and the [stream plugin](./stream).
 Stream core designates stream features in the broker with only default plugins activated and through protocols like AMQP 0.9.1, MQTT, and STOMP.
 
 
 ### Feature Matrix
 
-|Feature | Stream Core              | Stream Plugin    |
+|Feature | RabbitMQ Core              | Stream Plugin    |
 |-| ------------------------ | -------------    |
 |Activation| Built-in                 | [Must be activated](./stream#enabling-plugin)  |
 |Protocol| AMQP 0.9.1               | [RabbitMQ Stream](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)  |

--- a/versioned_docs/version-3.13/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-3.13/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)) |[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)) . [Clients implementations](#stream-clients-sub-entry-batching-compressions)     |
+|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients Compression Options](#stream-clients-sub-entry-batching-compression-options)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -57,16 +57,16 @@ Streams store messages using the AMQP 1.0 message format.
      * application data
      * message annotations
 
-### Stream clients sub-entry batching compressions
+### Stream Clients Sub-entry Batching Compression Options
 
-The compression happens client-side. The available compressions are:
+The compression happens client-side. The available compression implementations:
 - No compression
 - Gzip 
 - Snappy
 - LZ4
 - Zstd
 
-See the table below for the clients implementations: 
+The table below explains what options are supported by a number of RabbitMQ Stream Protocol clients: 
 
 |Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
 |-| ------------------------ | ------------- |--- | --- | --- |--- |

--- a/versioned_docs/version-3.13/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-3.13/stream-core-plugin-comparison.md
@@ -76,6 +76,3 @@ See the table below for the clients implementations:
 |[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
 |[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
 |[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
-
-
-Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/versioned_docs/version-3.13/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-3.13/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)) |[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
+|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)) . [Clients implementations](#stream-clients-sub-entry-batching-compressions)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -49,10 +49,33 @@ Stream core designates stream features in the broker with only default plugins a
 Streams store messages using the AMQP 1.0 message format.
 
 * RabbitMQ Stream client libraries are expected to support the AMQP 1.0 message format
-* The broker handles the conversion between AMQP 1.0 and AMQP 0.9.1 for AMQP 0.9.1 clients
-* AMQP 0.9.1 and stream clients can write to and read from the same stream, but [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is not supported.
+* The broker handles the [conversion](./conversions) between AMQP 1.0 and AMQP 0.9.1 for AMQP 0.9.1 clients
+* AMQP 0.9.1,AMQP 1.0 and stream clients can write to and read from the same stream. [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is supported without compression.
 * RabbitMQ Stream supports the following section of the AMQP 1.0 message format:
      * properties
      * application properties
      * application data
      * message annotations
+
+### Stream clients sub-entry batching compressions
+
+The compression happens client-side. The available compressions are:
+- No compression
+- Gzip 
+- Snappy
+- LZ4
+- Zstd
+
+See the table below for the clients implementations: 
+
+|Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
+|-| ------------------------ | ------------- |--- | --- | --- |--- |
+|[Java](https://github.com/rabbitmq/rabbitmq-stream-java-client)| ✅| ✅  |✅     |✅    |✅     | ✅  |
+|[.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client)| ✅| ✅   | ✅   |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    | ✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression) |
+|[Go](https://github.com/rabbitmq/rabbitmq-stream-go-client)| ✅| ✅   |✅    |✅   |✅    | ✅ |
+|[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
+|[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
+|[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
+
+
+Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/versioned_docs/version-3.13/stream.md
+++ b/versioned_docs/version-3.13/stream.md
@@ -30,7 +30,7 @@ This feature is available in all [currently maintained release series](/release-
 Streams can be used as a regular AMQP 0.9.1 queue or through a
 [dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
 plugin and associated client(s).
-Please see the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+Please see the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 This page covers the Stream plugin, which allows to interact with streams using this
 [new binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc).

--- a/versioned_docs/version-3.13/streams.md
+++ b/versioned_docs/version-3.13/streams.md
@@ -50,7 +50,7 @@ To answer these questions, streams were not introduced to replace queues but to 
 
 The following information details streams usage, and the administration and maintenance operations for streams.
 
-You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 ### Use Cases for Using Streams {#use-cases}
 

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -68,14 +68,14 @@ The compression happens client-side. The available compressions are:
 
 See the table below for the clients implementations: 
 
-|Client | Implemented        | No Compression|Gzip| Snappy | LZ4 | Zstd |
+|Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
 |-| ------------------------ | ------------- |--- | --- | --- |--- |
-|[Java](https://github.com/rabbitmq/rabbitmq-stream-java-client)| yes| yes built-in   |yes built-in    |yes built-in   |yes built-in    | yes built-in |
-|[.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client)| yes| yes built-in   | yes built-in   |[no built-in](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    |[no built-in](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    | [no built-in](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression) |
-|[Go](https://github.com/rabbitmq/rabbitmq-stream-go-client)| yes| yes built-in   |yes built-in    |yes built-in   |yes built-in    | yes built-in |
-|[Python](https://github.com/rabbitmq-community/rstream)| yes| yes built-in   | yes built-in   |[no built-in](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |[no built-in](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | [no built-in](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
-|[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| yes| yes built-in   |yes built-in    |no   |no    | no |
-|[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| no| no   |no    |no    | no |
+|[Java](https://github.com/rabbitmq/rabbitmq-stream-java-client)| ✅| ✅  |✅     |✅    |✅     | ✅  |
+|[.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client)| ✅| ✅   | ✅   |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    | ✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression) |
+|[Go](https://github.com/rabbitmq/rabbitmq-stream-go-client)| ✅| ✅   |✅    |✅   |✅    | ✅ |
+|[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
+|[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
+|[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
 
 
 Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams))|[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
+|Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implentations](#clients-sub-entry-batching-compressions)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -56,3 +56,27 @@ Streams store messages using the AMQP 1.0 message format.
      * application properties
      * application data
      * message annotations
+
+### Clients sub-entry batching compressions
+
+The compression happens client-side. The available compressions are:
+- No compression
+- Gzip 
+- Snappy
+- LZ4
+- Zstd
+
+See the table below for the clients implementations: 
+
+|Client | Implemented        | No Compression|Gzip| Snappy | LZ4 | Zstd |
+|-| ------------------------ | ------------- |--- | --- | --- |--- |
+|[Java](https://github.com/rabbitmq/rabbitmq-stream-java-client)| yes| yes built-in   |yes built-in    |yes built-in   |yes built-in    | yes built-in |
+|[.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client)| yes| yes built-in   | yes built-in   |[no built-in](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    |[no built-in](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    | [no built-in](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression) |
+|[Go](https://github.com/rabbitmq/rabbitmq-stream-go-client)| yes| yes built-in   |yes built-in    |yes built-in   |yes built-in    | yes built-in |
+|[Python](https://github.com/rabbitmq-community/rstream)| yes| yes built-in   | yes built-in   |[no built-in](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |[no built-in](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | [no built-in](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
+|[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| yes| yes built-in   |yes built-in    |no   |no    | no |
+|[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| no| no   |no    |no    | no |
+
+
+Gzip is the common algorithm for all clients that implement sub-entry batching.
+

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams))|[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implentations](#clients-sub-entry-batching-compressions)     |
+|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implementations](#stream-clients-sub-entry-batching-compressions)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -50,14 +50,14 @@ Streams store messages using the AMQP 1.0 message format.
 
 * RabbitMQ Stream client libraries are expected to support the AMQP 1.0 message format
 * The broker handles the [conversion](./conversions) between AMQP 1.0 and AMQP 0.9.1 for AMQP 0.9.1 clients
-* AMQP 0.9.1 and stream clients can write to and read from the same stream, but [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is not supported.
+* AMQP 0.9.1,AMQP 1.0 and stream clients can write to and read from the same stream. [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is supported without compression.
 * RabbitMQ Stream supports the following section of the AMQP 1.0 message format:
      * properties
      * application properties
      * application data
      * message annotations
 
-### Clients sub-entry batching compressions
+### Stream clients sub-entry batching compressions
 
 The compression happens client-side. The available compressions are:
 - No compression

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams))|[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implementations](#stream-clients-sub-entry-batching-compressions)     |
+|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients Compression Options](#stream-clients-sub-entry-batching-compression-options)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -57,16 +57,17 @@ Streams store messages using the AMQP 1.0 message format.
      * application data
      * message annotations
 
-### Stream clients sub-entry batching compressions
+### Stream Clients Sub-entry Batching Compression Options
 
-The compression happens client-side. The available compressions are:
+The compression happens client-side. The available compression implementations:
 - No compression
 - Gzip 
 - Snappy
 - LZ4
 - Zstd
 
-See the table below for the clients implementations: 
+The table below explains what options are supported by a number of RabbitMQ Stream Protocol clients: 
+
 
 |Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
 |-| ------------------------ | ------------- |--- | --- | --- |--- |

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -19,17 +19,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Stream Core vs Stream Plugin
+# RabbitMQ Core vs Stream Plugin
 
 ## Overview {#overview}
 
-This section covers the differences between [stream core](./streams) and the [stream plugin](./stream).
+This section covers the differences between [RabbitMQ core](./streams) and the [stream plugin](./stream).
 Stream core designates stream features in the broker with only default plugins activated and through protocols like AMQP 0.9.1, AMQP 1.0, MQTT, and STOMP.
 
 
 ### Feature Matrix
 
-|Feature | Stream Core              | Stream Plugin    |
+|Feature | RabbitMQ Core              | Stream Plugin    |
 |-| ------------------------ | -------------    |
 |Activation| Built-in                 | [Must be activated](./stream#enabling-plugin)  |
 |Protocol| AMQP 0.9.1 and AMQP 1.0    | [RabbitMQ Stream](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)  |

--- a/versioned_docs/version-4.0/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.0/stream-core-plugin-comparison.md
@@ -76,7 +76,3 @@ See the table below for the clients implementations:
 |[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
 |[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
 |[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
-
-
-Gzip is the common algorithm for all clients that implement sub-entry batching.
-

--- a/versioned_docs/version-4.0/stream.md
+++ b/versioned_docs/version-4.0/stream.md
@@ -30,7 +30,7 @@ This feature is available in all [currently maintained release series](/release-
 Streams can be used as a regular AMQP 0.9.1 queue or through a
 [dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
 plugin and associated client(s).
-Please see the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+Please see the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 This page covers the Stream plugin, which allows to interact with streams using this
 [new binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc).

--- a/versioned_docs/version-4.0/streams.md
+++ b/versioned_docs/version-4.0/streams.md
@@ -50,7 +50,7 @@ To answer these questions, streams were not introduced to replace queues but to 
 
 The following information details streams usage, and the administration and maintenance operations for streams.
 
-You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 ### Use Cases for Using Streams {#use-cases}
 

--- a/versioned_docs/version-4.1/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.1/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams)) |[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implementations](#stream-clients-sub-entry-batching-compressions)     |
+|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients Compression Options](#stream-clients-sub-entry-batching-compression-options)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -57,16 +57,17 @@ Streams store messages using the AMQP 1.0 message format.
      * application data
      * message annotations
 
-### Stream clients sub-entry batching compressions
+### Stream Clients Sub-entry Batching Compression Options
 
-The compression happens client-side. The available compressions are:
+The compression happens client-side. The available compression implementations:
 - No compression
 - Gzip 
 - Snappy
 - LZ4
 - Zstd
 
-See the table below for the clients implementations: 
+The table below explains what options are supported by a number of RabbitMQ Stream Protocol clients: 
+ 
 
 |Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
 |-| ------------------------ | ------------- |--- | --- | --- |--- |

--- a/versioned_docs/version-4.1/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.1/stream-core-plugin-comparison.md
@@ -76,6 +76,3 @@ See the table below for the clients implementations:
 |[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
 |[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
 |[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
-
-
-Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/versioned_docs/version-4.1/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.1/stream-core-plugin-comparison.md
@@ -19,17 +19,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Stream Core vs Stream Plugin
+# RabbitMQ core vs Stream Plugin
 
 ## Overview {#overview}
 
-This section covers the differences between [stream core](./streams) and the [stream plugin](./stream).
+This section covers the differences between [RabbitMQ core](./streams) and the [stream plugin](./stream).
 Stream core designates stream features in the broker with only default plugins activated and through protocols like AMQP 0.9.1, AMQP 1.0, MQTT, and STOMP.
 
 
 ### Feature Matrix
 
-|Feature | Stream Core              | Stream Plugin    |
+|Feature | RabbitMQ Core              | Stream Plugin    |
 |-| ------------------------ | -------------    |
 |Activation| Built-in                 | [Must be activated](./stream#enabling-plugin)  |
 |Protocol| AMQP 0.9.1 and AMQP 1.0   | [RabbitMQ Stream](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)  |

--- a/versioned_docs/version-4.1/stream-core-plugin-comparison.md
+++ b/versioned_docs/version-4.1/stream-core-plugin-comparison.md
@@ -36,7 +36,7 @@ Stream core designates stream features in the broker with only default plugins a
 |Clients| AMQP 0.9.1 clients ([documentation](./streams#usage)). AMQP 1.0 clients ([documentation](/client-libraries/amqp-client-libraries#support-for-streams)) |[RabbitMQ stream clients](./stream#overview)   |
 |Port| 5672                     | 5552             |
 |Format| Server-side AMQP 1.0 message format encoding and decoding  | Client-side AMQP 1.0 message format encoding and decoding |
-|Sub-entry batching|  Not supported    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression))      |
+|Sub-entry batching|  Supported (uncompressed)    | Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression)). [Clients implementations](#stream-clients-sub-entry-batching-compressions)     |
 |Offset tracking| Use external store      |  Built-in server-side support ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#consumer-offset-tracking)) or external store      |
 |Publishing deduplication|Not supported       |  Supported ([Java example](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#outbound-message-deduplication))        |
 |[Super stream](/blog/2022/07/13/rabbitmq-3-11-feature-preview-super-streams) |Not supported       |  Supported         |
@@ -50,9 +50,32 @@ Streams store messages using the AMQP 1.0 message format.
 
 * RabbitMQ Stream client libraries are expected to support the AMQP 1.0 message format
 * The broker handles the [conversion](./conversions) between AMQP 1.0 and AMQP 0.9.1 for AMQP 0.9.1 clients
-* AMQP 0.9.1 and stream clients can write to and read from the same stream, but [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is not supported.
+* AMQP 0.9.1,AMQP 1.0 and stream clients can write to and read from the same stream. [Sub-Entry Batching](https://rabbitmq.github.io/rabbitmq-stream-java-client/snapshot/htmlsingle/#sub-entry-batching-and-compression) is supported without compression.
 * RabbitMQ Stream supports the following section of the AMQP 1.0 message format:
      * properties
      * application properties
      * application data
      * message annotations
+
+### Stream clients sub-entry batching compressions
+
+The compression happens client-side. The available compressions are:
+- No compression
+- Gzip 
+- Snappy
+- LZ4
+- Zstd
+
+See the table below for the clients implementations: 
+
+|Client | Supported        | No Compression|Gzip| Snappy | LZ4 | Zstd |
+|-| ------------------------ | ------------- |--- | --- | --- |--- |
+|[Java](https://github.com/rabbitmq/rabbitmq-stream-java-client)| ✅| ✅  |✅     |✅    |✅     | ✅  |
+|[.NET](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client)| ✅| ✅   | ✅   |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    |✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression)    | ✅ [via interface](https://rabbitmq.github.io/rabbitmq-stream-dotnet-client/stable/htmlsingle/index.html#sub-entry-batching-and-compression) |
+|[Go](https://github.com/rabbitmq/rabbitmq-stream-go-client)| ✅| ✅   |✅    |✅   |✅    | ✅ |
+|[Python](https://github.com/rabbitmq-community/rstream)| ✅| ✅   | ✅   |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    |✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression)    | ✅ [via interface](https://github.com/rabbitmq-community/rstream?tab=readme-ov-file#sub-entry-batching-and-compression) |
+|[NodeJS](https://github.com/coders51/rabbitmq-stream-js-client)| ✅| ✅   |✅    | ❌   |❌    | ❌ |
+|[Rust](https://github.com/rabbitmq/rabbitmq-stream-rust-client)| ❌| ❌   |❌    |❌    | ❌ |
+
+
+Gzip is the common algorithm for all clients that implement sub-entry batching.

--- a/versioned_docs/version-4.1/stream.md
+++ b/versioned_docs/version-4.1/stream.md
@@ -30,7 +30,7 @@ This feature is available in all [currently maintained release series](/release-
 Streams can be used as a regular AMQP 0.9.1 queue or through a
 [dedicated binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc)
 plugin and associated client(s).
-Please see the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+Please see the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 This page covers the Stream plugin, which allows to interact with streams using this
 [new binary protocol](https://github.com/rabbitmq/rabbitmq-server/blob/v3.12.x/deps/rabbitmq_stream/docs/PROTOCOL.adoc).

--- a/versioned_docs/version-4.1/streams.md
+++ b/versioned_docs/version-4.1/streams.md
@@ -50,7 +50,7 @@ To answer these questions, streams were not introduced to replace queues but to 
 
 The following information details streams usage, and the administration and maintenance operations for streams.
 
-You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [stream core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
+You should also review the [stream plugin](./stream) information to learn more about the usage of streams with the binary RabbitMQ Stream protocol and the [RabbitMQ core and stream plugin comparison page](./stream-core-plugin-comparison) for the feature matrix.
 
 ### Use Cases for Using Streams {#use-cases}
 


### PR DESCRIPTION
Documentation for clients' sub-entry batching compressions.

The compression happens client-side. Here we document the clients' implementations.

@michaelklishin @acogoluegnes if it is ok with you, I will copy it for the other versions. ( If necessary )