### PR TITLE
Clarify that some Tanzu RabbitMQ plugins are Erlang applications

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -637,13 +637,13 @@ The table below lists tier 1 (core) plugins that ship with RabbitMQ.
 
 ## Additional Plugins in VMware Tanzu RabbitMQ® {#commercial-plugins}
 
-The table below lists plugins only available in [Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq).
+The table below lists plugins (or Erlang applications) only available in [Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq).
 For more details, see [Exclusive features in Tanzu RabbitMQ](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-rabbitmq-oci/4-2/tanzu-rabbitmq-oci-image/site-tanzu-rabbitmq-features.html).
 
 <table class="plugins">
   <thead>
     <tr>
-      <th>Plugin name</th>
+      <th>Plugin / Erlang application</th>
       <th>Description</th>
     </tr>
   </thead>


### PR DESCRIPTION
Update the commercial plugins section to clarify that some items, like `inet_tcp_compress_dist`, are Erlang applications rather than standard RabbitMQ plugins. This prevents user confusion since these applications do not appear in the output of `rabbitmq-plugins list`.