### PR TITLE
Update Kubernetes Operator guide for openshift

### DIFF
--- a/kubernetes/operator/using-on-openshift.md
+++ b/kubernetes/operator/using-on-openshift.md
@@ -55,8 +55,13 @@ spec:
       spec:
         template:
           spec:
-            containers: []
             securityContext: {}
+            containers:
+            - name: rabbitmq
+              securityContext: {}
+            initContainers:
+            - name: setup-container
+              securityContext: {}
 ```
 
 This resets the securityContext for the Pods to default, and ensures that RabbitMQ Pods are also assigned arbitrary user IDs in Openshift.


### PR DESCRIPTION
This now matches the example in the cluster-operator repo, and aligns with the latest and greatest verified workaround for openshift.

This guide does not seem to have its equivalent in `versioned_docs`, so I just did the change in one place.