### PR TITLE
[RMQ-2150] Delete date of release column from support timeline table

### DIFF
--- a/src/components/CommercialSupportTimelines/index.js
+++ b/src/components/CommercialSupportTimelines/index.js
@@ -18,7 +18,6 @@ function getTimelineRows(releaseBranches) {
     }
 
     const patchRelease = releases[0];
-    const releaseDate = new Date(patchRelease.release_date);
     const endOfCommunitySupportDate = previousReleaseDate;
     const endOfCommercialSupportDate = new Date(releaseBranch.end_of_support);
 
@@ -34,7 +33,6 @@ function getTimelineRows(releaseBranches) {
     rows.push({
       release: branch,
       patch: patchRelease.version,
-      releaseDate: releaseDate.toLocaleDateString("en-GB", dateOptions),
       endOfCommunitySupport,
       endOfCommercialSupport,
       isCommunitySupported,
@@ -60,7 +58,6 @@ export function CommercialSupportTimelines() {
           <tr>
             <th>Release</th>
             <th>Patch</th>
-            <th>Date of Release</th>
             <th>End of Community Support</th>
             <th>End of Commercial Support*</th>
           </tr>
@@ -70,7 +67,6 @@ export function CommercialSupportTimelines() {
             <tr key={row.release}>
               <td>{row.release}</td>
               <td>{row.patch}</td>
-              <td>{row.releaseDate}</td>
               <td className={row.isCommunitySupported ? styles.supported : styles.unsupported}>
                 {row.endOfCommunitySupport}
               </td>


### PR DESCRIPTION
Some of the release dates came after the end of community support, so decided to delete 'date of release' column from support timeline table