### PR TITLE
Clarify 4.3.0 upgrade requirements in main upgrade doc

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -123,12 +123,18 @@ This strategy is only recommended for replacing one node that must be decomissio
 
 ## RabbitMQ Version Upgradability {#rabbitmq-version-upgradability}
 
-It is possible to upgrade RabbitMQ 3.13.x directly to version up to RabbitMQ 4.3.x.
+:::warning
+
+RabbitMQ `3.13.x` users must first upgrade to `4.2.x`, then to `4.3.x`.
+
+:::
+
+Upgrading to `4.3.x` is only possible from `4.2.x`.
 
 All [stable feature flags must be enabled](./feature-flags#how-to-enable-feature-flags),
 **before** an upgrade, or the upgrade may fail.
 
-If you are not on RabbitMQ 3.13 yet, refer to the table below to understand your upgrade path.
+Refer to the table below to understand your upgrade path.
 
 <details>
   <summary>Release Series Upgradeability</summary>
@@ -137,6 +143,7 @@ The following shows the supported upgrade paths.
 
 | From     | To     |
 |----------|--------|
+| 4.2.x    | 4.3.x  |
 | 4.1.x    | 4.2.x  |
 | 4.0.x    | 4.2.x  |
 | 4.0.x    | 4.1.x  |

--- a/versioned_docs/version-4.3/upgrade.md
+++ b/versioned_docs/version-4.3/upgrade.md
@@ -134,8 +134,7 @@ Upgrading to `4.3.x` is only possible from `4.2.x`.
 All [stable feature flags must be enabled](./feature-flags#how-to-enable-feature-flags),
 **before** an upgrade, or the upgrade may fail.
 
-For users on releases older than RabbitMQ 3.13, refer to the table below to understand
-a suitable upgrade path.
+Refer to the table below to understand your upgrade path.
 
 <details>
   <summary>Release Series Upgradeability</summary>


### PR DESCRIPTION
This applies the changes to the 4.3 docs from b171f76 to the main upgrade doc. This cleans up a stale reference that said that 3.13 could be upgraded directly to 4.3, which the 4.3 release notes (and versioned docs) clarify is not supported.

This change copies the updates to the main upgrade doc and makes a small edit to the note explaining the table below - it previously sounded like the table was only useful for upgrading from 3.13 but it's useful for upgrades within 4.x as well.