### PR TITLE
Fix admonition syntax and repeated information

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -208,11 +208,9 @@ rabbitmqctl set_vm_memory_high_watermark 0
 
 ## Limited Address Space {#address-space}
 
-::: danger
+:::danger
 RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang)
 :::
-
-RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang).
 
 When running RabbitMQ inside a 32 bit Erlang VM in a 64 bit
 OS (or a 32 bit OS with PAE), the addressable memory is

--- a/versioned_docs/version-3.13/memory.md
+++ b/versioned_docs/version-3.13/memory.md
@@ -216,11 +216,9 @@ rabbitmqctl set_vm_memory_high_watermark 0
 
 ## Limited Address Space {#address-space}
 
-::: danger
+:::danger
 RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang)
 :::
-
-RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang).
 
 When running RabbitMQ inside a 32 bit Erlang VM in a 64 bit
 OS (or a 32 bit OS with PAE), the addressable memory is

--- a/versioned_docs/version-4.0/memory.md
+++ b/versioned_docs/version-4.0/memory.md
@@ -208,11 +208,9 @@ rabbitmqctl set_vm_memory_high_watermark 0
 
 ## Limited Address Space {#address-space}
 
-::: danger
+:::danger
 RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang)
 :::
-
-RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang).
 
 When running RabbitMQ inside a 32 bit Erlang VM in a 64 bit
 OS (or a 32 bit OS with PAE), the addressable memory is

--- a/versioned_docs/version-4.1/memory.md
+++ b/versioned_docs/version-4.1/memory.md
@@ -208,11 +208,9 @@ rabbitmqctl set_vm_memory_high_watermark 0
 
 ## Limited Address Space {#address-space}
 
-::: danger
+:::danger
 RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang)
 :::
-
-RabbitMQ only targets 64 bit operating systems and a 64-bit [Erlang runtime](./which-erlang).
 
 When running RabbitMQ inside a 32 bit Erlang VM in a 64 bit
 OS (or a 32 bit OS with PAE), the addressable memory is


### PR DESCRIPTION
While browsing the documentation I've seen that a danger admonition syntax was not right. Considering it's a styling change, fixed it as well in the versioned docs.

Also removed the phrase that was right below it as it's the same.