### PR TITLE
Shovels: document delete-after & no-ack incompatibility

### DIFF
--- a/docs/shovel-dynamic.md
+++ b/docs/shovel-dynamic.md
@@ -589,7 +589,7 @@ the declaration process.
         <div>
           If set to an integer, then the shovel will transfer that
           number of messages before deleting itself. This option cannot
-          be used in conjunction with <code>ack-mode : no-ack</code>.
+          be used together with <code>ack-mode</code> set to <code>no-ack</code>.
         </div>
       </td>
     </tr>
@@ -842,7 +842,7 @@ counterparts.
         <div>
           If set to an integer, then the shovel will transfer that
           number of messages before deleting itself. This option cannot
-          be used in conjunction with <code>ack-mode : no-ack</code>.
+          be used in conjunction with <code>ack-mode</code>: <code>no-ack</code>.
         </div>
       </td>
     </tr>

--- a/versioned_docs/version-3.13/shovel-dynamic.md
+++ b/versioned_docs/version-3.13/shovel-dynamic.md
@@ -534,7 +534,8 @@ the declaration process.
       </div>
       <div>
       If set to an integer, then the shovel will transfer that
-      number of messages before deleting itself.
+      number of messages before deleting itself. This option cannot
+      be used together with <code>ack-mode</code> set to <code>no-ack</code>.
       </div>
       </td>
     </tr>
@@ -792,14 +793,9 @@ counterparts.
       shovel should never delete itself.
       </div>
       <div>
-      If set to <code>queue-length</code> then the shovel will
-      measure the length of the source queue when starting up,
-      and delete itself after it has transferred that many
-      messages.
-      </div>
-      <div>
       If set to an integer, then the shovel will transfer that
-      number of messages before deleting itself.
+      number of messages before deleting itself. This option cannot
+      be used in conjunction with <code>ack-mode</code>: <code>no-ack</code>.
       </div>
       </td>
     </tr>

--- a/versioned_docs/version-4.0/shovel-dynamic.md
+++ b/versioned_docs/version-4.0/shovel-dynamic.md
@@ -598,7 +598,8 @@ the declaration process.
       </div>
       <div>
       If set to an integer, then the shovel will transfer that
-      number of messages before deleting itself.
+      number of messages before deleting itself. This option cannot
+      be used together with <code>ack-mode</code> set to <code>no-ack</code>.
       </div>
       </td>
     </tr>
@@ -855,14 +856,9 @@ counterparts.
       shovel should never delete itself.
       </div>
       <div>
-      If set to <code>queue-length</code> then the shovel will
-      measure the length of the source queue when starting up,
-      and delete itself after it has transferred that many
-      messages.
-      </div>
-      <div>
       If set to an integer, then the shovel will transfer that
-      number of messages before deleting itself.
+      number of messages before deleting itself. This option cannot
+      be used in conjunction with <code>ack-mode</code>: <code>no-ack</code>.
       </div>
       </td>
     </tr>

--- a/versioned_docs/version-4.1/shovel-dynamic.md
+++ b/versioned_docs/version-4.1/shovel-dynamic.md
@@ -598,7 +598,8 @@ the declaration process.
       </div>
       <div>
       If set to an integer, then the shovel will transfer that
-      number of messages before deleting itself.
+      number of messages before deleting itself. This option cannot
+      be used together with <code>ack-mode</code> set to <code>no-ack</code>.
       </div>
       </td>
     </tr>
@@ -855,14 +856,9 @@ counterparts.
       shovel should never delete itself.
       </div>
       <div>
-      If set to <code>queue-length</code> then the shovel will
-      measure the length of the source queue when starting up,
-      and delete itself after it has transferred that many
-      messages.
-      </div>
-      <div>
       If set to an integer, then the shovel will transfer that
-      number of messages before deleting itself.
+      number of messages before deleting itself. This option cannot
+      be used in conjunction with <code>ack-mode</code>: <code>no-ack</code>.
       </div>
       </td>
     </tr>


### PR DESCRIPTION
Remove src-delete-after:queue-length option for amqp10. It was never supported