### PR TITLE
Fix: Operator policy example uses an invalid policy argument

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1038,19 +1038,19 @@ rabbitmqadmin.exe operator_policies patch --name "cq.op-pol.1" --definition "{""
 The new `--definition` object will be merged into the existing policy definition.
 
 In the following example, an existing operator policy named `queues.op-pol.1` in the default virtual host (`/`)
-is updated to enable [queue federation](./federated-queues) to all the configured upstreams for the matched queues,
+is updated to add a [`max-length-bytes` key](./maxlength/) to all the matched queues,
 without affecting the rest of the policy definitions:
 
 <Tabs groupId="examples">
 <TabItem value="rabbitmqadmin" label="rabbitmqadmin with bash" default>
 ```bash
-rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"federation-upstream-set":"all"}'
+rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"max-length-bytes":1048576}'
 ```
 </TabItem>
 
 <TabItem value="rabbitmqadmin-PowerShell" label="rabbitmqadmin with PowerShell">
 ```bash
-rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""federation-upstream-set"": ""all""}"
+rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""max-length-bytes"": 1048576}"
 ```
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-3.13/policies.md
+++ b/versioned_docs/version-3.13/policies.md
@@ -1020,19 +1020,19 @@ rabbitmqadmin.exe operator_policies patch --name "cq.op-pol.1" --definition "{""
 The new `--definition` object will be merged into the existing policy definition.
 
 In the following example, an existing operator policy named `queues.op-pol.1` in the default virtual host (`/`)
-is updated to enable [queue federation](./federated-queues) to all the configured upstreams for the matched queues,
+is updated to add a [`max-length-bytes` key](./maxlength/) to all the matched queues,
 without affecting the rest of the policy definitions:
 
 <Tabs groupId="examples">
 <TabItem value="rabbitmqadmin" label="rabbitmqadmin with bash" default>
 ```bash
-rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"federation-upstream-set":"all"}'
+rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"max-length-bytes":1048576}'
 ```
 </TabItem>
 
 <TabItem value="rabbitmqadmin-PowerShell" label="rabbitmqadmin with PowerShell">
 ```bash
-rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""federation-upstream-set"": ""all""}"
+rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""max-length-bytes"": 1048576}"
 ```
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-4.0/policies.md
+++ b/versioned_docs/version-4.0/policies.md
@@ -1020,19 +1020,19 @@ rabbitmqadmin.exe operator_policies patch --name "cq.op-pol.1" --definition "{""
 The new `--definition` object will be merged into the existing policy definition.
 
 In the following example, an existing operator policy named `queues.op-pol.1` in the default virtual host (`/`)
-is updated to enable [queue federation](./federated-queues) to all the configured upstreams for the matched queues,
+is updated to add a [`max-length-bytes` key](./maxlength/) to all the matched queues,
 without affecting the rest of the policy definitions:
 
 <Tabs groupId="examples">
 <TabItem value="rabbitmqadmin" label="rabbitmqadmin with bash" default>
 ```bash
-rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"federation-upstream-set":"all"}'
+rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"max-length-bytes":1048576}'
 ```
 </TabItem>
 
 <TabItem value="rabbitmqadmin-PowerShell" label="rabbitmqadmin with PowerShell">
 ```bash
-rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""federation-upstream-set"": ""all""}"
+rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""max-length-bytes"": 1048576}"
 ```
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-4.1/policies.md
+++ b/versioned_docs/version-4.1/policies.md
@@ -1024,19 +1024,19 @@ rabbitmqadmin.exe operator_policies patch --name "cq.op-pol.1" --definition "{""
 The new `--definition` object will be merged into the existing policy definition.
 
 In the following example, an existing operator policy named `queues.op-pol.1` in the default virtual host (`/`)
-is updated to enable [queue federation](./federated-queues) to all the configured upstreams for the matched queues,
+is updated to add a [`max-length-bytes` key](./maxlength/) to all the matched queues,
 without affecting the rest of the policy definitions:
 
 <Tabs groupId="examples">
 <TabItem value="rabbitmqadmin" label="rabbitmqadmin with bash" default>
 ```bash
-rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"federation-upstream-set":"all"}'
+rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"max-length-bytes":1048576}'
 ```
 </TabItem>
 
 <TabItem value="rabbitmqadmin-PowerShell" label="rabbitmqadmin with PowerShell">
 ```bash
-rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""federation-upstream-set"": ""all""}"
+rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""max-length-bytes"": 1048576}"
 ```
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-4.2/policies.md
+++ b/versioned_docs/version-4.2/policies.md
@@ -1030,19 +1030,19 @@ rabbitmqadmin.exe operator_policies patch --name "cq.op-pol.1" --definition "{""
 The new `--definition` object will be merged into the existing policy definition.
 
 In the following example, an existing operator policy named `queues.op-pol.1` in the default virtual host (`/`)
-is updated to enable [queue federation](./federated-queues) to all the configured upstreams for the matched queues,
+is updated to add a [`max-length-bytes` key](./maxlength/) to all the matched queues,
 without affecting the rest of the policy definitions:
 
 <Tabs groupId="examples">
 <TabItem value="rabbitmqadmin" label="rabbitmqadmin with bash" default>
 ```bash
-rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"federation-upstream-set":"all"}'
+rabbitmqadmin operator_policies patch --name "queues.op-pol.1" --definition '{"max-length-bytes":1048576}'
 ```
 </TabItem>
 
 <TabItem value="rabbitmqadmin-PowerShell" label="rabbitmqadmin with PowerShell">
 ```bash
-rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""federation-upstream-set"": ""all""}"
+rabbitmqadmin.exe operator_policies patch --name "queues.op-pol.1" --definition "{""max-length-bytes"": 1048576}"
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
The "patch" example was setting a `federation-upstream-set` argument, which is not one of the [valid operator policy arguments](https://www.rabbitmq.com/docs/policies#why-operator-policies-exist).