### PR TITLE
[RMQ-2414] Replace version banner with a custom banner on 3.13 page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -250,6 +250,11 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             'https://github.com/rabbitmq/rabbitmq-website/tree/main/',
+          versions: {
+            '3.13': {
+              banner: 'none'
+            },
+          },
         },
         blog: {
           blogSidebarCount: 0,

--- a/versioned_docs/version-3.13/index.md
+++ b/versioned_docs/version-3.13/index.md
@@ -22,6 +22,11 @@ import {
     RabbitMQServerReleaseBranch,
     RabbitMQServerVersion,
 } from '@site/src/components/RabbitMQServer';
+import Admonition from '@theme/Admonition';
+
+<Admonition type="warning" icon="" title="" className="margin-top--sm">
+  This is documentation for RabbitMQ <strong>3.13</strong>, which is no longer actively maintained by the open source community but is commercially supported through VMware Tanzu RabbitMQ through Dec 30, 2027.
+</Admonition>
 
 # RabbitMQ <RabbitMQServerReleaseBranch/> Documentation
 


### PR DESCRIPTION
Since the text of version banner is hardcoded in [Docusaurus repo](https://github.com/facebook/docusaurus/blob/0372ecd1e910697f2f362a607b5fd730d8a7f9b1/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx#L66), we have to set the `banner` of `3.13` to `none` as per [docs](https://docusaurus.io/docs/versioning#configuring-versioning-behavior) and add the custom banner in `version-3.13/index.md`