### PR TITLE
Remove obsolete tools from documentation

### DIFF
--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -253,9 +253,8 @@ Miscellaneous projects:
  * A [RabbitMQ client for OCaml](https://github.com/andersfugmann/amqp-client)
 
 
-## Provisioning (Chef, Puppet, Docker, etc) {#operations}
+## Provisioning (Puppet, Docker, etc) {#operations}
 
-* [Chef RabbitMQ Cookbook](https://github.com/rabbitmq/chef-cookbook)
 * [Puppet RabbitMQ Module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
 * [RabbitMQ Docker image](https://hub.docker.com/_/rabbitmq/)
 * [Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)

--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -253,9 +253,8 @@ Miscellaneous projects:
  * A [RabbitMQ client for OCaml](https://github.com/andersfugmann/amqp-client)
 
 
-## Provisioning (Puppet, Docker, etc) {#operations}
+## Provisioning (Docker, Kurtosis, etc) {#operations}
 
-* [Puppet RabbitMQ Module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
 * [RabbitMQ Docker image](https://hub.docker.com/_/rabbitmq/)
 * [Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -94,7 +94,7 @@ Other guides related to Kubernetes:
 
  * [VMware Tanzu RabbitMQ®](https://tanzu.vmware.com/rabbitmq)
  * [RabbitMQ Cluster Kubernetes Operator](/kubernetes/operator/install-operator) by VMware (developed [on GitHub](https://github.com/rabbitmq/cluster-operator))
- * [VMware Tanzu RabbitMQ® on Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Kubernetes/3.13/tanzu-rabbitmq-kubernetes/installation.html)
+ * [VMware Tanzu RabbitMQ® on Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-rabbitmq-on-kubernetes/4-0/tanzu-rabbitmq-kubernetes/overview.html)
  * [Amazon MQ for RabbitMQ](https://aws.amazon.com/amazon-mq/)
  * [Amazon EC2](./ec2)
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -112,9 +112,8 @@ Other guides related to Kubernetes:
  * [Debian](./install-debian#apt-quick-start)
  * [RPM](./install-rpm#dnf-repositories)
 
-## Provisioning Tools (Puppet, etc)
+## Provisioning Tools
 
- * [Puppet module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
  * [Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
 
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -112,9 +112,8 @@ Other guides related to Kubernetes:
  * [Debian](./install-debian#apt-quick-start)
  * [RPM](./install-rpm#dnf-repositories)
 
-## Provisioning Tools (Chef, Puppet, etc)
+## Provisioning Tools (Puppet, etc)
 
- * [Chef cookbook](https://github.com/rabbitmq/chef-cookbook)
  * [Puppet module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
  * [Kurtosis Starlark package](https://github.com/kurtosis-tech/rabbitmq-package)
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -75,10 +75,7 @@ Please consult the installation guides for
 A wide variety of deployment tools can be used to automate
 RabbitMQ deployment.
 
-  * [Community Docker image](https://hub.docker.com/_/rabbitmq/) ([on GitHub](https://github.com/docker-library/rabbitmq))
-  * [Puppet module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
-
-are some popular options.
+The [Community Docker image](https://hub.docker.com/_/rabbitmq/) ([on GitHub](https://github.com/docker-library/rabbitmq)) is a popular option.
 
 
 ## Durable Storage on EBS Volumes {#ebs}

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -76,7 +76,6 @@ A wide variety of deployment tools can be used to automate
 RabbitMQ deployment.
 
   * [Community Docker image](https://hub.docker.com/_/rabbitmq/) ([on GitHub](https://github.com/docker-library/rabbitmq))
-  * [Chef cookbook](https://github.com/rabbitmq/chef-cookbook)
   * [Puppet module](https://github.com/puppetlabs/puppetlabs-rabbitmq)
 
 are some popular options.


### PR DESCRIPTION
* Chef cookbook for RabbitMQ is no longer supported.
* Puppet Module repository no longer exists.
* VMWare Tanzu RabbitMQ on Kubernetes link moved.