### PR TITLE
[RMQ-2047] Compare Tanzu RabbitMQ with open source RabbitMQ

### DIFF
--- a/src/components/SupportTimelines/index.js
+++ b/src/components/SupportTimelines/index.js
@@ -1,0 +1,77 @@
+import Link from '@docusaurus/Link';
+
+import styles from './index.module.css';
+
+export default function SupportTimelines() {
+  return (
+    <div>
+      <table className={styles.timelines_table}>
+        <thead>
+          <tr>
+            <th>Release</th>
+            <th>Patch</th>
+            <th>Date of Release</th>
+            <th>End of Community Support</th>
+            <th>End of Commercial Support*</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>4.1</td>
+            <td>4.1.3</td>
+            <td>4 Aug 2025</td>
+            <td className={styles.supported}>Next Release</td>
+            <td className={styles.supported}>30 Apr 2028</td>
+          </tr>
+          <tr>
+            <td>4.0</td>
+            <td>4.0.9</td>
+            <td>13 Apr 2025</td>
+            <td className={styles.unsupported}>14 Apr 2025</td>
+            <td className={styles.supported}>29 Sep 2027</td>
+          </tr>
+          <tr>
+            <td>3.13</td>
+            <td>3.13.7</td>
+            <td>25 Aug 2024</td>
+            <td className={styles.unsupported}>17 Sep 2024</td>
+            <td className={styles.supported}>30 Dec 2027</td>
+          </tr>
+          <tr>
+            <td>3.12</td>
+            <td>3.12.14</td>
+            <td>5 May 2024</td>
+            <td className={styles.unsupported}>21 Feb 2024</td>
+            <td className={styles.unsupported}>30 Jun 2025</td>
+          </tr>
+          <tr>
+            <td>3.11</td>
+            <td>3.11.28</td>
+            <td>21 Dec 2023</td>
+            <td className={styles.unsupported}>1 Jun 2023</td>
+            <td className={styles.unsupported}>30 Jun 2024</td>
+          </tr>
+          <tr>
+            <td>3.10</td>
+            <td>3.10.25</td>
+            <td>17 Jul 2023</td>
+            <td className={styles.unsupported}>27 Sep 2022</td>
+            <td className={styles.unsupported}>30 Jun 2024</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        *End of Commercial Support dates are indicative. Official commercial support lifecycle information can be found on the <Link to="https://support.broadcom.com/web/ecx/productlifecycle">Broadcom support portal</Link>.
+      </p>
+      <div>
+        <strong>Legend:</strong>
+        <div className={styles.legend_item}>
+          <span className={styles.supported_legend} />Latest Release, fully supported
+        </div>
+        <div className={styles.legend_item}>
+          <span className={styles.unsupported_legend} />Old Release, unsupported
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SupportTimelines/index.module.css
+++ b/src/components/SupportTimelines/index.module.css
@@ -1,0 +1,29 @@
+.timelines_table {
+  display: table;
+  width: 100%;
+}
+  
+.timelines_table th, .timelines_table td {
+  text-align: center;
+}
+
+.supported, .supported_legend {
+  background-color: var(--ifm-color-success-contrast-background);
+}
+
+.unsupported, .unsupported_legend {
+  background-color: var(--ifm-color-danger-contrast-background);
+}
+
+.legend_item {
+  padding-left: 1em;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.supported_legend, .unsupported_legend {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}

--- a/src/pages/commercial-features.js
+++ b/src/pages/commercial-features.js
@@ -2,8 +2,48 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
+import SupportTimelines from '@site/src/components/SupportTimelines';
 
 import styles from './index.module.css';
+
+const features = [
+  {
+    feature: <>Dependencies validated, <strong>security scanned</strong>, and included, as well as security fixes for base OS supplied</>,
+    benefit: 'Reduced cost of installing, upgrading, and testing dependencies. Reduced risk profile as OS security vulnerabilities are also supplied.'
+  },
+  {
+    feature: <><strong>Multi-site replication</strong>: assisted deployment and configuration of passive sites</>,
+    benefit: 'Reduced cost of deploying and configuring RabbitMQ clusters.'
+  },
+  {
+    feature: <>Multi-site replication with dynamic adaptation to wide area network latency and semi-automated <strong>promotion on failover</strong></>,
+    benefit: 'Reduced costs of designing and configuring disaster recovery topology; reduced recovery point objective, recovery time objective, and overall risk.'
+  },
+  {
+    feature: <>Lightweight, efficient & universal <strong>web app development</strong> & deployment</>,
+    benefit: 'AMQP 1.0 over websockets simplifies the use of the more flexible & feature rich protocol.'
+  },
+  {
+    feature: <>Reduced <strong>network utilization</strong> between RabbitMQ nodes</>,
+    benefit: 'Reduced cost of data ingress/egress between availability zones(especially, when running in a public cloud). Reduced risk of network saturation.'
+  },
+  {
+    feature: <>Delegated <strong>authentication</strong> and <strong>TLS certificates</strong> from <strong>Hashicorp Vault</strong></>,
+    benefit: 'Reduced cost of configuring integration and maintenance. Reduced security risks by using a single source of truth.'
+  },
+  {
+    feature: <><strong>Enhanced encryption</strong>: non-safe variants of TLS disabled by default</>,
+    benefit: 'Reduced security risk out of the box, as well as cost of disabling manually for every deployment.'
+  },
+  {
+    feature: <>Enhanced encryption: <strong>automated mutual TLS</strong> setup between RabbitMQ nodes</>,
+    benefit: 'Reduced cost of manually configuring each deployment. Reduced risk of man-in-the-middle attacks.'
+  },
+  {
+    feature: <>Easy Federal Information Processing Standards (<strong>FIPS</strong>) compliance</>,
+    benefit: 'Specific FIPS builds of Tanzu RabbitMQ'
+  }
+]
 
 export default function CommercialFeatures() {
   const { siteConfig } = useDocusaurusContext();
@@ -28,7 +68,7 @@ export default function CommercialFeatures() {
             </div>
           </div>
         </div>
-        <div className={styles.services}>
+        <div className={styles.section}>
           <div className={styles.container}>
             <Heading as="h1">VMware Tanzu RabbitMQ</Heading>
             <p>
@@ -106,6 +146,52 @@ export default function CommercialFeatures() {
                   queue, are collected and logged separately.
                 </p>
               </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.section} id="comparison">
+          <div className={styles.container}>
+            <Heading as="h1">Tanzu RabbitMQ vs Open Source</Heading>
+            <table className={styles.comparison_table}>
+              <thead>
+                <tr>
+                  <th className={styles.text_left}>Features</th>
+                  <th>Open Source RabbitMQ</th>
+                  <th>Tanzu RabbitMQ</th>
+                  <th className={styles.text_left}>Benefits</th>
+                </tr>
+              </thead>
+              <tbody>
+                {features.map(({feature, benefit}) => (
+                  <tr key={feature}>
+                    <td>{feature}</td>
+                    <td className={styles.unsupported}>❌</td>
+                    <td className={styles.supported}>✅</td>
+                    <td>{benefit}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <div className={styles.container}>
+            <Heading as="h1">Support Timelines</Heading>
+            <SupportTimelines />
+            <br />
+            <div>
+              <Link
+                className="button button--primary"
+                to="mailto:contact-tanzu-data.pdl@broadcom.com"
+              >
+                Contact Us
+              </Link>
+              &nbsp;
+              <Link className="button button--primary" to="/contact#consulting">
+                Find a Partner
+              </Link>
             </div>
           </div>
         </div>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import Mermaid from '@theme/Mermaid';
+import SupportTimelines from '@site/src/components/SupportTimelines';
 
 import styles from './index.module.css';
 
@@ -60,7 +60,7 @@ export default function Support() {
             <Heading as="h4">Commercial RabbitMQ includes both 24/7 support and features not available in the open source version.</Heading>
 
             <Tabs>
-              <TabItem value="feature-1" label="Enterprise Support" default>
+              <TabItem value="feature-1" label="Commercial Support">
                 <Heading as="h2">Around the clock, around the globe support</Heading>
                 <div className={styles.flex_columns}>
                   <section>
@@ -87,7 +87,11 @@ export default function Support() {
                   </section>
                 </div>
               </TabItem>
-              <TabItem value="feature-2" label="Enterprise Features">
+              <TabItem value="feature-2" label="Support Timelines" default>
+                <SupportTimelines />
+                <br />
+              </TabItem>
+              <TabItem value="feature-3" label="Enterprise Features">
                 <Heading as="h2">Exclusive capabilities supporting your mission-critical apps</Heading>
                 <div className={styles.flex_columns}>
                   <section>
@@ -125,9 +129,9 @@ export default function Support() {
 
         <div className={styles.featured_partner}>
           <div className={styles.container}>
-            <Heading as="h1"><span className={styles.highlight_text}>Partner Spotlight: Announcing AceMQ, our RabbitMQ MSP Partner</span></Heading>
-            <Heading as="h1"><span className={styles.highlight_text}>AceMQ <small>is our featured authorized partner providing End-to-End RabbitMQ solutions, including: white-glove commercial support and expert services for Tanzu RabbitMQ & RabbitMQ Community Edition. </small></span></Heading>
-            <p><strong className={styles.highlight_text}>To learn more about AceMQ’s RabbitMQ support, managed services, and RabbitMQ consulting & training offerings, please get in touch below: </strong></p>
+            <Heading as="h1">Partner Spotlight: Announcing AceMQ, our RabbitMQ MSP Partner</Heading>
+            <Heading as="h1">AceMQ <small>is our featured authorized partner providing End-to-End RabbitMQ solutions, including: white-glove commercial support and expert services for Tanzu RabbitMQ & RabbitMQ Community Edition. </small></Heading>
+            <p><strong>To learn more about AceMQ’s RabbitMQ support, managed services, and RabbitMQ consulting & training offerings, please get in touch below: </strong></p>
             <div>
               <Link className="button button--primary" to="https://acemq.com/rabbitmq/" rel="noopener">Consulting</Link>&nbsp;
               <Link className="button button--primary" to="https://acemq.com/rabbitmq/licensing/" rel="noopener">Commercial Support</Link>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -36,14 +36,14 @@ export default function Home() {
               <section>
                 <OSIKeyholeIcon/>
                 <Heading as="h2">Free and Open Source</Heading>
-                <p>RabbitMQ is licensed under the <Link to="https://www.tldrlegal.com/license/mozilla-public-license-2-0-mpl-2">Mozilla Public License 2.0</Link>,
-                   while most client libraries are dual-licensed under the Apache Software License 2.0 and the Mozilla Public License 2.0. You have the freedom to use and
-                  modify RabbitMQ in a very broad range of contexts.</p>
-                <p>Of course, contributions are more than welcome! Whether it
-                  is through detailed bug reports, patches, helping someone,
-                  documentation or any form of advocacy. In fact contributing
-                  is the best way to support the project!
-                  Take a look at our <Link to="/github">Contributors page</Link>.</p>
+                <p>
+                  RabbitMQ is a powerful, enterprise grade open-source messaging and streaming broker 
+                  that enables fast, reliable and versatile communication for applications—perfect for distributed microservices, real-time data, and scalable systems.
+                </p>
+                <p>
+                  Free under the <Link to="https://www.tldrlegal.com/license/mozilla-public-license-2-0-mpl-2">Mozilla Public License 2.0</Link>
+                  , it’s backed by a vibrant global community. Dive in with our easy-to-use <Link to="/docs">docs</Link> or <Link to="/github">contribute</Link> to shape its future!
+                </p>
               </section>
               <section>
                 <CommercialSupportIcon/>
@@ -53,6 +53,9 @@ export default function Home() {
                   It ensures your apps stay reliable and secure with <Link to="/contact#tanzu-rabbitmq">24/7 expert support from the engineers who make the product</Link>,
                   longer lifecycle, disaster recovery, cloud cost savings, and industry compliance.
                 </p>
+                <div className={styles.comparison_link}>
+                  <Link to="/commercial-features#comparison">See how Tanzu RabbitMQ compares to Open Source</Link>
+                </div>
                 <div>
                   <Link className="button button--primary" to="mailto:contact-tanzu-data.pdl@broadcom.com">Contact Us</Link>&nbsp;
                   <Link className="button button--primary" to="/contact#consulting">Find a Partner</Link>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -119,7 +119,7 @@ html[data-theme='dark'] .heroCta .release_notes_link {
   }
 }
 
-.why, .license, .tanzu_license, .usecases_heading, .usecases, .testimonies, .supporttypes, .partners, .featured_partner, .services {
+.why, .license, .tanzu_license, .usecases_heading, .usecases, .testimonies, .supporttypes, .partners, .featured_partner, .section {
   padding: 2em 0px;
   scroll-margin-top: 60px;
 }
@@ -132,10 +132,6 @@ html[data-theme='dark'] .heroCta .release_notes_link {
 
 .featured_partner {
   background-color: var(--ifm-color-emphasis-100);
-}
-
-.highlight_text {
-  background-color: var(--ifm-color-primary-contrast-background);
 }
 
 .featured_partner h1 small {
@@ -246,12 +242,8 @@ html[data-theme='dark'] .blockquote blockquote:after {
   --ifm-button-size-multiplier: 1;
 }
 
-html[data-theme='dark'] .licensing_cta a {
+html[data-theme='dark'] .commercial_features_cta a {
   background-color: var(--ifm-font-color-base);
-}
-
-.services h1 {
-  text-align: center;
 }
 
 .services_row {
@@ -272,11 +264,37 @@ html[data-theme='dark'] .licensing_cta a {
       max-width: 100%;
   }
 
-  .licensing_hero .heroInner {
+  .commercial_features_hero .heroInner {
     align-items: center;
   }
 }
 
 .services_col img {
   width: 100%;
+}
+
+.comparison_table {
+  display: table;
+  width: 100%;
+}
+
+.text_left {
+  text-align: left;
+}
+
+.supported, .unsupported {
+  font-size: 1.25em;
+  text-align: center;
+}
+
+.supported {
+  background-color: var(--ifm-color-success-contrast-background);
+}
+
+.unsupported {
+  background-color: var(--ifm-color-danger-contrast-background);
+}
+
+.comparison_link {
+  margin-bottom: 0.5em;
 }


### PR DESCRIPTION
We can keep this PR open for a while to allow others to review it.

I don't have permission to add reviewers. @michaelklishin, could you please help me add @HowardTwine, @MirahImage, and @nithinkrish as reviewers? I've been told that all my PRs need to include these three people as reviewers.

The changes in this PR:
- On the support page, in the Partner Spotlight, remove the pink background
- On the support page, under the VMware Tanzu RabbitMQ section, change ‘Enterprise Support’ to ‘Commercial Support’
- On the support page, under the VMware Tanzu RabbitMQ section, add a third tab titled ‘Support Timelines’ and place it between Commercial Support and Enterprise Features. Set this new third tab as the default tab visible when someone visits the support page. I created a common component under `/components` because this table is also used on licensing(commercial features) page.
- At the bottom of the licensing(commercial features) page, below ‘audit logging’, create a new section 'Tanzu RabbitMQ vs Open Source'
- Below the new table, create another new section 'Support Timelines'
- On the home page, can you create a CTA between the content and the buttons (with space inbetween) that says, “See how Tanzu RabbitMQ compares to Open Source”
- On the home page, update the content under the ‘Free and Open Source’ section

These changes help justify calling the page a licensing page. Can we change 'Commercial Features' back to 'Licensing'?