### PR TITLE
Fix per-message TTL QQ memory overhead

### DIFF
--- a/docs/quorum-queues/index.md
+++ b/docs/quorum-queues/index.md
@@ -178,10 +178,10 @@ for many workloads.
 
 ### Queue and Per-Message TTL
 
-Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL (since RabbitMQ 3.10)
+Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL
 (including [Per-Queue Message TTL in Queues](./ttl#per-queue-message-ttl) and
-[Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
-When using any form of message TTL, the memory overhead increases by 2 bytes per message.
+ [Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
+When using any form of message TTL, the memory overhead increases by 16 bytes per message.
 
 ### Length Limit
 

--- a/versioned_docs/version-3.13/quorum-queues/index.md
+++ b/versioned_docs/version-3.13/quorum-queues/index.md
@@ -169,8 +169,8 @@ Quorum queues are not meant to be used as [temporary queues](./queues#temporary-
 
 Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL
 (including [Per-Queue Message TTL in Queues](./ttl#per-queue-message-ttl) and
-[Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
-When using any form of message TTL, the memory overhead increases by 2 bytes per message.
+ [Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
+When using any form of message TTL, the memory overhead increases by 16 bytes per message.
 
 #### Length Limit
 

--- a/versioned_docs/version-4.0/quorum-queues/index.md
+++ b/versioned_docs/version-4.0/quorum-queues/index.md
@@ -178,10 +178,10 @@ for many workloads.
 
 ### Queue and Per-Message TTL
 
-Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL (since RabbitMQ 3.10)
+Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL
 (including [Per-Queue Message TTL in Queues](./ttl#per-queue-message-ttl) and
-[Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
-When using any form of message TTL, the memory overhead increases by 2 bytes per message.
+ [Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
+When using any form of message TTL, the memory overhead increases by 16 bytes per message.
 
 ### Length Limit
 

--- a/versioned_docs/version-4.1/quorum-queues/index.md
+++ b/versioned_docs/version-4.1/quorum-queues/index.md
@@ -178,10 +178,10 @@ for many workloads.
 
 ### Queue and Per-Message TTL
 
-Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL (since RabbitMQ 3.10)
+Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL
 (including [Per-Queue Message TTL in Queues](./ttl#per-queue-message-ttl) and
-[Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
-When using any form of message TTL, the memory overhead increases by 2 bytes per message.
+ [Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
+When using any form of message TTL, the memory overhead increases by 16 bytes per message.
 
 ### Length Limit
 

--- a/versioned_docs/version-4.2/quorum-queues/index.md
+++ b/versioned_docs/version-4.2/quorum-queues/index.md
@@ -178,10 +178,10 @@ for many workloads.
 
 ### Queue and Per-Message TTL
 
-Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL (since RabbitMQ 3.10)
+Quorum queues support both [Queue TTL](./ttl#queue-ttl) and message TTL
 (including [Per-Queue Message TTL in Queues](./ttl#per-queue-message-ttl) and
-[Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
-When using any form of message TTL, the memory overhead increases by 2 bytes per message.
+ [Per-Message TTL in Publishers](./ttl#per-message-ttl-in-publishers)).
+When using any form of message TTL, the memory overhead increases by 16 bytes per message.
 
 ### Length Limit
 


### PR DESCRIPTION
2 words = 16 bytes