### PR TITLE
Add JavaScript client library examples

### DIFF
--- a/client-libraries/amqp-client-libraries.md
+++ b/client-libraries/amqp-client-libraries.md
@@ -460,13 +460,13 @@ const publishResult = await publisher.publish(message);
 
 switch (publishResult.outcome) {
   case rabbit.OutcomeState.ACCEPTED:
-    console.log("Message Accepted");
+    // the broker accepted (confirmed) the message
     break;
   case rabbit.OutcomeState.RELEASED:
-    console.log("Message Released");
+    // the broker could not route the message anywhere
     break;
   case rabbit.OutcomeState.REJECTED:
-    console.log("Message Rejected");
+    // at least one queue rejected the message
     break;
   default:
     break;


### PR DESCRIPTION
As the JavaScript AMQP client starts to become usable and useful, it can be published on the website, together with some documentation.