### PR TITLE
Update home page content

### DIFF
--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -54,7 +54,7 @@ export default function Support() {
           </div>
         </div>
 
-        <div id="tanzu-rabbitmq" className={styles.license}>
+        <div id="tanzu-rabbitmq" className={styles.tanzu_license}>
           <div className={styles.container}>
             <Heading as="h1">VMware Tanzu RabbitMQ</Heading>
             <Heading as="h4">Commercial RabbitMQ includes both 24/7 support and features not available in the open source version.</Heading>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,6 +29,39 @@ export default function Home() {
           </div>
         </div>
 
+        <div className={styles.license}>
+          <div className={styles.container}>
+            <p>RabbitMQ is a Free and Open Source Software. In addition, Broadcom offers an enterprise grade commercial offering with 24/7 expert support.</p>
+            <div className={styles.flex_columns}>
+              <section>
+                <OSIKeyholeIcon/>
+                <Heading as="h2">Free and Open Source</Heading>
+                <p>RabbitMQ is licensed under the <Link to="https://www.tldrlegal.com/license/mozilla-public-license-2-0-mpl-2">Mozilla Public License 2.0</Link>,
+                   while most client libraries are dual-licensed under the Apache Software License 2.0 and the Mozilla Public License 2.0. You have the freedom to use and
+                  modify RabbitMQ in a very broad range of contexts.</p>
+                <p>Of course, contributions are more than welcome! Whether it
+                  is through detailed bug reports, patches, helping someone,
+                  documentation or any form of advocacy. In fact contributing
+                  is the best way to support the project!
+                  Take a look at our <Link to="/github">Contributors page</Link>.</p>
+              </section>
+              <section>
+                <CommercialSupportIcon/>
+                <Heading as="h2">Commercial offering</Heading>
+                <p>
+                  If you’re running mission-critical apps, <Link to="https://www.vmware.com/products/app-platform/tanzu-rabbitmq">Tanzu RabbitMQ’s enterprise-grade version</Link> is essential.
+                  It ensures your apps stay reliable and secure with <Link to="/contact#tanzu-rabbitmq">24/7 expert support from the engineers who make the product</Link>,
+                  longer lifecycle, disaster recovery, cloud cost savings, and industry compliance.
+                </p>
+                <div>
+                  <Link className="button button--primary" to="mailto:contact-tanzu-data.pdl@broadcom.com">Contact Us</Link>&nbsp;
+                  <Link className="button button--primary" to="/contact#consulting">Find a Partner</Link>
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+
         <div className={styles.why}>
           <div className={styles.container}>
             <Heading as="h1">Why RabbitMQ?</Heading>
@@ -289,52 +322,6 @@ flowchart TD
                 </div>
               </TabItem>
             </Tabs>
-          </div>
-        </div>
-
-        <div className={styles.license}>
-          <div className={styles.container}>
-            <Heading as="h1">What about the license?</Heading>
-            <p>Since its original release in 2007, RabbitMQ is Free and Open
-              Source Software. In addition, Broadcom offer a range of
-              commercial offerings.</p>
-            <div className={styles.flex_columns}>
-              <section>
-                <OSIKeyholeIcon/>
-                <Heading as="h2">Free and Open Source</Heading>
-                <p>RabbitMQ is licensed under the <Link to="https://www.tldrlegal.com/license/mozilla-public-license-2-0-mpl-2">Mozilla Public License 2.0</Link>,
-                   while most client libraries are dual-licensed under the Apache Software License 2.0 and the Mozilla Public License 2.0. You have the freedom to use and
-                  modify RabbitMQ in a very broad range of contexts.</p>
-                <p>Of course, contributions are more than welcome! Whether it
-                  is through detailed bug reports, patches, helping someone,
-                  documentation or any form of advocacy. In fact contributing
-                  is the best way to support the project!
-                  Take a look at our <Link to="/github">Contributors page</Link>.</p>
-              </section>
-              <section>
-                <CommercialSupportIcon/>
-                <Heading as="h2">Commercial offerings</Heading>
-                <p>Broadcom offers <Link
-                  to="https://tanzu.vmware.com/rabbitmq/oss">enterprise-grade
-                  24/7 support</Link> where you have access to the engineers
-                  making the product.</p>
-                <p>In addition, a range of commercial offerings for RabbitMQ
-                  are available. These commercial offerings include all of the
-                  features of RabbitMQ, with some additional management and
-                  advanced features like <Link
-                  to="https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/standby-replication.html">warm
-                  standby replication</Link>, <Link
-                  to="https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/clustering-compression-rabbitmq.html">intra-cluster
-                  data compression</Link> and <Link
-                  to="/blog/2025/04/16/amqp-websocket">AMQP 1.0
-                  over WebSocket</Link>.
-                  </p>
-                <p>For a list of the commercial offerings, take a look at
-                  the <Link to="https://tanzu.vmware.com/rabbitmq">Ways to run
-                  Tanzu RabbitMQ and Free and Open Source RabbitMQ
-                  distributions table</Link>.</p>
-              </section>
-            </div>
           </div>
         </div>
 

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -119,7 +119,7 @@ html[data-theme='dark'] .heroCta .release_notes_link {
   }
 }
 
-.why, .license, .usecases_heading, .usecases, .testimonies, .supporttypes, .partners, .featured_partner {
+.why, .license, .tanzu_license, .usecases_heading, .usecases, .testimonies, .supporttypes, .partners, .featured_partner {
   padding: 2em 0px;
   scroll-margin-top: 60px;
 }
@@ -146,9 +146,8 @@ html[data-theme='dark'] .heroCta .release_notes_link {
   font-style: italic;
 }
 
-.usecases_heading, .license, .partner {
+.tanzu_license, .partner, .why, .usecases {
   background-color: var(--ifm-color-primary-contrast-background);
-
 }
 
 .usecases .flex_columns {


### PR DESCRIPTION
1. Move “What about the license?” section to the top of the page. Delete the “What about the license?” title to save space
2. Alternate background colors from white to `primary-contrast-background` separating each section. Start with white for the section we moved to the top. After making this change, the license section on the home page should use a white background, while the license section on the support page should not. Therefore, rename the `license` class to `⁠tanzu_license` on the support page
3. Update the description under the deleted title
4. Change title from “Commercial offerings” (plural) to “Commercial offering” (singular), update content under the title
