### PR TITLE
Add ocpp plugin to community plugins page

### DIFF
--- a/src/pages/community-plugins.md
+++ b/src/pages/community-plugins.md
@@ -216,4 +216,18 @@ here, [get in touch](/contact)!
       </ul>
     </td>
   </tr>
+
+  <tr>
+    <th>rabbitmq_web_ocpp</th>
+  </tr>
+  <tr>
+    <td>
+      Turns the broker into a highly-scalable, memory-efficient and low-latency gateway for EV charge stations. This plugin provides a native thin translator layer for OCPP-over-WebSockets to AMQP protocol. Both OCPP version 1.6J and 2.x are supported, including mTLS auth support for SecurityProfile 3.
+      <ul>
+        <li><a href="https://github.com/vampirebyte/rabbitmq-web-ocpp/releases">Releases</a></li>
+        <li>Authors: <b>Razvan Grigore</b></li>
+        <li>GitHub: <a href="https://github.com/vampirebyte/rabbitmq-web-ocpp">vampirebyte/rabbitmq-web-ocpp</a></li>
+      </ul>
+    </td>
+  </tr>
 </table>


### PR DESCRIPTION
Helllo,

Since last year we worked hard on the implementation and testing of our first Erlang plugin, heavily inspired by web_mqtt, called rabbitmq_web_ocpp: https://github.com/vampirebyte/rabbitmq-web-ocpp

We finally have a stable version, checked with multiple modern RabbitMQ versions and tested in real EV chargers backend setups (OCPP is the de-facto standard used by the whole industry, governed by OCA).

With some luck, my talk will be selected for MQSummit this year 🙂

Would love to have the plugin featured on the community page, I saw there are not so many 3rd party developers left doing this.

PS: We also plan to write another plugin for SSE browser protocol for streams.

Thank you in advance!
R
