### PR TITLE
change gradle configuration name from compile to implementation

### DIFF
--- a/client-libraries/java-client.md
+++ b/client-libraries/java-client.md
@@ -74,7 +74,7 @@ If using Gradle:
 
 ```groovy
 dependencies {
-  compile 'com.rabbitmq:amqp-client:5.31.0'
+  implementation 'com.rabbitmq:amqp-client:5.31.0'
 }
 ```
 


### PR DESCRIPTION
Since its 7.0 release, gradle has removed `compile` configuration for dependencies. Instead, `implementation` works
[https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal](url)

> The usage of the compile and runtime configurations in the Java ecosystem plugins has been discouraged since [Gradle 3.4](https://docs.gradle.org/3.4/release-notes.html#the-java-library-plugin).
Refer: [https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations](url)

> We strongly encourage users to migrate to this plugin, instead of the java plugin, whenever they are building a library. Some of the new configurations of this plugin are available to the java plugin too, and others are just deprecated.
instead of compile, you should use one of implementation or api
Refer: [https://docs.gradle.org/3.4/release-notes.html](url)

It seems safe to assume that most of the people referring to this documentation might be using Gradle version 3.4 and above

People using older versions in legacy systems might automatically stick to the `compile` keyword (or, should we add an explanation for both versions? - seems unnecessary considering this is the documentation of RabbitMQ and not a Gradle tutorial)