### PR TITLE
By @lacatoire: Consul peer discovery: note that RABBITMQ_USE_LONGNAME is also required

### DIFF
--- a/docs/cluster-formation.md
+++ b/docs/cluster-formation.md
@@ -608,6 +608,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/docs/cluster-formation.md
+++ b/docs/cluster-formation.md
@@ -610,11 +610,14 @@ When it is set to `true`, other options explained below come into play.
 
 :::important
 
-Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
-RabbitMQ use long node names. To use long names with Consul peer discovery,
-[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
-set to `true` on every cluster node (including any that join later). See
-[Node Names](./clustering#node-names) for background.
+Setting `cluster_formation.consul.use_longname` to `true` configures the Consul
+peer discovery plugin to use long node names. It does not, however, make RabbitMQ nodes use them.
+
+To make the nodes use long names, make sure the
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) is set to
+`true` for every cluster node, including any that might join the cluster later.
+
+See [Node Names](./clustering#node-names) in the Clustering guide to learn more.
 
 :::
 

--- a/versioned_docs/version-3.13/cluster-formation.md
+++ b/versioned_docs/version-3.13/cluster-formation.md
@@ -816,6 +816,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-3.13/cluster-formation.md
+++ b/versioned_docs/version-3.13/cluster-formation.md
@@ -818,11 +818,14 @@ When it is set to `true`, other options explained below come into play.
 
 :::important
 
-Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
-RabbitMQ use long node names. To use long names with Consul peer discovery,
-[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
-set to `true` on every cluster node (including any that join later). See
-[Node Names](./clustering#node-names) for background.
+Setting `cluster_formation.consul.use_longname` to `true` configures the Consul
+peer discovery plugin to use long node names. It does not, however, make RabbitMQ nodes use them.
+
+To make the nodes use long names, make sure the
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) is set to
+`true` for every cluster node, including any that might join the cluster later.
+
+See [Node Names](./clustering#node-names) in the Clustering guide to learn more.
 
 :::
 

--- a/versioned_docs/version-4.0/cluster-formation.md
+++ b/versioned_docs/version-4.0/cluster-formation.md
@@ -825,6 +825,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-4.0/cluster-formation.md
+++ b/versioned_docs/version-4.0/cluster-formation.md
@@ -827,11 +827,14 @@ When it is set to `true`, other options explained below come into play.
 
 :::important
 
-Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
-RabbitMQ use long node names. To use long names with Consul peer discovery,
-[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
-set to `true` on every cluster node (including any that join later). See
-[Node Names](./clustering#node-names) for background.
+Setting `cluster_formation.consul.use_longname` to `true` configures the Consul
+peer discovery plugin to use long node names. It does not, however, make RabbitMQ nodes use them.
+
+To make the nodes use long names, make sure the
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) is set to
+`true` for every cluster node, including any that might join the cluster later.
+
+See [Node Names](./clustering#node-names) in the Clustering guide to learn more.
 
 :::
 

--- a/versioned_docs/version-4.1/cluster-formation.md
+++ b/versioned_docs/version-4.1/cluster-formation.md
@@ -608,6 +608,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-4.1/cluster-formation.md
+++ b/versioned_docs/version-4.1/cluster-formation.md
@@ -610,11 +610,14 @@ When it is set to `true`, other options explained below come into play.
 
 :::important
 
-Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
-RabbitMQ use long node names. To use long names with Consul peer discovery,
-[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
-set to `true` on every cluster node (including any that join later). See
-[Node Names](./clustering#node-names) for background.
+Setting `cluster_formation.consul.use_longname` to `true` configures the Consul
+peer discovery plugin to use long node names. It does not, however, make RabbitMQ nodes use them.
+
+To make the nodes use long names, make sure the
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) is set to
+`true` for every cluster node, including any that might join the cluster later.
+
+See [Node Names](./clustering#node-names) in the Clustering guide to learn more.
 
 :::
 

--- a/versioned_docs/version-4.2/cluster-formation.md
+++ b/versioned_docs/version-4.2/cluster-formation.md
@@ -608,6 +608,16 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
+RabbitMQ use long node names. To use long names with Consul peer discovery,
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
+set to `true` on every cluster node (including any that join later). See
+[Node Names](./clustering#node-names) for background.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:

--- a/versioned_docs/version-4.2/cluster-formation.md
+++ b/versioned_docs/version-4.2/cluster-formation.md
@@ -610,11 +610,14 @@ When it is set to `true`, other options explained below come into play.
 
 :::important
 
-Setting `cluster_formation.consul.use_longname` to `true` does not, by itself, make
-RabbitMQ use long node names. To use long names with Consul peer discovery,
-[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) must also be
-set to `true` on every cluster node (including any that join later). See
-[Node Names](./clustering#node-names) for background.
+Setting `cluster_formation.consul.use_longname` to `true` configures the Consul
+peer discovery plugin to use long node names. It does not, however, make RabbitMQ nodes use them.
+
+To make the nodes use long names, make sure the
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) is set to
+`true` for every cluster node, including any that might join the cluster later.
+
+See [Node Names](./clustering#node-names) in the Clustering guide to learn more.
 
 :::
 

--- a/versioned_docs/version-4.3/cluster-formation.md
+++ b/versioned_docs/version-4.3/cluster-formation.md
@@ -608,6 +608,19 @@ When `cluster_formation.consul.svc_addr_auto` is set to `false`,
 service name will be taken as is from `cluster_formation.consul.svc_addr`.
 When it is set to `true`, other options explained below come into play.
 
+:::important
+
+Setting `cluster_formation.consul.use_longname` to `true` configures the Consul
+peer discovery plugin to use long node names. It does not, however, make RabbitMQ nodes use them.
+
+To make the nodes use long names, make sure the
+[`RABBITMQ_USE_LONGNAME`](./configure#supported-environment-variables) is set to
+`true` for every cluster node, including any that might join the cluster later.
+
+See [Node Names](./clustering#node-names) in the Clustering guide to learn more.
+
+:::
+
 In the following example, the service address reported to Consul is
 hardcoded to `hostname1.rmq.eng.example.local` instead of being computed automatically
 from the environment:


### PR DESCRIPTION
This is #2510 with some editing and a 4.3 edition from me.