### PR TITLE
Reduce H2 font size to 2.0rem

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -38,7 +38,11 @@ html[data-theme='dark'] {
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
-article h2,
+article h2 {
+  clear: both;
+  font-size: 2.0rem !important;
+}
+
 article h3 {
   clear: both;
 }


### PR DESCRIPTION
Some feel strongly about the H2 header size that seems to be 3.0rem (48px) with our current theme and `custom.css`.

## Before

H2 font size of 3.0rem.

<img width="1819" height="2441" alt="CleanShot 2025-08-29 at 12  22 39" src="https://github.com/user-attachments/assets/fabdf1de-8fd1-4eb7-a6c8-8f630a521cd9" />


## After

H2 font size of 2.0rem.

<img width="1819" height="2441" alt="CleanShot 2025-08-29 at 12  23 01" src="https://github.com/user-attachments/assets/69bdeb4b-03e3-44f2-b364-9a87177fc235" />
