### PR TITLE
Mention encrypted listeners in protocol-listener API reference

### DIFF
--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -1679,7 +1679,9 @@ Responds a 200 OK if if all given protocols have active listeners,
 otherwise responds with a 503 Service Unavailable. Multiple protocols
 may be provided by separating the names with commas.
 
-Valid protocol names are: `amqp091`, `amqp10`, `mqtt`, `stomp`, `web-mqtt`, `web-stomp`.
+Valid protocol names are: `amqp`, `mqtt`, `stomp`, `web-mqtt`, `web-stomp`.
+To check for the encrypted listeners, add an `s` to the protocol name, for
+example `amqps` or `mqtts`.
 
 ### GET /api/health/checks/virtual-hosts
 

--- a/versioned_docs/version-4.0/http-api-reference.md
+++ b/versioned_docs/version-4.0/http-api-reference.md
@@ -1678,7 +1678,9 @@ Relevant documentation guides: <a href="./networking">Networking</a>.
 Responds a 200 OK if there is an active listener for the given protocol,
 otherwise responds with a 503 Service Unavailable.
 
-Valid protocol names are: `amqp091`, `amqp10`, `mqtt`, `stomp`, `web-mqtt`, `web-stomp`.
+Valid protocol names are: `amqp`, `mqtt`, `stomp`, `web-mqtt`, `web-stomp`.
+To check for the encrypted listeners, add an `s` to the protocol name, for
+example `amqps` or `mqtts`.
 
 ### GET /api/health/checks/virtual-hosts
 

--- a/versioned_docs/version-4.1/http-api-reference.md
+++ b/versioned_docs/version-4.1/http-api-reference.md
@@ -1679,7 +1679,9 @@ Responds a 200 OK if if all given protocols have active listeners,
 otherwise responds with a 503 Service Unavailable. Multiple protocols
 may be provided by separating the names with commas.
 
-Valid protocol names are: `amqp091`, `amqp10`, `mqtt`, `stomp`, `web-mqtt`, `web-stomp`.
+Valid protocol names are: `amqp`, `mqtt`, `stomp`, `web-mqtt`, `web-stomp`.
+To check for the encrypted listeners, add an `s` to the protocol name, for
+example `amqps` or `mqtts`.
 
 ### GET /api/health/checks/virtual-hosts
 


### PR DESCRIPTION
The protocol-listener health check accepts protocol names with 's' for the encrypted listeners like `amqps` and `mqtts`. The health check distinguishes between encrypted and non-encrypted so to get a 200 when running AMQPS but not AMQP you need to query for `amqps`.

This change mentions the encrypted protocol names. I've also combined `amqp091` and `amqp10` as `amqp` which is what the health check translates these into.

Also see https://github.com/rabbitmq/rabbitmq-server/blob/c7f6cad331443df0eaad668c2f1ca62410259c3a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl#L71-L135. The health check normalizes the protocol names so it can accept quite a large range