### PR TITLE
dlx: Add blurb on resource alarm behavior

### DIFF
--- a/docs/dlx.md
+++ b/docs/dlx.md
@@ -295,6 +295,20 @@ with configured dead-letter-exchange exchange 'amq.topic' in vhost 'my-vhost'
 and configured dead-letter-routing-key 'my-app.events.type.abc'
 ```
 
+### Dead Lettering and Resource Alarms {#dead-lettering-and-resource-alarms}
+
+Dead lettering is an internal operation: it is not subject to [resource alarm](./alarms)-triggered
+blocking of publishers. When a [disk alarm](./disk-alarms) is triggered, all connections that
+publish messages are blocked, but consumers can continue to deliver and reject (or nack) messages.
+
+This means that if consumers reject messages from a queue that has a dead letter exchange configured,
+the dead letter target queue will continue to grow even while the disk alarm is active.
+In the worst case, this can exhaust all remaining disk space.
+
+To guard against this, apply a [queue length limit](./maxlength) to dead letter target queues.
+With an `overflow` setting of `drop-head`, excess messages will be discarded
+rather than accumulating without bound.
+
 ### Re-Publishing with Publisher Confirms
 
 By default, dead-lettered messages are re-published *without* publisher


### PR DESCRIPTION
In some cases you can run past the disk limit by dead-lettering, especially because publishing is blocked. For example if you consume a message, do some work, and then publish another message, the stalled publish might cause a nack which results in dead lettering, growing the disk footprint. Rather than blocking dead lettering in disk/memory alarms I think it makes sense to document the behavior instead.

I only applied this to the main doc for now but when/if we're satisfied with the wording I can copy it to the other version directories.