### PR TITLE
update Kubernetes version recommendations to v1.29 - v1.32

### DIFF
--- a/kubernetes/operator/install-operator.md
+++ b/kubernetes/operator/install-operator.md
@@ -29,6 +29,7 @@ This guide covers the installation of the [RabbitMQ Cluster Kubernetes Operator]
 The Operator requires
 
 * Kubernetes 1.19 or later (1.25 or later versions are [recommended](/docs/memory-use#page-cache), in particular for environments that use [RabbitMQ Streams](/docs/streams))
+* The RabbitMQ Operators have been tested on Kubernetes v1.29 to v1.32.
 * [RabbitMQ DockerHub image](https://hub.docker.com/_/rabbitmq) that provides a [supported release series of RabbitMQ](/release-information)
 
 -----


### PR DESCRIPTION
Updated the installation guide to reflect the latest tested compatibility matrix (v1.29 to v1.32).