### PR TITLE
Fix rabbitmqadmin list command syntax

### DIFF
--- a/versioned_docs/version-4.2/management-cli.md
+++ b/versioned_docs/version-4.2/management-cli.md
@@ -275,19 +275,19 @@ rabbitmqadmin show churn
 ### List Cluster Nodes
 
 ``` shell
-rabbitmqadmin nodes list
+rabbitmqadmin list nodes
 ```
 
 ### List Virtual Hosts
 
 ``` shell
-rabbitmqadmin vhosts list
+rabbitmqadmin list vhosts
 ```
 
 ### List Users
 
 ``` shell
-rabbitmqadmin users list
+rabbitmqadmin list users
 ```
 
 ### Create a User
@@ -360,31 +360,31 @@ rabbitmqadmin users connections --username "a-user"
 ### List Queues
 
 ``` shell
-rabbitmqadmin queues list
+rabbitmqadmin list queues
 ```
 
 ``` shell
-rabbitmqadmin --vhost "monitoring" queues list
+rabbitmqadmin --vhost "monitoring" list queues
 ```
 
 ### List Exchanges
 
 ``` shell
-rabbitmqadmin exchanges list
+rabbitmqadmin list exchanges
 ```
 
 ``` shell
-rabbitmqadmin --vhost "events" exchanges list
+rabbitmqadmin --vhost "events" list exchanges
 ```
 
 ### List Bindings
 
 ``` shell
-rabbitmqadmin bindings list
+rabbitmqadmin list bindings
 ```
 
 ``` shell
-rabbitmqadmin --vhost "events" bindings list
+rabbitmqadmin --vhost "events" list bindings
 ```
 
 ### Bind a Queue to an Exchange
@@ -669,12 +669,12 @@ rabbitmqadmin --vhost "events" exchanges delete --name "target.exchange.name" --
 ### List Connections
 
 ``` shell
-rabbitmqadmin connections list
+rabbitmqadmin list connections
 ```
 
 ``` shell
 # List connections for a specific virtual host
-rabbitmqadmin --vhost "events" connections list
+rabbitmqadmin --vhost "events" list connections
 ```
 
 ### Close a Connection
@@ -692,23 +692,23 @@ rabbitmqadmin users close_connections --name "a-user"
 ### List Channels
 
 ``` shell
-rabbitmqadmin channels list
+rabbitmqadmin list channels
 ```
 
 ``` shell
 # List channels in a specific virtual host
-rabbitmqadmin --vhost "events" channels list
+rabbitmqadmin --vhost "events" list channels
 ```
 
 ### List Consumers
 
 ```shell
-rabbitmqadmin consumers list
+rabbitmqadmin list consumers
 ```
 
 ```shell
 # List consumers in a specific virtual host
-rabbitmqadmin --vhost "events" consumers list
+rabbitmqadmin --vhost "events" list consumers
 ```
 
 ### Bind an Exchange to a Queue
@@ -1298,7 +1298,7 @@ This is useful for pre-computing password hashes for user management scripts or 
 ### List Policies
 
 ```shell
-rabbitmqadmin policies list
+rabbitmqadmin list policies
 ```
 
 ```shell
@@ -1432,7 +1432,7 @@ rabbitmqadmin policies delete_definition_keys_from_all \
 ### List Operator Policies
 
 ```shell
-rabbitmqadmin operator_policies list
+rabbitmqadmin list operator_policies
 ```
 
 ```shell


### PR DESCRIPTION
## Summary

  The `management-cli.md` page documented list commands using `<resource> list` syntax
  (e.g. `rabbitmqadmin queues list`) but the actual `rabbitmqadmin` tool uses
  `list <resource>` syntax.

  ## Evidence

  Running the incorrect syntax from the docs returns an error:

  $ ./rabbitmqadmin exchanges list
  ERROR: Action exchanges not understood

  The tool's built-in `help subcommands` output clearly shows the correct syntax:

  $ ./rabbitmqadmin help subcommands
  
  Display

    list connections [<column>...]
    list channels [<column>...]
    list consumers [<column>...]
    list exchanges [<column>...]
    list queues [<column>...]
    list bindings [<column>...]
    list users [<column>...]
    list vhosts [<column>...]
    list permissions [<column>...]
    list nodes [<column>...]
    list parameters [<column>...]
    list policies [<column>...]
    list operator_policies [<column>...]
    list vhost_limits [<column>...]
    show overview [<column>...]

  Both the error and the help output confirm that the correct syntax is
  `list <resource>`, not `<resource> list`.

  ## Changes

  Fixed all instances in `versioned_docs/version-4.2/management-cli.md`:

  | Before (incorrect) | After (correct) |
  |---|---|
  | `rabbitmqadmin queues list` | `rabbitmqadmin list queues` |
  | `rabbitmqadmin exchanges list` | `rabbitmqadmin list exchanges` |
  | `rabbitmqadmin bindings list` | `rabbitmqadmin list bindings` |
  | `rabbitmqadmin connections list` | `rabbitmqadmin list connections` |
  | `rabbitmqadmin channels list` | `rabbitmqadmin list channels` |
  | `rabbitmqadmin consumers list` | `rabbitmqadmin list consumers` |
  | `rabbitmqadmin nodes list` | `rabbitmqadmin list nodes` |
  | `rabbitmqadmin vhosts list` | `rabbitmqadmin list vhosts` |
  | `rabbitmqadmin users list` | `rabbitmqadmin list users` |
  | `rabbitmqadmin policies list` | `rabbitmqadmin list policies` |
  | `rabbitmqadmin operator_policies list` | `rabbitmqadmin list operator_policies` |
  
  Tested on RabbitMQ 4.2.1.
