### PR TITLE
Fix typo (decied -> decide) in Deprecated Features section

### DIFF
--- a/docs/deprecated-features/index.md
+++ b/docs/deprecated-features/index.md
@@ -99,7 +99,7 @@ removed.
 deprecated_features.permit.some_deprecated_feature = false
 ```
 
-Another user may decied to turn a *denied by default* deprecated feature back
+Another user may decide to turn a *denied by default* deprecated feature back
 on to buy more time to adapt their applications while still upgrading
 RabbitMQ:
 

--- a/versioned_docs/version-3.13/deprecated-features/index.md
+++ b/versioned_docs/version-3.13/deprecated-features/index.md
@@ -99,7 +99,7 @@ removed.
 deprecated_features.permit.some_deprecated_feature = false
 ```
 
-Another user may decied to turn a *denied by default* deprecated feature back
+Another user may decide to turn a *denied by default* deprecated feature back
 on to buy more time to adapt their applications while still upgrading
 RabbitMQ:
 

--- a/versioned_docs/version-4.0/deprecated-features/index.md
+++ b/versioned_docs/version-4.0/deprecated-features/index.md
@@ -99,7 +99,7 @@ removed.
 deprecated_features.permit.some_deprecated_feature = false
 ```
 
-Another user may decied to turn a *denied by default* deprecated feature back
+Another user may decide to turn a *denied by default* deprecated feature back
 on to buy more time to adapt their applications while still upgrading
 RabbitMQ:
 

--- a/versioned_docs/version-4.1/deprecated-features/index.md
+++ b/versioned_docs/version-4.1/deprecated-features/index.md
@@ -99,7 +99,7 @@ removed.
 deprecated_features.permit.some_deprecated_feature = false
 ```
 
-Another user may decied to turn a *denied by default* deprecated feature back
+Another user may decide to turn a *denied by default* deprecated feature back
 on to buy more time to adapt their applications while still upgrading
 RabbitMQ:
 


### PR DESCRIPTION
Noticed a typo when reading the docs, so figured I would do a quick PR.