### PR TITLE
Remove Erlang 26 support claim

### DIFF
--- a/docs/which-erlang.md
+++ b/docs/which-erlang.md
@@ -149,11 +149,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           <li>
             The 4.0 release series is compatible with Erlang 26.2.
           </li>
-          :::important
-
-            RabbitMQ versions prior to 4.0.4 are not compatible with Erlang 27.
-
-          :::
         </ul>
       </td>
     </tr>

--- a/docs/which-erlang.md
+++ b/docs/which-erlang.md
@@ -42,7 +42,7 @@ During a transition period of a few months after a new major Erlang/OTP release 
 and the previous oldest series can be supported for a few months in addition
 to the two most recent series.
 
-At the moment the fully supported series are Erlang `27.x` and `26.x`.
+At the moment the fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
 
 ### Erlang 29 Support
 
@@ -50,7 +50,7 @@ Erlang 29 is **not supported** by RabbitMQ 4.3.
 
 ### Erlang 28 Support
 
-Erlang 28 is **partially supported** by RabbitMQ 4.3.x: upgrades of clusters running Khepri has known issues
+Erlang 28 is **partially supported** by RabbitMQ 4.3.x: upgrades of clusters running Khepri have known issues
 directly related to the breaking changes in Erlang 28 that equally affect Erlang 29.
 
 ### Erlang 27 Support
@@ -60,6 +60,9 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 ### Erlang 26 Support
 
 Erlang 26 is supported starting with RabbitMQ 3.12.0.
+
+Erlang 26 [reached end of life on May 26, 2026](https://endoflife.date/erlang) and is
+**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
@@ -102,7 +105,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>26.2</li>
+          <li>27.0</li>
         </ul>
       </td>
       <td>
@@ -123,7 +126,11 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             to Erlang 28 have a known issue that affects rolling upgrades.
           </li>
           <li>
-            The starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+            Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+          </li>
+          <li>
+            Erlang 26 <a href="https://endoflife.date/erlang">reached end of life on May 26, 2026</a> and is no longer supported.
+            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -199,7 +206,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature and ready for production use.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -239,7 +246,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature enough for production.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -414,7 +421,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `25.x`).
+(e.g. `27.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/docs/which-erlang.md
+++ b/docs/which-erlang.md
@@ -59,12 +59,8 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 ### Erlang 26 Support
 
-Erlang 26 is supported starting with RabbitMQ 3.12.0.
-
-Erlang 26 [reached end of life on May 26, 2026](https://endoflife.date/erlang) and is
+Erlang 26 has reached end of life and is
 **no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
-
-
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
 The table below provides an Erlang compatibility matrix of currently supported RabbitMQ release series.
@@ -129,7 +125,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
           </li>
           <li>
-            Erlang 26 <a href="https://endoflife.date/erlang">reached end of life on May 26, 2026</a> and is no longer supported.
+            Erlang 26 has reached end of life and is no longer supported.
             The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>

--- a/docs/which-erlang.md
+++ b/docs/which-erlang.md
@@ -36,13 +36,7 @@ to Erlang 28 have a known issue that affects rolling upgrades.
 
 ## Supported Erlang Version Policy {#supported-version-policy}
 
-RabbitMQ generally supports up to [two most recent Erlang release series](https://groups.google.com/d/msg/rabbitmq-users/G4UJ9zbIYHs/qCeyjkjyCQAJ).
-
-During a transition period of a few months after a new major Erlang/OTP release comes out, usually May to August every calendar year, the newest series won't be immediately supported
-and the previous oldest series can be supported for a few months in addition
-to the two most recent series.
-
-At the moment the fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
+The fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
 
 ### Erlang 29 Support
 
@@ -55,12 +49,13 @@ directly related to the breaking changes in Erlang 28 that equally affect Erlang
 
 ### Erlang 27 Support
 
-Erlang 27 is supported starting with RabbitMQ 4.0.4.
+Erlang 27 is supported.
 
 ### Erlang 26 Support
 
 Erlang 26 has reached end of life and is
-**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
+**no longer supported**.
+
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
 The table below provides an Erlang compatibility matrix of currently supported RabbitMQ release series.
@@ -111,7 +106,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul class="notes">
-        <li>
+          <li>
             Erlang 29 is not supported by RabbitMQ.
           </li>
           <li>
@@ -126,7 +121,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
           <li>
             Erlang 26 has reached end of life and is no longer supported.
-            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -206,6 +200,75 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
         </ul>
       </td>
+    </tr>
+</table>
+
+As a guideline, most recent minor and patch versions of each supported Erlang/OTP series
+are recommended.
+
+## Provisioning Latest Erlang Releases {#erlang-repositories}
+
+Most recent versions can be obtained from a number of sources:
+
+ * [Team RabbitMQ Debian repositories](install-debian#apt-repositories) or [Launchpad](install-debian#apt-launchpad-erlang)
+ * [Zero dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from Team RabbitMQ, also available [from a `dnf`/`yum` repository](install-rpm#dnf-repositories)
+ * As part of [RabbitMQ Docker image](https://github.com/docker-library/rabbitmq/)
+ * [erlang.org](https://www.erlang.org/downloads#prebuilt) provides binary builds of patch releases for Windows
+ * Building from source with [kerl](https://github.com/kerl/kerl)
+
+## Installing Erlang/OTP on Debian or Ubuntu {#debian}
+
+Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
+heavily sliced and diced into dozens of packages. In addition, unless the system
+has backport repositories enabled, the versions tend to be quite old.
+See [Debian and Ubuntu installation guide](./install-debian) for
+more information on the essential packages, dependencies, and alternative apt repositories.
+
+## Installing Erlang/OTP on RHEL, CentOS and Fedora {#redhat}
+
+There are multiple RPM packages available for Erlang/OTP. The recommended option is
+the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
+It closely follows the latest Erlang/OTP patch release schedule.
+
+See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more information on the available options.
+
+
+## Erlang Versions in Clusters {#clusters}
+
+It is **highly recommended** that the same major version of
+Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
+(e.g. `27.x`).
+
+RabbitMQ will check for internal protocol versions of
+Erlang and its distributed libraries when a node joins a
+cluster, refusing to cluster if there's a potentially
+incompatible combination detected.
+
+Outside of a reasonably long upgrade time window, it is
+recommended that all nodes use exactly the same version of Erlang.
+
+
+## Building Erlang from Source {#building-from-source}
+
+If a sufficiently recent Erlang package is not available for a given operating system,
+Erlang/OTP can be [built from source](http://www.erlang.org/doc/installation_guide/INSTALL.html).
+This requires a build environment that satisfies the Erlang build dependencies, such as a
+modern OpenSSL version.
+
+[kerl](https://github.com/kerl/kerl) makes building Erlang/OTP releases from
+source, including specific tags from GitHub, a much more pleasant experience.
+
+
+## Older RabbitMQ and Erlang Releases {#old-timers}
+
+### Unsupported RabbitMQ Series {#eol-series}
+
+<table class="matrix">
+    <tr>
+      <th><a href="/release-information">Unsupported RabbitMQ Series</a></th>
+      <th>Minimum required Erlang/OTP</th>
+      <th>Maximum supported Erlang/OTP</th>
+      <th>Notes</th>
     </tr>
 
     <tr>
@@ -380,75 +443,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
         </ul>
       </td>
-    </tr>
-</table>
-
-As a guideline, most recent minor and patch versions of each supported Erlang/OTP series
-are recommended.
-
-## Provisioning Latest Erlang Releases {#erlang-repositories}
-
-Most recent versions can be obtained from a number of sources:
-
- * [Team RabbitMQ Debian repositories](install-debian#apt-repositories) or [Launchpad](install-debian#apt-launchpad-erlang)
- * [Zero dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from Team RabbitMQ, also available [from a `dnf`/`yum` repository](install-rpm#dnf-repositories)
- * As part of [RabbitMQ Docker image](https://github.com/docker-library/rabbitmq/)
- * [erlang.org](https://www.erlang.org/downloads#prebuilt) provides binary builds of patch releases for Windows
- * Building from source with [kerl](https://github.com/kerl/kerl)
-
-## Installing Erlang/OTP on Debian or Ubuntu {#debian}
-
-Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
-heavily sliced and diced into dozens of packages. In addition, unless the system
-has backport repositories enabled, the versions tend to be quite old.
-See [Debian and Ubuntu installation guide](./install-debian) for
-more information on the essential packages, dependencies, and alternative apt repositories.
-
-## Installing Erlang/OTP on RHEL, CentOS and Fedora {#redhat}
-
-There are multiple RPM packages available for Erlang/OTP. The recommended option is
-the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
-It closely follows the latest Erlang/OTP patch release schedule.
-
-See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more information on the available options.
-
-
-## Erlang Versions in Clusters {#clusters}
-
-It is **highly recommended** that the same major version of
-Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `27.x`).
-
-RabbitMQ will check for internal protocol versions of
-Erlang and its distributed libraries when a node joins a
-cluster, refusing to cluster if there's a potentially
-incompatible combination detected.
-
-Outside of a reasonably long upgrade time window, it is
-recommended that all nodes use exactly the same version of Erlang.
-
-
-## Building Erlang from Source {#building-from-source}
-
-If a sufficiently recent Erlang package is not available for a given operating system,
-Erlang/OTP can be [built from source](http://www.erlang.org/doc/installation_guide/INSTALL.html).
-This requires a build environment that satisfies the Erlang build dependencies, such as a
-modern OpenSSL version.
-
-[kerl](https://github.com/kerl/kerl) makes building Erlang/OTP releases from
-source, including specific tags from GitHub, a much more pleasant experience.
-
-
-## Older RabbitMQ and Erlang Releases {#old-timers}
-
-### Unsupported RabbitMQ Series {#eol-series}
-
-<table class="matrix">
-    <tr>
-      <th><a href="/release-information">Unsupported RabbitMQ Series</a></th>
-      <th>Minimum required Erlang/OTP</th>
-      <th>Maximum supported Erlang/OTP</th>
-      <th>Notes</th>
     </tr>
 
     <tr>

--- a/versioned_docs/version-3.13/which-erlang.md
+++ b/versioned_docs/version-3.13/which-erlang.md
@@ -41,7 +41,7 @@ During a transition period of a few months after a new major Erlang/OTP release 
 and the previous oldest series can be supported for a few months in addition
 to the two most recent series.
 
-At the moment the supported series are Erlang `27.x` and `26.x`.
+At the moment the supported series is Erlang `27.x`.
 
 ### Erlang 29 Support
 
@@ -58,8 +58,8 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 ### Erlang 26 Support
 
-Erlang 26 is supported starting with RabbitMQ 3.12.0.
-
+Erlang 26 has reached end of life and is
+**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -115,7 +115,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       be mature and ready for production use.
       </li>
       <li>
-      Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+      Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
       </li>
       </ul>
       </td>
@@ -155,7 +155,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       be mature enough for production.
       </li>
       <li>
-      Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+      Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
       </li>
       </ul>
       </td>
@@ -332,7 +332,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `25.x`).
+(e.g. `27.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-3.13/which-erlang.md
+++ b/versioned_docs/version-3.13/which-erlang.md
@@ -35,13 +35,7 @@ Erlang 28 is not supported by RabbitMQ 3.13.x.
 
 ## Supported Erlang Version Policy {#supported-version-policy}
 
-RabbitMQ generally supports up to [two most recent Erlang release series](https://groups.google.com/d/msg/rabbitmq-users/G4UJ9zbIYHs/qCeyjkjyCQAJ).
-
-During a transition period of a few months after a new major Erlang/OTP release comes out, usually May to August every calendar year, the newest series won't be immediately supported
-and the previous oldest series can be supported for a few months in addition
-to the two most recent series.
-
-At the moment the supported series is Erlang `27.x`.
+Supported series are Erlang `27.x` and `26.x`.
 
 ### Erlang 29 Support
 
@@ -54,12 +48,11 @@ and is not currently supported by RabbitMQ.
 
 ### Erlang 27 Support
 
-Erlang 27 is supported starting with RabbitMQ 4.0.4.
+Erlang 27 is supported.
 
 ### Erlang 26 Support
 
-Erlang 26 has reached end of life and is
-**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
+Erlang 26 is supported starting with RabbitMQ 3.12.0.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -79,7 +72,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
     <tr>
       <td>
       <ul>
-      <li><a href="https://www.rabbitmq.com/blog/2025/02/07/rabbitmq-3.13.8-is-released">3.13.8</a></li>
       <li>3.13.7</li>
       <li>3.13.6</li>
       <li>3.13.5</li>
@@ -332,7 +324,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `27.x`).
+(e.g. `25.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.0/which-erlang.md
+++ b/versioned_docs/version-4.0/which-erlang.md
@@ -35,13 +35,7 @@ Erlang 28 is not supported by RabbitMQ 4.0.x.
 
 ## Supported Erlang Version Policy {#supported-version-policy}
 
-RabbitMQ generally supports up to [two most recent Erlang release series](https://groups.google.com/d/msg/rabbitmq-users/G4UJ9zbIYHs/qCeyjkjyCQAJ).
-
-During a transition period of a few months after a new major Erlang/OTP release comes out, usually May to August every calendar year, the newest series won't be immediately supported
-and the previous oldest series can be supported for a few months in addition
-to the two most recent series.
-
-At the moment the supported series is Erlang `27.x`.
+The supported series are Erlang `27.x` and `26.x`.
 
 ### Erlang 29 Support
 
@@ -54,12 +48,11 @@ and is not currently supported by RabbitMQ.
 
 ### Erlang 27 Support
 
-Erlang 27 is supported starting with RabbitMQ 4.0.4.
+Erlang 27 is supported.
 
 ### Erlang 26 Support
 
-Erlang 26 has reached end of life and is
-**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
+Erlang 26 is supported starting with RabbitMQ 3.12.0.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -95,7 +88,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>27.0</li>
+          <li>26.2</li>
         </ul>
       </td>
       <td>
@@ -110,10 +103,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
           <li>
             Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
-          </li>
-          <li>
-            Erlang 26 has reached end of life and is no longer supported.
-            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -400,7 +389,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `27.x`).
+(e.g. `25.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.0/which-erlang.md
+++ b/versioned_docs/version-4.0/which-erlang.md
@@ -130,11 +130,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           <li>
             The 4.0 release series is compatible with Erlang 26.2.
           </li>
-          :::important
-
-            RabbitMQ versions prior to 4.0.4 are not compatible with Erlang 27.
-
-          :::
         </ul>
       </td>
     </tr>

--- a/versioned_docs/version-4.0/which-erlang.md
+++ b/versioned_docs/version-4.0/which-erlang.md
@@ -41,7 +41,7 @@ During a transition period of a few months after a new major Erlang/OTP release 
 and the previous oldest series can be supported for a few months in addition
 to the two most recent series.
 
-At the moment the supported series are Erlang `27.x` and `26.x`.
+At the moment the supported series is Erlang `27.x`.
 
 ### Erlang 29 Support
 
@@ -58,8 +58,8 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 ### Erlang 26 Support
 
-Erlang 26 is supported starting with RabbitMQ 3.12.0.
-
+Erlang 26 has reached end of life and is
+**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -95,7 +95,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>26.2</li>
+          <li>27.0</li>
         </ul>
       </td>
       <td>
@@ -109,7 +109,11 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             Erlang 28 is not currently supported by RabbitMQ.
           </li>
           <li>
-            The starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+            Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+          </li>
+          <li>
+            Erlang 26 has reached end of life and is no longer supported.
+            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -183,7 +187,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature and ready for production use.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -222,7 +226,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature enough for production.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -396,7 +400,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `25.x`).
+(e.g. `27.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.1/which-erlang.md
+++ b/versioned_docs/version-4.1/which-erlang.md
@@ -58,8 +58,6 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 ### Erlang 26 Support
 
-Erlang 26 is supported starting with RabbitMQ 3.12.0.
-
 Erlang 26 has reached end of life and is
 **no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 

--- a/versioned_docs/version-4.1/which-erlang.md
+++ b/versioned_docs/version-4.1/which-erlang.md
@@ -35,13 +35,7 @@ Erlang 28 is not supported by RabbitMQ 4.1.x.
 
 ## Supported Erlang Version Policy {#supported-version-policy}
 
-RabbitMQ generally supports up to [two most recent Erlang release series](https://groups.google.com/d/msg/rabbitmq-users/G4UJ9zbIYHs/qCeyjkjyCQAJ).
-
-During a transition period of a few months after a new major Erlang/OTP release comes out, usually May to August every calendar year, the newest series won't be immediately supported
-and the previous oldest series can be supported for a few months in addition
-to the two most recent series.
-
-At the moment the supported series is Erlang `27.x`.
+The supported series are Erlang `27.x` and `26.x`.
 
 ### Erlang 29 Support
 
@@ -54,12 +48,11 @@ and is not currently supported by RabbitMQ.
 
 ### Erlang 27 Support
 
-Erlang 27 is supported starting with RabbitMQ 4.0.4.
+Erlang 27 is supported.
 
 ### Erlang 26 Support
 
-Erlang 26 has reached end of life and is
-**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
+Erlang 26 is supported starting with RabbitMQ 3.12.0.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -105,7 +98,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>27.0</li>
+          <li>26.2</li>
         </ul>
       </td>
       <td>
@@ -120,10 +113,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
           <li>
             Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
-          </li>
-          <li>
-            Erlang 26 has reached end of life and is no longer supported.
-            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -410,7 +399,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `27.x`).
+(e.g. `25.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.1/which-erlang.md
+++ b/versioned_docs/version-4.1/which-erlang.md
@@ -41,7 +41,7 @@ During a transition period of a few months after a new major Erlang/OTP release 
 and the previous oldest series can be supported for a few months in addition
 to the two most recent series.
 
-At the moment the supported series are Erlang `27.x` and `26.x`.
+At the moment the supported series is Erlang `27.x`.
 
 ### Erlang 29 Support
 
@@ -60,6 +60,8 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 Erlang 26 is supported starting with RabbitMQ 3.12.0.
 
+Erlang 26 has reached end of life and is
+**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -105,7 +107,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>26.2</li>
+          <li>27.0</li>
         </ul>
       </td>
       <td>
@@ -119,7 +121,11 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             Erlang 28 is not supported by RabbitMQ 4.1.x.
           </li>
           <li>
-            The starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+            Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+          </li>
+          <li>
+            Erlang 26 has reached end of life and is no longer supported.
+            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -193,7 +199,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature and ready for production use.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -232,7 +238,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature enough for production.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -406,7 +412,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `25.x`).
+(e.g. `27.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.1/which-erlang.md
+++ b/versioned_docs/version-4.1/which-erlang.md
@@ -140,11 +140,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           <li>
             The 4.0 release series is compatible with Erlang 26.2.
           </li>
-          :::important
-
-            RabbitMQ versions prior to 4.0.4 are not compatible with Erlang 27.
-
-          :::
         </ul>
       </td>
     </tr>

--- a/versioned_docs/version-4.2/which-erlang.md
+++ b/versioned_docs/version-4.2/which-erlang.md
@@ -42,7 +42,7 @@ During a transition period of a few months after a new major Erlang/OTP release 
 and the previous oldest series can be supported for a few months in addition
 to the two most recent series.
 
-At the moment the fully supported series are Erlang `27.x` and `26.x`.
+At the moment the fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
 
 ### Erlang 29 Support
 
@@ -50,7 +50,7 @@ Erlang 29 is **not supported** by RabbitMQ 4.2.
 
 ### Erlang 28 Support
 
-Erlang 28 is **partially supported** by RabbitMQ 4.2.x: upgrades of clusters running Khepri has known issues
+Erlang 28 is **partially supported** by RabbitMQ 4.2.x: upgrades of clusters running Khepri have known issues
 directly related to the breaking changes in Erlang 28 that equally affect Erlang 29.
 
 ### Erlang 27 Support
@@ -61,6 +61,8 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 Erlang 26 is supported starting with RabbitMQ 3.12.0.
 
+Erlang 26 has reached end of life and is
+**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -89,7 +91,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>26.2</li>
+          <li>27.0</li>
         </ul>
       </td>
       <td>
@@ -105,6 +107,10 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           <li>
             Erlang 28 is **only supported for brand new clusters**: upgrades of clusters running RabbitMQ with Khepri on Erlang 27
             to Erlang 28 have a known issue that affects rolling upgrades.
+          </li>
+          <li>
+            Erlang 26 has reached end of life and is no longer supported.
+            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -129,7 +135,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>26.2</li>
+          <li>27.0</li>
         </ul>
       </td>
       <td>
@@ -143,7 +149,11 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             Erlang 28 is not supported by RabbitMQ versions before `4.2.0`.
           </li>
           <li>
-            The starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+            Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+          </li>
+          <li>
+            Erlang 26 has reached end of life and is no longer supported.
+            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -219,7 +229,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature and ready for production use.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -259,7 +269,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature enough for production.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -434,7 +444,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `25.x`).
+(e.g. `27.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.2/which-erlang.md
+++ b/versioned_docs/version-4.2/which-erlang.md
@@ -36,13 +36,7 @@ to Erlang 28 have a known issue that affects rolling upgrades.
 
 ## Supported Erlang Version Policy {#supported-version-policy}
 
-RabbitMQ generally supports up to [two most recent Erlang release series](https://groups.google.com/d/msg/rabbitmq-users/G4UJ9zbIYHs/qCeyjkjyCQAJ).
-
-During a transition period of a few months after a new major Erlang/OTP release comes out, usually May to August every calendar year, the newest series won't be immediately supported
-and the previous oldest series can be supported for a few months in addition
-to the two most recent series.
-
-At the moment the fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
+The fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
 
 ### Erlang 29 Support
 
@@ -55,12 +49,12 @@ directly related to the breaking changes in Erlang 28 that equally affect Erlang
 
 ### Erlang 27 Support
 
-Erlang 27 is supported starting with RabbitMQ 4.0.4.
+Erlang 27 is supported.
 
 ### Erlang 26 Support
 
 Erlang 26 has reached end of life and is
-**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
+**no longer supported**.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -108,7 +102,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
           <li>
             Erlang 26 has reached end of life and is no longer supported.
-            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -151,7 +144,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
           <li>
             Erlang 26 has reached end of life and is no longer supported.
-            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -231,6 +223,75 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
         </ul>
       </td>
+    </tr>
+</table>
+
+As a guideline, most recent minor and patch versions of each supported Erlang/OTP series
+are recommended.
+
+## Provisioning Latest Erlang Releases {#erlang-repositories}
+
+Most recent versions can be obtained from a number of sources:
+
+ * [Team RabbitMQ Debian repositories](install-debian#apt-repositories) or [Launchpad](install-debian#apt-launchpad-erlang)
+ * [Zero dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from Team RabbitMQ, also available [from a `dnf`/`yum` repository](install-rpm#dnf-repositories)
+ * As part of [RabbitMQ Docker image](https://github.com/docker-library/rabbitmq/)
+ * [erlang.org](https://www.erlang.org/downloads#prebuilt) provides binary builds of patch releases for Windows
+ * Building from source with [kerl](https://github.com/kerl/kerl)
+
+## Installing Erlang/OTP on Debian or Ubuntu {#debian}
+
+Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
+heavily sliced and diced into dozens of packages. In addition, unless the system
+has backport repositories enabled, the versions tend to be quite old.
+See [Debian and Ubuntu installation guide](./install-debian) for
+more information on the essential packages, dependencies, and alternative apt repositories.
+
+## Installing Erlang/OTP on RHEL, CentOS and Fedora {#redhat}
+
+There are multiple RPM packages available for Erlang/OTP. The recommended option is
+the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
+It closely follows the latest Erlang/OTP patch release schedule.
+
+See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more information on the available options.
+
+
+## Erlang Versions in Clusters {#clusters}
+
+It is **highly recommended** that the same major version of
+Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
+(e.g. `27.x`).
+
+RabbitMQ will check for internal protocol versions of
+Erlang and its distributed libraries when a node joins a
+cluster, refusing to cluster if there's a potentially
+incompatible combination detected.
+
+Outside of a reasonably long upgrade time window, it is
+recommended that all nodes use exactly the same version of Erlang.
+
+
+## Building Erlang from Source {#building-from-source}
+
+If a sufficiently recent Erlang package is not available for a given operating system,
+Erlang/OTP can be [built from source](http://www.erlang.org/doc/installation_guide/INSTALL.html).
+This requires a build environment that satisfies the Erlang build dependencies, such as a
+modern OpenSSL version.
+
+[kerl](https://github.com/kerl/kerl) makes building Erlang/OTP releases from
+source, including specific tags from GitHub, a much more pleasant experience.
+
+
+## Older RabbitMQ and Erlang Releases {#old-timers}
+
+### Unsupported RabbitMQ Series {#eol-series}
+
+<table class="matrix">
+    <tr>
+      <th><a href="/release-information">Unsupported RabbitMQ Series</a></th>
+      <th>Minimum required Erlang/OTP</th>
+      <th>Maximum supported Erlang/OTP</th>
+      <th>Notes</th>
     </tr>
 
     <tr>
@@ -405,75 +466,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
         </ul>
       </td>
-    </tr>
-</table>
-
-As a guideline, most recent minor and patch versions of each supported Erlang/OTP series
-are recommended.
-
-## Provisioning Latest Erlang Releases {#erlang-repositories}
-
-Most recent versions can be obtained from a number of sources:
-
- * [Team RabbitMQ Debian repositories](install-debian#apt-repositories) or [Launchpad](install-debian#apt-launchpad-erlang)
- * [Zero dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from Team RabbitMQ, also available [from a `dnf`/`yum` repository](install-rpm#dnf-repositories)
- * As part of [RabbitMQ Docker image](https://github.com/docker-library/rabbitmq/)
- * [erlang.org](https://www.erlang.org/downloads#prebuilt) provides binary builds of patch releases for Windows
- * Building from source with [kerl](https://github.com/kerl/kerl)
-
-## Installing Erlang/OTP on Debian or Ubuntu {#debian}
-
-Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
-heavily sliced and diced into dozens of packages. In addition, unless the system
-has backport repositories enabled, the versions tend to be quite old.
-See [Debian and Ubuntu installation guide](./install-debian) for
-more information on the essential packages, dependencies, and alternative apt repositories.
-
-## Installing Erlang/OTP on RHEL, CentOS and Fedora {#redhat}
-
-There are multiple RPM packages available for Erlang/OTP. The recommended option is
-the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
-It closely follows the latest Erlang/OTP patch release schedule.
-
-See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more information on the available options.
-
-
-## Erlang Versions in Clusters {#clusters}
-
-It is **highly recommended** that the same major version of
-Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `27.x`).
-
-RabbitMQ will check for internal protocol versions of
-Erlang and its distributed libraries when a node joins a
-cluster, refusing to cluster if there's a potentially
-incompatible combination detected.
-
-Outside of a reasonably long upgrade time window, it is
-recommended that all nodes use exactly the same version of Erlang.
-
-
-## Building Erlang from Source {#building-from-source}
-
-If a sufficiently recent Erlang package is not available for a given operating system,
-Erlang/OTP can be [built from source](http://www.erlang.org/doc/installation_guide/INSTALL.html).
-This requires a build environment that satisfies the Erlang build dependencies, such as a
-modern OpenSSL version.
-
-[kerl](https://github.com/kerl/kerl) makes building Erlang/OTP releases from
-source, including specific tags from GitHub, a much more pleasant experience.
-
-
-## Older RabbitMQ and Erlang Releases {#old-timers}
-
-### Unsupported RabbitMQ Series {#eol-series}
-
-<table class="matrix">
-    <tr>
-      <th><a href="/release-information">Unsupported RabbitMQ Series</a></th>
-      <th>Minimum required Erlang/OTP</th>
-      <th>Maximum supported Erlang/OTP</th>
-      <th>Notes</th>
     </tr>
 
     <tr>

--- a/versioned_docs/version-4.2/which-erlang.md
+++ b/versioned_docs/version-4.2/which-erlang.md
@@ -172,11 +172,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           <li>
             The 4.0 release series is compatible with Erlang 26.2.
           </li>
-          :::important
-
-            RabbitMQ versions prior to 4.0.4 are not compatible with Erlang 27.
-
-          :::
         </ul>
       </td>
     </tr>

--- a/versioned_docs/version-4.2/which-erlang.md
+++ b/versioned_docs/version-4.2/which-erlang.md
@@ -59,8 +59,6 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 ### Erlang 26 Support
 
-Erlang 26 is supported starting with RabbitMQ 3.12.0.
-
 Erlang 26 has reached end of life and is
 **no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 

--- a/versioned_docs/version-4.3/which-erlang.md
+++ b/versioned_docs/version-4.3/which-erlang.md
@@ -42,7 +42,7 @@ During a transition period of a few months after a new major Erlang/OTP release 
 and the previous oldest series can be supported for a few months in addition
 to the two most recent series.
 
-At the moment the fully supported series are Erlang `27.x` and `26.x`.
+At the moment the fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
 
 ### Erlang 29 Support
 
@@ -50,7 +50,7 @@ Erlang 29 is **not supported** by RabbitMQ 4.3.
 
 ### Erlang 28 Support
 
-Erlang 28 is **partially supported** by RabbitMQ 4.3.x: upgrades of clusters running Khepri has known issues
+Erlang 28 is **partially supported** by RabbitMQ 4.3.x: upgrades of clusters running Khepri have known issues
 directly related to the breaking changes in Erlang 28 that equally affect Erlang 29.
 
 ### Erlang 27 Support
@@ -61,6 +61,8 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 Erlang 26 is supported starting with RabbitMQ 3.12.0.
 
+Erlang 26 has reached end of life and is
+**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -103,7 +105,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
       </td>
       <td>
         <ul>
-          <li>26.2</li>
+          <li>27.0</li>
         </ul>
       </td>
       <td>
@@ -121,7 +123,11 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             to Erlang 28 have a known issue that affects rolling upgrades.
           </li>
           <li>
-            The starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+            Starting with the 4.0.4 release, the 4.0.x release series is compatible with Erlang 27.
+          </li>
+          <li>
+            Erlang 26 has reached end of life and is no longer supported.
+            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -197,7 +203,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature and ready for production use.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -237,7 +243,7 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
             be mature enough for production.
           </li>
           <li>
-            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">supports FIPS mode on OpenSSL 3</a>
+            Erlang 26.1 and later versions <a href="https://github.com/erlang/otp/pull/7392">support FIPS mode on OpenSSL 3</a>
           </li>
         </ul>
       </td>
@@ -412,7 +418,7 @@ See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more informa
 
 It is **highly recommended** that the same major version of
 Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `25.x`).
+(e.g. `27.x`).
 
 RabbitMQ will check for internal protocol versions of
 Erlang and its distributed libraries when a node joins a

--- a/versioned_docs/version-4.3/which-erlang.md
+++ b/versioned_docs/version-4.3/which-erlang.md
@@ -59,8 +59,6 @@ Erlang 27 is supported starting with RabbitMQ 4.0.4.
 
 ### Erlang 26 Support
 
-Erlang 26 is supported starting with RabbitMQ 3.12.0.
-
 Erlang 26 has reached end of life and is
 **no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
 

--- a/versioned_docs/version-4.3/which-erlang.md
+++ b/versioned_docs/version-4.3/which-erlang.md
@@ -147,11 +147,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           <li>
             The 4.0 release series is compatible with Erlang 26.2.
           </li>
-          :::important
-
-            RabbitMQ versions prior to 4.0.4 are not compatible with Erlang 27.
-
-          :::
         </ul>
       </td>
     </tr>

--- a/versioned_docs/version-4.3/which-erlang.md
+++ b/versioned_docs/version-4.3/which-erlang.md
@@ -36,13 +36,7 @@ to Erlang 28 have a known issue that affects rolling upgrades.
 
 ## Supported Erlang Version Policy {#supported-version-policy}
 
-RabbitMQ generally supports up to [two most recent Erlang release series](https://groups.google.com/d/msg/rabbitmq-users/G4UJ9zbIYHs/qCeyjkjyCQAJ).
-
-During a transition period of a few months after a new major Erlang/OTP release comes out, usually May to August every calendar year, the newest series won't be immediately supported
-and the previous oldest series can be supported for a few months in addition
-to the two most recent series.
-
-At the moment the fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
+The fully supported series is Erlang `27.x`, with `28.x` partially supported (see below).
 
 ### Erlang 29 Support
 
@@ -55,12 +49,12 @@ directly related to the breaking changes in Erlang 28 that equally affect Erlang
 
 ### Erlang 27 Support
 
-Erlang 27 is supported starting with RabbitMQ 4.0.4.
+Erlang 27 is supported.
 
 ### Erlang 26 Support
 
 Erlang 26 has reached end of life and is
-**no longer supported**. Users still running Erlang 26 should upgrade to Erlang 27 or 28.
+**no longer supported**.
 
 ## RabbitMQ and Erlang/OTP Compatibility Matrix {#compatibility-matrix}
 
@@ -125,7 +119,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
           <li>
             Erlang 26 has reached end of life and is no longer supported.
-            The minimum required Erlang/OTP version was raised to 27.0 as a result.
           </li>
         </ul>
       </td>
@@ -205,6 +198,75 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
         </ul>
       </td>
+    </tr>
+</table>
+
+As a guideline, most recent minor and patch versions of each supported Erlang/OTP series
+are recommended.
+
+## Provisioning Latest Erlang Releases {#erlang-repositories}
+
+Most recent versions can be obtained from a number of sources:
+
+ * [Team RabbitMQ Debian repositories](install-debian#apt-repositories) or [Launchpad](install-debian#apt-launchpad-erlang)
+ * [Zero dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from Team RabbitMQ, also available [from a `dnf`/`yum` repository](install-rpm#dnf-repositories)
+ * As part of [RabbitMQ Docker image](https://github.com/docker-library/rabbitmq/)
+ * [erlang.org](https://www.erlang.org/downloads#prebuilt) provides binary builds of patch releases for Windows
+ * Building from source with [kerl](https://github.com/kerl/kerl)
+
+## Installing Erlang/OTP on Debian or Ubuntu {#debian}
+
+Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
+heavily sliced and diced into dozens of packages. In addition, unless the system
+has backport repositories enabled, the versions tend to be quite old.
+See [Debian and Ubuntu installation guide](./install-debian) for
+more information on the essential packages, dependencies, and alternative apt repositories.
+
+## Installing Erlang/OTP on RHEL, CentOS and Fedora {#redhat}
+
+There are multiple RPM packages available for Erlang/OTP. The recommended option is
+the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
+It closely follows the latest Erlang/OTP patch release schedule.
+
+See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more information on the available options.
+
+
+## Erlang Versions in Clusters {#clusters}
+
+It is **highly recommended** that the same major version of
+Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
+(e.g. `27.x`).
+
+RabbitMQ will check for internal protocol versions of
+Erlang and its distributed libraries when a node joins a
+cluster, refusing to cluster if there's a potentially
+incompatible combination detected.
+
+Outside of a reasonably long upgrade time window, it is
+recommended that all nodes use exactly the same version of Erlang.
+
+
+## Building Erlang from Source {#building-from-source}
+
+If a sufficiently recent Erlang package is not available for a given operating system,
+Erlang/OTP can be [built from source](http://www.erlang.org/doc/installation_guide/INSTALL.html).
+This requires a build environment that satisfies the Erlang build dependencies, such as a
+modern OpenSSL version.
+
+[kerl](https://github.com/kerl/kerl) makes building Erlang/OTP releases from
+source, including specific tags from GitHub, a much more pleasant experience.
+
+
+## Older RabbitMQ and Erlang Releases {#old-timers}
+
+### Unsupported RabbitMQ Series {#eol-series}
+
+<table class="matrix">
+    <tr>
+      <th><a href="/release-information">Unsupported RabbitMQ Series</a></th>
+      <th>Minimum required Erlang/OTP</th>
+      <th>Maximum supported Erlang/OTP</th>
+      <th>Notes</th>
     </tr>
 
     <tr>
@@ -379,75 +441,6 @@ For RabbitMQ releases that have reached end of life, see [Unsupported Series Com
           </li>
         </ul>
       </td>
-    </tr>
-</table>
-
-As a guideline, most recent minor and patch versions of each supported Erlang/OTP series
-are recommended.
-
-## Provisioning Latest Erlang Releases {#erlang-repositories}
-
-Most recent versions can be obtained from a number of sources:
-
- * [Team RabbitMQ Debian repositories](install-debian#apt-repositories) or [Launchpad](install-debian#apt-launchpad-erlang)
- * [Zero dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from Team RabbitMQ, also available [from a `dnf`/`yum` repository](install-rpm#dnf-repositories)
- * As part of [RabbitMQ Docker image](https://github.com/docker-library/rabbitmq/)
- * [erlang.org](https://www.erlang.org/downloads#prebuilt) provides binary builds of patch releases for Windows
- * Building from source with [kerl](https://github.com/kerl/kerl)
-
-## Installing Erlang/OTP on Debian or Ubuntu {#debian}
-
-Standard Debian and Ubuntu repositories provide Erlang/OTP but it is
-heavily sliced and diced into dozens of packages. In addition, unless the system
-has backport repositories enabled, the versions tend to be quite old.
-See [Debian and Ubuntu installation guide](./install-debian) for
-more information on the essential packages, dependencies, and alternative apt repositories.
-
-## Installing Erlang/OTP on RHEL, CentOS and Fedora {#redhat}
-
-There are multiple RPM packages available for Erlang/OTP. The recommended option is
-the [zero-dependency Erlang RPM](https://github.com/rabbitmq/erlang-rpm) from the RabbitMQ team.
-It closely follows the latest Erlang/OTP patch release schedule.
-
-See [CentOS, RHEL and Fedora installation guide](./install-rpm) for more information on the available options.
-
-
-## Erlang Versions in Clusters {#clusters}
-
-It is **highly recommended** that the same major version of
-Erlang is used across all [cluster nodes](./upgrade#rabbitmq-erlang-version-requirement)
-(e.g. `27.x`).
-
-RabbitMQ will check for internal protocol versions of
-Erlang and its distributed libraries when a node joins a
-cluster, refusing to cluster if there's a potentially
-incompatible combination detected.
-
-Outside of a reasonably long upgrade time window, it is
-recommended that all nodes use exactly the same version of Erlang.
-
-
-## Building Erlang from Source {#building-from-source}
-
-If a sufficiently recent Erlang package is not available for a given operating system,
-Erlang/OTP can be [built from source](http://www.erlang.org/doc/installation_guide/INSTALL.html).
-This requires a build environment that satisfies the Erlang build dependencies, such as a
-modern OpenSSL version.
-
-[kerl](https://github.com/kerl/kerl) makes building Erlang/OTP releases from
-source, including specific tags from GitHub, a much more pleasant experience.
-
-
-## Older RabbitMQ and Erlang Releases {#old-timers}
-
-### Unsupported RabbitMQ Series {#eol-series}
-
-<table class="matrix">
-    <tr>
-      <th><a href="/release-information">Unsupported RabbitMQ Series</a></th>
-      <th>Minimum required Erlang/OTP</th>
-      <th>Maximum supported Erlang/OTP</th>
-      <th>Notes</th>
     </tr>
 
     <tr>


### PR DESCRIPTION
Erlang/OTP 26 reached [end of life on 2026-05-26](https://endoflife.date/erlang) and is no longer supported by RabbitMQ. 

This PR updates `docs/which-erlang.md` accordingly.