### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -337,6 +337,7 @@ const config = {
       },
     ],
     "./src/plugins/configure-svgo.js",
+    "docusaurus-plugin-copy-page-button",
   ],
 
   themeConfig:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mermaid-js/layout-elk": "^0.1.9",
         "clsx": "^2.1.1",
         "cookie": ">=0.7.0",
+        "docusaurus-plugin-copy-page-button": "^0.7.0",
         "docusaurus-theme-github-codeblock": "^2.0.2",
         "dompurify": ">=3.4.0",
         "path-to-regexp": ">=8.4.0",
@@ -5195,9 +5196,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5210,9 +5208,6 @@
       "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5227,9 +5222,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5242,9 +5234,6 @@
       "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5734,9 +5723,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5752,9 +5738,6 @@
       "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5772,9 +5755,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5790,9 +5770,6 @@
       "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5810,9 +5787,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5828,9 +5802,6 @@
       "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5976,9 +5947,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5994,9 +5962,6 @@
       "integrity": "sha512-gYi2ainYZV2z+jwjp9UKuPVOf3c5q+NkH3QRDjqDrIPLagqDsYNjobi8p5oajGcPGFLNTcVw08VTcubJGChReA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6014,9 +5979,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6032,9 +5994,6 @@
       "integrity": "sha512-Msx1eniw95lhMHUSe3D5FXweKHtkHtzJLsHJDj920uL4Dm7UHqzwaCuZdCmzbkHnO96YjjQvAm266djg8wupmQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6052,9 +6011,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6070,9 +6026,6 @@
       "integrity": "sha512-NSpZdbz4dj0pu1A0Z9l68Bll5HAzEMtBAeMe6jc4GEVfpIw6eeafQHm2/yMUEh09tgl8t9LzM9DycfdTZDjM4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -9662,6 +9615,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.7.0.tgz",
+      "integrity": "sha512-2YGcDHlgGjTuemVVqSBV7C7myT3aKo7PiNIPJH1zwy0ltE41qgS+wFHmEH8202SrQaszu9DYiAFEJ/TAGAL0WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/docusaurus-theme-github-codeblock": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/docusaurus-theme-github-codeblock/-/docusaurus-theme-github-codeblock-2.0.2.tgz",
@@ -12391,9 +12357,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12413,9 +12376,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12437,9 +12397,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12459,9 +12416,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mermaid-js/layout-elk": "^0.1.9",
     "clsx": "^2.1.1",
     "cookie": ">=0.7.0",
+    "docusaurus-plugin-copy-page-button": "^0.7.0",
     "docusaurus-theme-github-codeblock": "^2.0.2",
     "dompurify": ">=3.4.0",
     "path-to-regexp": ">=8.4.0",


### PR DESCRIPTION
## Summary

Adds [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to the RabbitMQ docs site so readers can copy any documentation page as clean markdown — useful when piping AMQP/streams/management plugin context into ChatGPT, Claude, Perplexity, or Gemini.

The plugin auto-injects a small "Copy page" button + dropdown into the doc page's table-of-contents area. The dropdown offers:

- Copy as markdown
- View as markdown
- Open in ChatGPT / Claude / Perplexity / Gemini

Live preview of the UI: https://portdeveloper.github.io/copy-page-button-showcase/

The button works across all six versioned editions (3.13, 4.0, 4.1, 4.2, 4.3, 4.4-dev) since auto-injection runs per page after Docusaurus's versioned routing.

## Adoption

The plugin currently ships on docs sites for React Native (via facebook/react-native-website#5085), PlayCanvas, Puppeteer, Arbitrum, Cardano, Sui, Ethereum execution-apis, and others — full list in the [project README](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button#used-by).

## Changes

- Added `"docusaurus-plugin-copy-page-button"` to the `plugins` array in `docusaurus.config.js`
- Added `docusaurus-plugin-copy-page-button@^0.7.0` to `dependencies`
- Resulting `package-lock.json` updates

`npm run build` passes locally (pre-existing broken-anchor warnings unrelated to this change still surface).

## Notes

The lockfile diff also shows incidental `"libc"` field removals on a handful of optional native deps. That's npm 10.9.8 (what I ran with) normalizing keys differently from the lockfile's original generator; happy to regenerate against a pinned npm version if maintainers prefer.