### PR TITLE
Document Unix domain socket listeners

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -689,8 +689,9 @@ some settings are quite obscure.
     <td>`listeners.tcp`</td>
     <td>
       Ports or hostname/pair on which to listen for "plain" AMQP 0-9-1 and AMQP 1.0 connections
-      (without [TLS](./ssl)). See the [Networking guide](./networking) for more
-      details and examples.
+      (without [TLS](./ssl)). A listener can also bind to a
+      [Unix domain socket](./networking#unix-domain-socket). See the
+      [Networking guide](./networking) for more details and examples.
 
       <div>
         Default:

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -162,6 +162,39 @@ ssl_options.verify     = verify_peer
 ssl_options.fail_if_no_peer_cert = false
 ```
 
+### Listening on a Unix Domain Socket {#unix-domain-socket}
+
+A listener can bind to a Unix domain socket instead of a TCP interface. This is
+useful when clients connect from the same host and the overhead and attack
+surface of a TCP port are not desirable.
+
+A Unix domain socket listener is configured with the same `listeners.tcp.*` (or
+`listeners.ssl.*`) options as a TCP listener. The value is a socket path
+prefixed with `unix:` (or the equivalent `local:`), followed by `:0` in place of
+a port number:
+
+```ini
+listeners.tcp.1 = unix:/var/run/rabbitmq/rabbitmq.sock:0
+```
+
+The `unix:` and `local:` prefixes are interchangeable. The trailing `:0` is
+required: a Unix domain socket has no port, so the port component must be `0`.
+
+A single node can serve both TCP and Unix domain socket listeners at the same
+time:
+
+```ini
+listeners.tcp.1 = 192.168.1.99:5672
+listeners.tcp.2 = unix:/var/run/rabbitmq/rabbitmq.sock:0
+```
+
+:::info
+
+Clients must support connecting over a Unix domain socket to use this kind of
+listener. Consult the documentation of your client library for details.
+
+:::
+
 
 ## Port Access {#ports}
 


### PR DESCRIPTION
Documents native Unix domain socket (UDS) listener support, which is added to the server by rabbitmq/rabbitmq-server#16877 (closing rabbitmq/rabbitmq-server#7311).

## Changes

- Add a "Listening on a Unix Domain Socket" section to the networking guide (`docs/networking.md`), covering the `unix:`/`local:` prefix syntax, the required `:0` port, and a combined TCP + UDS example
- Cross-link the new section from the `listeners.tcp` row of the configuration guide (`docs/configure.md`)

## Related

- Server PR: rabbitmq/rabbitmq-server#16877 (originally rabbitmq/rabbitmq-server#16877)
- Issue: rabbitmq/rabbitmq-server#7311
