### PR TITLE
Add Rabbit Relay to JavaScript and Node section

### DIFF
--- a/client-libraries/devtools.md
+++ b/client-libraries/devtools.md
@@ -140,6 +140,7 @@ Miscellaneous projects:
    automatic error recovery, redelivery flood protection, transparent encryption and channel pooling.
  * [node-rabbitmq-client](https://github.com/cody-greene/node-rabbitmq-client): RabbitMQ (AMQP 0-9-1) client library with auto-reconnect, zero dependencies, TypeScript support, and Promise-based API.
  * [ComQ](https://github.com/toa-io/comq): Production grade RPC and pub/sub.
+ * [Rabbit Relay](https://github.com/bitspacerlabs/rabbit-relay): a TypeScript-first RabbitMQ framework for Node.js built on top of [amqplib](https://github.com/amqp-node/amqplib), with typed/versioned events, publisher confirms, bounded retries and dead-letter queues, RPC, reconnect recovery, topology planning/validation/diff CLI, and OpenTelemetry.
 
 
 ## Go {#go-dev}


### PR DESCRIPTION
Hello!

Thanks for maintaining such a product and docs. I'd like to propose adding [Rabbit Relay](https://github.com/bitspacerlabs/rabbit-relay) to the JavaScript and Node section.

Rabbit Relay is a TypeScript-first RabbitMQ framework built on top of [amqplib](https://github.com/amqp-node/amqplib), focused on reliability, typed messaging, operational tooling, and observability while keeping the underlying RabbitMQ concepts explicit.

The project is now stable on the 1.x line, so I believe it would be a good fit for inclusion alongside the existing Node.js options.

## Links

- **Repo:** https://github.com/bitspacerlabs/rabbit-relay
- **npm:** https://www.npmjs.com/package/@bitspacerlabs/rabbit-relay
- **Docs:** https://bitspacerlabs.github.io/rabbit-relay/docs/
- **Changelog:** https://github.com/bitspacerlabs/rabbit-relay/blob/main/CHANGELOG.md

## What it is

Rabbit Relay is a stable (v1.2.1, semver) TypeScript framework that adds typed/versioned events, publisher confirms, bounded retries, dead-letter queues, RPC, reconnect recovery, topology ownership modes, and OpenTelemetry - while keeping RabbitMQ concepts (exchanges, queues, bindings, routing keys, acks) explicit.

## Why it's not redundant

Rabbit Relay's differentiators not covered by any listed peer:

- Typed/versioned event factories with runtime schema validation (Zod/Valibot compatible)
- Topology plan/validate/diff CLI
- DLQ redrive (programmatic + CLI with dry-run)
- OpenTelemetry adapter
- Consumer middleware + process-wide plugin hooks
- Structured health checks

## Stability

- Stable on the 1.x line, follows semver
- Dual ESM/CommonJS builds with TypeScript declarations
- Single runtime dependency: `amqplib`
- Unit tests, live RabbitMQ integration tests, packed-package ESM/CJS/TypeScript smoke tests
- CI on Node.js 18, 20, 22, and 24
- MIT licensed

## The change

One line added to the JavaScript and Node section, after ComQ:

```markdown
 * [Rabbit Relay](https://github.com/bitspacerlabs/rabbit-relay): a TypeScript-first RabbitMQ framework for Node.js built on top of [amqplib](https://github.com/amqp-node/amqplib), with typed/versioned events, publisher confirms, bounded retries and dead-letter queues, RPC, reconnect recovery, topology planning/validation/diff CLI, and OpenTelemetry.