### PR TITLE
[RMQ-2052] Remove pink background from Partner Spotlight on the suppo…

### DIFF
--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -125,9 +125,9 @@ export default function Support() {
 
         <div className={styles.featured_partner}>
           <div className={styles.container}>
-            <Heading as="h1"><span className={styles.highlight_text}>Partner Spotlight: Announcing AceMQ, our RabbitMQ MSP Partner</span></Heading>
-            <Heading as="h1"><span className={styles.highlight_text}>AceMQ <small>is our featured authorized partner providing End-to-End RabbitMQ solutions, including: white-glove commercial support and expert services for Tanzu RabbitMQ & RabbitMQ Community Edition. </small></span></Heading>
-            <p><strong className={styles.highlight_text}>To learn more about AceMQ’s RabbitMQ support, managed services, and RabbitMQ consulting & training offerings, please get in touch below: </strong></p>
+            <Heading as="h1">Partner Spotlight: Announcing AceMQ, our RabbitMQ MSP Partner</Heading>
+            <Heading as="h1">AceMQ <small>is our featured authorized partner providing End-to-End RabbitMQ solutions, including: white-glove commercial support and expert services for Tanzu RabbitMQ & RabbitMQ Community Edition. </small></Heading>
+            <p><strong>To learn more about AceMQ’s RabbitMQ support, managed services, and RabbitMQ consulting & training offerings, please get in touch below: </strong></p>
             <div>
               <Link className="button button--primary" to="https://acemq.com/rabbitmq/" rel="noopener">Consulting</Link>&nbsp;
               <Link className="button button--primary" to="https://acemq.com/rabbitmq/licensing/" rel="noopener">Commercial Support</Link>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -134,10 +134,6 @@ html[data-theme='dark'] .heroCta .release_notes_link {
   background-color: var(--ifm-color-emphasis-100);
 }
 
-.highlight_text {
-  background-color: var(--ifm-color-primary-contrast-background);
-}
-
 .featured_partner h1 small {
   font-size: 1rem;
 }


### PR DESCRIPTION
…rt page

On the support page, in the Partner Spotlight, change the pink to grey behind the text, matching the grey background color. We will only have black text and grey background.