### PR TITLE
fix unmatched CSS class names

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -246,7 +246,7 @@ html[data-theme='dark'] .blockquote blockquote:after {
   --ifm-button-size-multiplier: 1;
 }
 
-html[data-theme='dark'] .licensing_cta a {
+html[data-theme='dark'] .commercial_features_cta a {
   background-color: var(--ifm-font-color-base);
 }
 
@@ -272,7 +272,7 @@ html[data-theme='dark'] .licensing_cta a {
       max-width: 100%;
   }
 
-  .licensing_hero .heroInner {
+  .commercial_features_hero .heroInner {
     align-items: center;
   }
 }


### PR DESCRIPTION
Some class names need to be renamed in the CSS file so that can work in dark mode

<img width="1154" height="141" alt="image" src="https://github.com/user-attachments/assets/a46ff5b8-6e8e-40d0-b789-97de59dfbd7f" />
