### PR TITLE
Consul peer discovery: note that RABBITMQ_USE_LONGNAME is also required

### DIFF
--- a/docs/cluster-formation.md
+++ b/docs/cluster-formation.md
@@ -608,6 +608,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-3.13/cluster-formation.md
+++ b/versioned_docs/version-3.13/cluster-formation.md
@@ -816,6 +816,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-4.0/cluster-formation.md
+++ b/versioned_docs/version-4.0/cluster-formation.md
@@ -825,6 +825,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-4.1/cluster-formation.md
+++ b/versioned_docs/version-4.1/cluster-formation.md
@@ -608,6 +608,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-4.2/cluster-formation.md
+++ b/versioned_docs/version-4.2/cluster-formation.md
@@ -608,6 +608,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:


### PR DESCRIPTION
Clarify in the Consul peer discovery section that `cluster_formation.consul.use_longname = true` alone does not switch a RabbitMQ node to long node names: `RABBITMQ_USE_LONGNAME` must also be set to `true` on every cluster node.

Applied to `docs/` and the 4.2, 4.1, 4.0 and 3.13 editions.

Fixes #1366