### PR TITLE
Update 404 to no longer existing tool

### DIFF
--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -222,7 +222,7 @@ Miscellaneous projects:
 
 ## Visualisation {#viz}
 
- * [Rabbit Viz](https://plexsystems.github.io/rabbit-viz/), a tool for visualizing [exported definition files](/docs/backup#rabbitmq-definitions).
+ * [RabbitGUI](https://rabbitgui.com), a tool for vizualizing and managing dead letter queues.
 
 
 ## Unity 3D {#unity-dev}


### PR DESCRIPTION
Rabbit Viz no longer exists, the repository has been archived and the suggested alternative also dos not exist.
I placed RabbitGUI as an alternative for users.