### PR TITLE
Bump `nanoid` dependency to address a security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15153,9 +15153,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "estree-util-value-to-estree": "$estree-util-value-to-estree",
     "webpack-dev-server": "$webpack-dev-server",
     "js-yaml": ">=4.2.0",
+    "nanoid": "^3.3.18",
     "serialize-javascript": ">=7.0.3",
     "lodash-es": ">=4.18.0",
     "lodash": ">=4.18.0",


### PR DESCRIPTION
Namely https://github.com/rabbitmq/rabbitmq-website/security/dependabot/99.