### PR TITLE
Stream: document new default for max frame size (DO NOT MERGE YET)

### DIFF
--- a/docs/stream.md
+++ b/docs/stream.md
@@ -213,12 +213,12 @@ The configuration entries have [TLS counterparts](#tls) (`advertised_tls_host` a
 
 ### Maximum Frame Size {#frame-size}
 
-RabbitMQ Stream protocol uses a maximum frame size limit. The default is 1 MiB and the value
-can be increased if necessary:
+RabbitMQ Stream protocol uses a maximum frame size limit. The default is 20 MiB and the value
+can be adapted if necessary:
 
 ```ini
 # in bytes
-stream.frame_max = 2097152
+stream.frame_max = 10485760
 ```
 
 

--- a/versioned_docs/version-4.3/stream.md
+++ b/versioned_docs/version-4.3/stream.md
@@ -213,12 +213,12 @@ The configuration entries have [TLS counterparts](#tls) (`advertised_tls_host` a
 
 ### Maximum Frame Size {#frame-size}
 
-RabbitMQ Stream protocol uses a maximum frame size limit. The default is 1 MiB and the value
-can be increased if necessary:
+RabbitMQ Stream protocol uses a maximum frame size limit. The default is 20 MiB and the value
+can be adapted if necessary:
 
 ```ini
 # in bytes
-stream.frame_max = 2097152
+stream.frame_max = 10485760
 ```
 
 


### PR DESCRIPTION
References rabbitmq/rabbitmq-server#17126

Merge when 4.3.5 is out.