### PR TITLE
Remove a unrelated example from set_user_limits section

### DIFF
--- a/docs/man/rabbitmqctl.8.md
+++ b/docs/man/rabbitmqctl.8.md
@@ -1685,11 +1685,6 @@ max-channels
           <p class="Pp">This command clears the maximum number of connections limit for user "limited_user":</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
-            <code class="Li">rabbitmqctl clear_user_limits limited_user 'max-connections'</code>
-          </div>
-          <p class="Pp">This command disables client connections for user "limited_user":</p>
-          <p class="Pp"></p>
-          <div class="Bd Bd-indent lang-bash">
             <code class="Li">rabbitmqctl set_user_limits limited_user '&lcub;"max-connections": 0}'</code>
           </div>
         </dd>

--- a/versioned_docs/version-3.13/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-3.13/man/rabbitmqctl.8.md
@@ -1714,11 +1714,6 @@ max-channels
           <p class="Pp">This command clears the maximum number of connections limit for user "limited_user":</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
-            <code class="Li">rabbitmqctl clear_user_limits limited_user 'max-connections'</code>
-          </div>
-          <p class="Pp">This command disables client connections for user "limited_user":</p>
-          <p class="Pp"></p>
-          <div class="Bd Bd-indent lang-bash">
             <code class="Li">rabbitmqctl set_user_limits limited_user '&lcub;"max-connections": 0}'</code>
           </div>
         </dd>

--- a/versioned_docs/version-4.0/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-4.0/man/rabbitmqctl.8.md
@@ -1684,11 +1684,6 @@ max-channels
           <p class="Pp">This command clears the maximum number of connections limit for user "limited_user":</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
-            <code class="Li">rabbitmqctl clear_user_limits limited_user 'max-connections'</code>
-          </div>
-          <p class="Pp">This command disables client connections for user "limited_user":</p>
-          <p class="Pp"></p>
-          <div class="Bd Bd-indent lang-bash">
             <code class="Li">rabbitmqctl set_user_limits limited_user '&lcub;"max-connections": 0}'</code>
           </div>
         </dd>

--- a/versioned_docs/version-4.1/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-4.1/man/rabbitmqctl.8.md
@@ -1685,11 +1685,6 @@ max-channels
           <p class="Pp">This command clears the maximum number of connections limit for user "limited_user":</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
-            <code class="Li">rabbitmqctl clear_user_limits limited_user 'max-connections'</code>
-          </div>
-          <p class="Pp">This command disables client connections for user "limited_user":</p>
-          <p class="Pp"></p>
-          <div class="Bd Bd-indent lang-bash">
             <code class="Li">rabbitmqctl set_user_limits limited_user '&lcub;"max-connections": 0}'</code>
           </div>
         </dd>

--- a/versioned_docs/version-4.2/man/rabbitmqctl.8.md
+++ b/versioned_docs/version-4.2/man/rabbitmqctl.8.md
@@ -1685,11 +1685,6 @@ max-channels
           <p class="Pp">This command clears the maximum number of connections limit for user "limited_user":</p>
           <p class="Pp"></p>
           <div class="Bd Bd-indent lang-bash">
-            <code class="Li">rabbitmqctl clear_user_limits limited_user 'max-connections'</code>
-          </div>
-          <p class="Pp">This command disables client connections for user "limited_user":</p>
-          <p class="Pp"></p>
-          <div class="Bd Bd-indent lang-bash">
             <code class="Li">rabbitmqctl set_user_limits limited_user '&lcub;"max-connections": 0}'</code>
           </div>
         </dd>


### PR DESCRIPTION
https://www.rabbitmq.com/docs/man/rabbitmqctl.8#set_user_limits

<img width="940" height="290" alt="image" src="https://github.com/user-attachments/assets/8ebf8993-b809-4197-a4b6-cafeb3a4d44a" />

There is the `clear_user_limits` example in the `set_user_limits` section. And this `clear_user_limits` example is already written in the `clear_user_limits` example section. So this PR removes it from  the `set_user_limits` section.
