### PR TITLE
Add `%% coding: utf-8` directive to `inter_node_tls.config` examples

### DIFF
--- a/docs/clustering-ssl.md
+++ b/docs/clustering-ssl.md
@@ -246,6 +246,10 @@ separate server certificate and private key files, enables [peer verification](.
 and requires peers to present a certificate:
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
   {server, [
     {cacertfile, "/full/path/to/ca_certificate.pem"},
@@ -317,6 +321,10 @@ As with other operating systems, more [TLS options](./ssl) are available
 to be set if necessary.
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
     {server, [
         {cacertfile, "C:/Path/To/ca_certificate.pem"},

--- a/versioned_docs/version-3.13/clustering-ssl.md
+++ b/versioned_docs/version-3.13/clustering-ssl.md
@@ -246,6 +246,10 @@ separate server certificate and private key files, enables [peer verification](.
 and requires peers to present a certificate:
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
   {server, [
     {cacertfile, "/full/path/to/ca_certificate.pem"},
@@ -317,6 +321,10 @@ As with other operating systems, more [TLS options](./ssl) are available
 to be set if necessary.
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
     {server, [
         {cacertfile, "C:/Path/To/ca_certificate.pem"},

--- a/versioned_docs/version-4.0/clustering-ssl.md
+++ b/versioned_docs/version-4.0/clustering-ssl.md
@@ -246,6 +246,10 @@ separate server certificate and private key files, enables [peer verification](.
 and requires peers to present a certificate:
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
   {server, [
     {cacertfile, "/full/path/to/ca_certificate.pem"},
@@ -317,6 +321,10 @@ As with other operating systems, more [TLS options](./ssl) are available
 to be set if necessary.
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
     {server, [
         {cacertfile, "C:/Path/To/ca_certificate.pem"},

--- a/versioned_docs/version-4.1/clustering-ssl.md
+++ b/versioned_docs/version-4.1/clustering-ssl.md
@@ -246,6 +246,10 @@ separate server certificate and private key files, enables [peer verification](.
 and requires peers to present a certificate:
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
   {server, [
     {cacertfile, "/full/path/to/ca_certificate.pem"},
@@ -317,6 +321,10 @@ As with other operating systems, more [TLS options](./ssl) are available
 to be set if necessary.
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
     {server, [
         {cacertfile, "C:/Path/To/ca_certificate.pem"},

--- a/versioned_docs/version-4.2/clustering-ssl.md
+++ b/versioned_docs/version-4.2/clustering-ssl.md
@@ -246,6 +246,10 @@ separate server certificate and private key files, enables [peer verification](.
 and requires peers to present a certificate:
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
   {server, [
     {cacertfile, "/full/path/to/ca_certificate.pem"},
@@ -317,6 +321,10 @@ As with other operating systems, more [TLS options](./ssl) are available
 to be set if necessary.
 
 ```bash
+%% coding: utf-8
+%% This directive tells the Erlang preprocessor to interpret this file
+%% as UTF-8, which is required if any values contain non-ASCII characters
+%% (for example, in the password field).
 [
     {server, [
         {cacertfile, "C:/Path/To/ca_certificate.pem"},


### PR DESCRIPTION
The Erlang preprocessor interprets files as Latin-1 by default. Without the `%% coding: utf-8` directive, non-ASCII characters in values such as the `password` field are not parsed correctly.

Add the directive and an explanatory comment to both the Linux and Windows `inter_node_tls.config` example blocks.

Related to erlang/otp#8289
Related to rabbitmq/rabbitmq-server#10826