### PR TITLE
Update end of community support to end of month

### DIFF
--- a/src/components/CommercialSupportTimelines/index.js
+++ b/src/components/CommercialSupportTimelines/index.js
@@ -3,12 +3,12 @@ import {getReleaseBranches} from '../RabbitMQServerReleaseInfo';
 import styles from "./index.module.css"
 
 function formatDate(date, isReleaseDate) {
-  const year = date.toLocaleDateString("en-US", { year: "numeric" });
-  const month = date.toLocaleDateString("en-US", { month: "short" });
+  const year = date.toLocaleDateString("en-US", { year: "numeric", timeZone: "UTC" });
+  const month = date.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
   if (isReleaseDate) {
     return `${month} ${year}`;
   }
-  const day = date.toLocaleDateString("en-US", { day: "numeric" });
+  const day = date.toLocaleDateString("en-US", { day: "numeric", timeZone: "UTC" });
   return `${day} ${month} ${year}`;
 }
 
@@ -55,7 +55,8 @@ function getTimelineRows(releaseBranches) {
       isCommercialSupported
     });
 
-    previousReleaseDate = new Date(minorRelease.release_date);
+    const d = new Date(minorRelease.release_date);
+    previousReleaseDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0));
   }
 
   return rows;

--- a/src/components/RabbitMQServerReleaseInfo/index.js
+++ b/src/components/RabbitMQServerReleaseInfo/index.js
@@ -65,7 +65,7 @@ export function RabbitMQServerReleaseInfoTable() {
   const docusaurusVersions = useVersions();
 
   const now = Date.now();
-  const dateOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+  const dateOptions = { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' };
 
   var isLatestReleaseBranch = false;
   var previousReleaseBranch;
@@ -162,7 +162,8 @@ export function RabbitMQServerReleaseInfoTable() {
         } else if (previousReleaseBranch) {
           const prevReleases = previousReleaseBranch.releases;
           const initialPrevRelease = prevReleases[prevReleases.length - 1];
-          endOfCommunitySupportDate = new Date(initialPrevRelease.release_date);
+          const d = new Date(initialPrevRelease.release_date);
+          endOfCommunitySupportDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0));
         } else {
           hasOSSSupport = true;
           endOfCommunitySupportDate = <abbr title="Supported until the next major or minor release branch is published.">Next release</abbr>;


### PR DESCRIPTION
Calculate the end of community support date as the last day of the month when derived from the subsequent release. Additionally, set the timezone to UTC for date formatting to prevent off-by-one day rendering issues.