### PR TITLE
Docs: quorum queue priorities in 4.3 — policy restriction and 32-level support

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -131,7 +131,7 @@ Some optional arguments cannot be configured using a policy. They control variou
 that cannot be changed at runtime. Two key examples are:
 
  * The type of a queue
- * The [maximum number of priorities](./priority) of classic queues
+ * The [maximum number of priorities](./priority) of classic and quorum queues
 
 Those values intentionally cannot be configured by policies: their values are fixed at queue declaration time.
 

--- a/docs/priority.md
+++ b/docs/priority.md
@@ -131,22 +131,35 @@ priority.
 
 ### Quorum Queues
 
-Quorum queues internally only support two priorities: high and normal. Messages without
-a priority set or having priorities in the [0, 4] range will be considered to be of normal priority.
+:::important
 
-Messages with a priority higher than 4 will be considered to be of high priority.
+Strict message priority support for quorum queues is available as of RabbitMQ 4.3.
 
-Now, consider a priority quorum queue with the same messages, but with different priorities:
+:::
 
-| Message | Enqueueing Order | Priority |
-|---------|------------------|----------|
-| A       | 1                | 1        |
-| B       | 2                | 2        |
-| C       | 3                | 8        |
+Starting with RabbitMQ 4.3, quorum queues support strict message priorities with 32 priority levels (0-31). Unlike the previous "fair share" approach (2:1 ratio between high and normal priorities), strict priorities ensure that higher priority messages are always delivered before lower priority messages.
 
-These messages will be dispatched (sent) to a consumer (or multiple consumers) in the following order: C, A, B.
-Message C will be considered a high priority message, while A and B will
-both have normal priority.
+Priority levels 0-31 are supported. Priority values higher than 31 will be clamped to 31 (the maximum priority). This allows applications to use standard priority values without worrying about exceeding the maximum.
+
+#### Per-Priority Message Counts
+
+Each priority level maintains separate message counts that are visible in the Management UI. This allows operators to monitor queue depth per priority and ensure that high-priority messages are not getting stuck behind lower-priority ones.
+
+#### Redelivery of Returned Messages
+
+When messages are returned to the queue (via `reject`, `nack`, or `modify`), they do not retain their original priority. Instead, they are added to the returns queue and are requeued in the exact order they were returned, regardless of their priority.
+
+#### Priority-Aware Message Expiration
+
+Message expiration (TTL) scans now run across all priority levels, ensuring that messages expire in the correct order regardless of their priority level. For each priority level, the scan will only process messages until it encounters the first unexpired message. This prevents low-priority messages from blocking the expiration of high-priority messages that have exceeded their TTL.
+
+#### Management UI Support
+
+The Management UI displays per-priority message counts for each quorum queue, allowing operators to:
+
+* Monitor queue depth broken down by priority level
+* Identify if high-priority messages are being delayed by lower-priority ones
+* Make informed decisions about consumer allocation and queue configuration
 
 ## Priority Queue Behaviour {#behaviour}
 

--- a/versioned_docs/version-4.3/policies.md
+++ b/versioned_docs/version-4.3/policies.md
@@ -131,7 +131,7 @@ Some optional arguments cannot be configured using a policy. They control variou
 that cannot be changed at runtime. Two key examples are:
 
  * The type of a queue
- * The [maximum number of priorities](./priority) of classic queues
+ * The [maximum number of priorities](./priority) of classic and quorum queues
 
 Those values intentionally cannot be configured by policies: their values are fixed at queue declaration time.
 

--- a/versioned_docs/version-4.3/priority.md
+++ b/versioned_docs/version-4.3/priority.md
@@ -131,22 +131,35 @@ priority.
 
 ### Quorum Queues
 
-Quorum queues internally only support two priorities: high and normal. Messages without
-a priority set or having priorities in the [0, 4] range will be considered to be of normal priority.
+:::important
 
-Messages with a priority higher than 4 will be considered to be of high priority.
+Strict message priority support for quorum queues is available as of RabbitMQ 4.3.
 
-Now, consider a priority quorum queue with the same messages, but with different priorities:
+:::
 
-| Message | Enqueueing Order | Priority |
-|---------|------------------|----------|
-| A       | 1                | 1        |
-| B       | 2                | 2        |
-| C       | 3                | 8        |
+Starting with RabbitMQ 4.3, quorum queues support strict message priorities with 32 priority levels (0-31). Unlike the previous "fair share" approach (2:1 ratio between high and normal priorities), strict priorities ensure that higher priority messages are always delivered before lower priority messages.
 
-These messages will be dispatched (sent) to a consumer (or multiple consumers) in the following order: C, A, B.
-Message C will be considered a high priority message, while A and B will
-both have normal priority.
+Priority levels 0-31 are supported. Priority values higher than 31 will be clamped to 31 (the maximum priority). This allows applications to use standard priority values without worrying about exceeding the maximum.
+
+#### Per-Priority Message Counts
+
+Each priority level maintains separate message counts that are visible in the Management UI. This allows operators to monitor queue depth per priority and ensure that high-priority messages are not getting stuck behind lower-priority ones.
+
+#### Redelivery of Returned Messages
+
+When messages are returned to the queue (via `reject`, `nack`, or `modify`), they do not retain their original priority. Instead, they are added to the returns queue and are requeued in the exact order they were returned, regardless of their priority.
+
+#### Priority-Aware Message Expiration
+
+Message expiration (TTL) scans now run across all priority levels, ensuring that messages expire in the correct order regardless of their priority level. For each priority level, the scan will only process messages until it encounters the first unexpired message. This prevents low-priority messages from blocking the expiration of high-priority messages that have exceeded their TTL.
+
+#### Management UI Support
+
+The Management UI displays per-priority message counts for each quorum queue, allowing operators to:
+
+* Monitor queue depth broken down by priority level
+* Identify if high-priority messages are being delayed by lower-priority ones
+* Make informed decisions about consumer allocation and queue configuration
 
 ## Priority Queue Behaviour {#behaviour}
 


### PR DESCRIPTION
Two related doc fixes for quorum queue priorities in 4.3.

The "What Cannot Be Set Using a Policy" section in the policies guide says the maximum number of priorities of *classic queues* cannot be set via a policy. As of 4.3, quorum queues also support priorities, and the same restriction applies to them — `max-priority` is not a recognised policy key for quorum queues either.

Reproduced against a 4.3.0 cluster with all feature flags enabled:

```
$ rabbitmqctl set_policy --apply-to quorum_queues test "^x$" '{"max-priority":5}'
Error: Validation failed
[{<<"max-priority">>,5}] are not recognised policy settings
```

Updated only the one bullet, in `docs/policies.md` and `versioned_docs/version-4.3/policies.md`.

The "Quorum Queues" subsection of `docs/priority.md` (and the 4.3 versioned copy) was also still describing pre-4.3 behaviour — only "two internal priorities (high/normal)" with priority 4 as the threshold, including an example table where priorities 1/2/8 dispatch as C, A, B. As of 4.3, quorum queues support 32 strict priority levels (0–31) via `x-max-priority`. Replaced the drifted text with the authoritative copy from `docs/quorum-queues.md`'s Priorities section, preserving the existing `### Quorum Queues` heading.

Older versioned copies (3.13, 4.0, 4.1, 4.2) are left untouched since strict quorum queue priorities are a 4.3 feature.
