### PR TITLE
Fix typos in README and clarify queue name change in Go tutorial 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ The process involves one email and one online signature using a legally binding 
 
 Sorry about this annoyance and thank you!
 
-## ContributionWorkflow
+## Contribution Workflow
 
 ### TL;DR
 
 This repository contains documentation guides for multiple RabbitMQ release series.
 
-Therefore, the very first question to consder before making any changes is:
+Therefore, the very first question to consider before making any changes is:
 what editions (versions) does my change apply to? Should I update just the next release edition,
 all `4.x` ones or even `3.13.x`?
 
@@ -150,7 +150,7 @@ The RabbitMQ documentation is dual-licensed under the Apache License 2.0 and
 the Mozilla Public License 2.0. Users can choose any of these licenses
 according to their needs. However, **the blog is excluded from this license and
 remains the intellectual property of Broadcom Inc.** Blog posts may not be
-restributed.
+redistributed.
 
 ### SPDX
 

--- a/tutorials/tutorial-two-go-amqp10.md
+++ b/tutorials/tutorial-two-go-amqp10.md
@@ -63,10 +63,16 @@ will take three seconds.
 
 We will slightly modify the _send.go_ code from our previous example,
 to allow arbitrary messages to be sent from the command line. This
-program will schedule tasks to our work queue, so let's name it
-`new_task.go`:
+program will schedule tasks to a work queue named `task_queue`
+(instead of `hello`), so let's name the file `new_task.go`:
 
 ```go
+publisher, err := conn.NewPublisher(ctx, &rmq.QueueAddress{Queue: "task_queue"}, nil)
+if err != nil {
+	log.Panicf("Failed to create publisher: %v", err)
+}
+defer func() { _ = publisher.Close(context.Background()) }()
+
 body := bodyFrom(os.Args)
 res, err := publisher.Publish(ctx, rmq.NewMessage([]byte(body)))
 if err != nil {


### PR DESCRIPTION
- Fix three typos in README.md ("ContributionWorkflow" → "Contribution Workflow", "consder" → "consider", "restributed" → "redistributed")
- In the Go tutorial 2, add a sentence to explain the queue rename to `task_queue`, and include the previously omitted publisher initialization snippet for completeness