### PR TITLE
Doc update: strongly advise against manual CLI cluster formation

### DIFF
--- a/versioned_docs/version-4.3/clustering.md
+++ b/versioned_docs/version-4.3/clustering.md
@@ -635,14 +635,16 @@ case matters, and these strings must match exactly.
 Starting with RabbitMQ `4.1.0`, nodes no longer need to be stopped and reset
 before joining another node.
 
+
 `rabbitmqctl join_cluster` performs the necessary preparations.
 
 :::
 
 :::tip
 
-Consider using one of the [peer discovery mechanisms](./cluster-formation) instead
-of manual cluster formation with CLI tools.
+For production environments, it is strongly recommended to use one of the automated [peer discovery mechanisms](./cluster-formation) instead of manual cluster formation with CLI tools. 
+
+Manual cluster formation (`rabbitmqctl join_cluster`) is highly prone to human error and race conditions. Manual CLI joins should be strictly reserved for local development, testing, or specific edge-case recovery scenarios.
 
 :::
 


### PR DESCRIPTION
Updated the cluster formation documentation to explicitly recommend automated peer discovery for production environments. The previous wording ("Consider using...") was too soft and led users to rely on manual `rabbitmqctl join_cluster` commands in production. 

Added a warning that manual CLI joins are prone to human error. Discussed with Mirah.