### PR TITLE
Adding Kourier, a Kotlin client

### DIFF
--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -200,6 +200,9 @@ Miscellaneous projects:
 
  * [March Hare, a JRuby RabbitMQ client](http://rubymarchhare.info)
 
+### Kotlin
+
+ * [Kourier, a Kotlin AMQP client](https://kourier.dev)
 
 ## C and C++ {#c-dev}
 

--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -202,7 +202,7 @@ Miscellaneous projects:
 
 ### Kotlin
 
- * [Kourier, a Kotlin AMQP client](https://kourier.dev)
+ * [Kourier, a Kotlin AMQP 0.9.1 client](https://kourier.dev)
 
 ## C and C++ {#c-dev}
 


### PR DESCRIPTION
Hello!

I just added a Kotlin client under the Other JVM languages. Note that this client is compatible with Kotlin Multiplatform, so it also runs outside of JVM (maybe we should make a dedicated section for Kotlin?)