### PR TITLE
K8S Operator: bump the apiVersion of PDB used in the guide

### DIFF
--- a/kubernetes/operator/using-operator/index.md
+++ b/kubernetes/operator/using-operator/index.md
@@ -1025,7 +1025,7 @@ consistency, such as pause-minority mode for partition tolerance.
 To create and set a `PodDisruptionBudget` object, first create a file called `rabbitmq-pdb.yaml` that includes:
 
 ```yaml
-    apiVersion: policy/v1beta1
+    apiVersion: policy/v1
     kind: PodDisruptionBudget
     metadata:
       name: pdb-rabbitmq


### PR DESCRIPTION
The policy/v1beta1 API version of PodDisruptionBudget is no longer served as of v1.25 (released on August 2022).