### PR TITLE
Fix dependabot updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "esbuild": "^0.25.0",
     "minimatch": "~3.1.3",
     "http-proxy-middleware": "^3.0.6",
-    "estree-util-value-to-estree": ">=3.3.3",
+    "estree-util-value-to-estree": "$estree-util-value-to-estree",
     "webpack-dev-server": "$webpack-dev-server",
     "js-yaml": ">=4.2.0",
     "serialize-javascript": ">=7.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "minimatch": "~3.1.3",
     "http-proxy-middleware": "^3.0.6",
     "estree-util-value-to-estree": ">=3.3.3",
-    "webpack-dev-server": "^5.2.4",
+    "webpack-dev-server": "$webpack-dev-server",
     "js-yaml": ">=4.2.0",
     "serialize-javascript": ">=7.0.3",
     "lodash-es": ">=4.18.0",


### PR DESCRIPTION
The overrides entry pinned an independent version range from the
devDependencies entry. When Dependabot bumps the direct dependency
across a major version, npm requires overrides targeting a direct
dependency to match it exactly, causing an EOVERRIDE failure.
Referencing it via $webpack-dev-server keeps it in sync automatically.
