### PR TITLE
Fix link to Broadcom Security Advisories

### DIFF
--- a/src/pages/security.mdx
+++ b/src/pages/security.mdx
@@ -30,12 +30,12 @@ Please do **not** report security vulnerabilities via public GitHub issues, publ
 
 #### For commercial Broadcom / VMware Tanzu Customers
 
-If you are a commercial customer using **VMware Tanzu RabbitMQ** or other commercial distributions, please refer to the [Broadcom Security Advisories](https://support.broadcom.com/web/ecx/security-advisory).
+If you are a commercial customer using **VMware Tanzu RabbitMQ** or other commercial distributions, please refer to the [Broadcom Security Advisories](https://support.broadcom.com/web/ecx/security-advisory?segment=VT).
 
 The Broadcom Support Portal is the authoritative source of truth for all commercial releases. It includes comprehensive vulnerability information, including CVEs in dependencies and underlying Erlang runtime that are not listed on this page.
 
 :::tip
-You can search the [Broadcom Security Advisories](https://support.broadcom.com/web/ecx/security-advisory) for a specific RabbitMQ version.
+You can search the [Broadcom Security Advisories](https://support.broadcom.com/web/ecx/security-advisory?segment=VT) for a specific RabbitMQ version.
 For example, if you type *RabbitMQ 4.2.8* into the search box, you will see the security advisory for that specific release.
 :::
 


### PR DESCRIPTION
The new URL links to `VT` (VMware Tanzu).