### PR TITLE
Update exchange name in tutorial 4 and Java stream source file

### DIFF
--- a/src/components/Tutorials/T4DiagramDirectX.md
+++ b/src/components/Tutorials/T4DiagramDirectX.md
@@ -1,7 +1,7 @@
 ```mermaid
 flowchart LR
     P((P))
-    X{{direct}}
+    X{{X}}
     Q1[[Q₁]]
     Q2[[Q₂]]
     C1((C₁))

--- a/src/components/Tutorials/T4DiagramFull.md
+++ b/src/components/Tutorials/T4DiagramFull.md
@@ -1,7 +1,7 @@
 ```mermaid
 flowchart LR
     P((P))
-    X{{direct}}
+    X{{X}}
     Q1[[amq.gen-S9b…]]
     Q2[[amq.gen-Ag1…]]
     C1((C₁))

--- a/src/components/Tutorials/T4DiagramMultipleBindings.md
+++ b/src/components/Tutorials/T4DiagramMultipleBindings.md
@@ -1,7 +1,7 @@
 ```mermaid
 flowchart LR
     P((P))
-    X{{direct}}
+    X{{X}}
     Q1[[Q₁]]
     Q2[[Q₂]]
     C1((C₁))

--- a/tutorials/tutorial-one-java-stream.md
+++ b/tutorials/tutorial-one-java-stream.md
@@ -89,7 +89,7 @@ Next, create a `pom.xml` file with the RabbitMQ Stream Java client as a dependen
 
 Next, let's create two files for the message producer (sender) and the message consumer (receiver) part of this tutorial.
 They will be called  [`Send.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java-stream-mvn/src/main/java/Send.java) and
-[`Receiver.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java-stream-mvn/src/main/java/Receiver.java), respectively.
+[`Receive.java`](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/java-stream-mvn/src/main/java/Receive.java), respectively.
 
 The producer will connect to RabbitMQ, send a single message, then exit. The consumer will consume and print it
 to standard output.


### PR DESCRIPTION
I think the exchange name should be `X` instead.

<img width="1004" height="246" alt="image" src="https://github.com/user-attachments/assets/9efcaf7b-9340-4c41-a74b-eb883ee9e211" />


Reference
https://www.rabbitmq.com/tutorials/tutorial-four-java#direct-exchange