### PR TITLE
Add the endpoint introduced in rabbitmq/rabbitmq-server#15074 to the HTTP API reference guide

### DIFF
--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -1182,6 +1182,10 @@ A list of all permissions for a given user.
 
 A list of all topic permissions for a given user.
 
+### GET /api/users/\{_user_\}/queues
+
+A list of all queues originally declared by a given user.
+
 ### GET /api/user-limits
 
 Lists per-user limits for all users.


### PR DESCRIPTION
Note the difference in wording: "originally declared by" instead of "owned by" because "ownership" of a queue is not very well defined, and is typically used to describe the owning connection in the AMQP 0-9-1 sense.