### PR TITLE
[RMQ-2295] Add End of Commercial Support to release-information page

### DIFF
--- a/release-information/index.md
+++ b/release-information/index.md
@@ -35,7 +35,7 @@ the release notes of the target release.
 ## RabbitMQ Releases {#currently-supported}
 
 :::info[Long term support]
-Long term support is available to the users who [hold a valid commercial support license](/contact?utm_source=rmq_release-information_banner&utm_medium=rmq_website&utm_campaign=tanzu#tanzu-rabbitmq). Commercial  support lifecycle information can be found on the [Broadcom support portal](https://support.broadcom.com/web/ecx/productlifecycle).
+Long term support is available to the users who [hold a valid commercial support license](/contact?utm_source=rmq_release-information_banner&utm_medium=rmq_website&utm_campaign=tanzu#tanzu-rabbitmq). *End of Commercial Support dates below are indicative. Official commercial support lifecycle information can be found on the [Broadcom support portal](https://support.broadcom.com/web/ecx/productlifecycle).
 :::
 
 <RabbitMQServerReleaseInfoTable/>

--- a/src/components/RabbitMQServerReleaseInfo/index.js
+++ b/src/components/RabbitMQServerReleaseInfo/index.js
@@ -152,7 +152,9 @@ export function RabbitMQServerReleaseInfoTable() {
       }
 
       var endOfCommunitySupportDate = "-";
+      let endOfCommercialSupportDate = "-";
       var hasOSSSupport = false;
+      let hasCommercialSupported = false;
       if (releaseBranch.end_of_support) {
         /* Release branch is supported. */
         if (releaseBranch.end_of_community_support) {
@@ -165,6 +167,7 @@ export function RabbitMQServerReleaseInfoTable() {
           hasOSSSupport = true;
           endOfCommunitySupportDate = <abbr title="Supported until the next major or minor release branch is published.">Next release</abbr>;
         }
+        endOfCommercialSupportDate = new Date(releaseBranch.end_of_support);
       }
 
       {
@@ -187,6 +190,11 @@ export function RabbitMQServerReleaseInfoTable() {
           latestReleaseBranchClassName,
           isLatestReleaseForBranch ? "" : showClassName
         ].join(' ')}>{content}</div>;
+      }
+
+      if (endOfCommercialSupportDate instanceof Date) {
+        hasCommercialSupported = endOfCommercialSupportDate > now;
+        endOfCommercialSupportDate = endOfCommercialSupportDate.toLocaleDateString("en-GB", dateOptions);
       }
 
       if (isLatestReleaseForBranch) {
@@ -239,6 +247,13 @@ export function RabbitMQServerReleaseInfoTable() {
           ].join(' ')}>{releaseDate}</div>
 
           {endOfCommunitySupportDate}
+
+          <div className={[
+            "release-eos",
+            "release-eos-commercial",
+            hasCommercialSupported ? 'supported-release latest-release' : 'unsupported-release',
+            isLatestReleaseForBranch ? "" : showClassName
+          ].join(' ')}>{endOfCommercialSupportDate}</div>
         </>
       );
 
@@ -274,6 +289,12 @@ export function RabbitMQServerReleaseInfoTable() {
             "release-eos",
             "release-eos-community"
           ].join(' ')}>End of Community Support</div>
+
+          <div className={[
+            "release-info-header",
+            "release-eos",
+            "release-eos-commercial"
+          ].join(' ')}>End of Commercial Support*</div>
 
           {rows}
         </div>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -263,6 +263,7 @@ html[data-theme='dark'] .release-information {
 
 .release-links ul {
   display: flex;
+  justify-content: center;
   margin: 0;
   padding-left: 0;
 }
@@ -270,7 +271,6 @@ html[data-theme='dark'] .release-information {
 .release-links ul > li {
   display: inline-block;
   list-style-type: none;
-  margin-left: var(--ifm-table-cell-padding);
 }
 
 .release-links ul > li + li {
@@ -315,6 +315,7 @@ html[data-theme='dark'] .release-information {
 
   border-top-width: var(--ifm-table-border-width);
   border-left-width: var(--ifm-table-border-width);
+  text-align: center;
 }
 
 .release-info-grid .release-links {
@@ -329,11 +330,13 @@ html[data-theme='dark'] .release-information {
 
   border-top-width: var(--ifm-table-border-width);
   border-left-width: var(--ifm-table-border-width);
+  text-align: center;
 }
 
 .release-info-grid .release-eos {
   border-top-width: var(--ifm-table-border-width);
   border-left-width: var(--ifm-table-border-width);
+  text-align: center;
 }
 
 .release-info-grid .release-eos-community {
@@ -451,6 +454,10 @@ html[data-theme='dark'] .release-info-grid .release-toggle path {
 
   .release-info-grid .release-eos-community {
     grid-column: 6 / span 1;
+  }
+
+  .release-info-grid .release-eos-commercial {
+    grid-column: 7 / span 1;
   }
 }
 


### PR DESCRIPTION
- Add `End of Commercial Support` column to `/release-information` page
- Center the text in every column of the table
- Change the last sentence of `LONG TERM SUPPORT` alert to "*End of Commercial Support dates below are indicative. Official commercial support lifecycle information can be found on the Broadcom support portal"